### PR TITLE
Small updates to authentication code after testing with frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@
 - Pino logger with ECS formatter
 - Plugin to log request/response lifecycle events
 - Add Logger to the context and then used it in the resolvers
+
+### Updated
+- Made some updates to auth code based on testing out recent changes with frontend [#34]

--- a/src/controllers/signinController.ts
+++ b/src/controllers/signinController.ts
@@ -10,7 +10,12 @@ export const signinController = async (req: Request, res: Response) => {
 
     if (user) {
       const token = generateToken(user);
-      res.json({ success: true, token });
+      if (token) {
+        res.status(200).json({ success: true, token });
+      } else {
+        throw new Error('Login failed');
+      }
+
     } else {
       res.status(401).json({ success: false, message: 'Invalid credentials' });
     }

--- a/src/controllers/signupController.ts
+++ b/src/controllers/signupController.ts
@@ -9,10 +9,14 @@ export const signupController = async (req: Request, res: Response) => {
     user = await user.register() || null;
     if (user) {
       if (user.errors.length >= 1) {
-        res.status(400).json({ success: false, message: user.errors?.join(', ') });
+        res.status(400).json({ success: false, message: user.errors?.join('| ') });
       } else {
         const token = generateToken(user);
-        res.status(200).json({ success: true, token });
+        if (token) {
+          res.status(200).json({ success: true, token });
+        } else {
+          throw new Error('Signup failed');
+        }
       }
     } else {
       res.status(500).json({ success: false, message: 'Unable to create the account at this time.' });

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -135,7 +135,7 @@ export class User {
     const email = this.email || '';
 
     if (!validateEmail(email) || !this.validatePassword()) {
-      this.errors.push('Login failed');
+      return null;
     }
 
     try {
@@ -154,7 +154,7 @@ export class User {
   // Register the User if the data is valid
   async register(): Promise<User | Falsey> {
     this.cleanup();
-    this.validateNewUser();
+    await this.validateNewUser();
 
     if (this.errors.length === 0) {
       const passwordHash = await this.hashPassword(this.password);
@@ -175,7 +175,7 @@ export class User {
       }
     } else {
       formatLogMessage(logger)?.debug(`Invalid user: ${this.email}`);
-      return null;
+      return this;
     }
   }
 }


### PR DESCRIPTION
- I added a check in signinController and signupController for token, because "generateToken" could return null
- Update signupController to use the pipe delimiter ('|') for creating a string of concatenated errors, because commas are used in error messages, and it makes it difficult for frontend to create an array from the string.
- Updated User.spec.ts so that tests pass
- Also, made some comments on specific changes below for more details