### PR TITLE
Added acceptedTerms boolean to User schema for Create Account page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 ### Added
-- Added acceptedTerms to User schema
+- Added acceptedTerms to User schema and to user sql table
 - Added schema for Section and Tag
 - Initial schema, model, mocks and resolver for Templates
 - Initial schema, model, mocks and resolver for Collaborators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### Added
+- Added acceptedTerms to User schema
 - Added schema for Section and Tag
 - Initial schema, model, mocks and resolver for Templates
 - Initial schema, model, mocks and resolver for Collaborators

--- a/data-migrations/2024-05-01-1103-create-user-table.sql
+++ b/data-migrations/2024-05-01-1103-create-user-table.sql
@@ -6,6 +6,7 @@ CREATE TABLE `users` (
   `givenName` VARCHAR(255) NOT NULL,
   `surName` VARCHAR(255) NOT NULL,
   `affiliationId` VARCHAR(255) NOT NULL,
+  `acceptedTerms` TINYINT(1) NOT NULL DEFAULT 0,
   `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `createdById` int,
   `modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -19,6 +19,7 @@ export class User extends MySqlModel {
   public surName?: string;
   // TODO: Make this required once we build out the signup page
   public affiliationId?: string;
+  public acceptedTerms: boolean;
   public orcid?: string;
 
   // Initialize a new User
@@ -33,6 +34,7 @@ export class User extends MySqlModel {
     this.orcid = options.orcid;
     // TODO: Remove this hard-coded UCOP default once we build out the signup page
     this.affiliationId = options.affiliationId || 'https://ror.org/00dmfq477';
+    this.acceptedTerms = options.acceptedTerms;
 
     this.cleanup();
   }
@@ -132,7 +134,7 @@ export class User extends MySqlModel {
 
   // Find the User by their Id
   static async findById(reference: string, context: MyContext, userId: number): Promise<User> {
-    const sql = 'SELECT id, email, givenName, surName, role, affiliationId, created, modified \
+    const sql = 'SELECT id, email, givenName, surName, role, affiliationId, acceptedTerms, created, modified \
                  FROM users WHERE id = ?';
     const results = await User.query(context, sql, [userId.toString()], reference);
     return results[0];
@@ -140,14 +142,14 @@ export class User extends MySqlModel {
 
   // Find the User by their email address
   static async findByEmail(reference: string, context: MyContext, email: string): Promise<User> {
-    const sql = 'SELECT id, email, givenName, surName, role, affiliationId, created, modified \
+    const sql = 'SELECT id, email, givenName, surName, role, affiliationId, acceptedTerms, created, modified \
                  FROM users WHERE email = ?';
     const results = await User.query(context, sql, [email], reference);
     return results[0];
   }
 
   static async findByAffiliationId(reference: string, context: MyContext, affiliationId: string): Promise<User[]> {
-    const sql = 'SELECT id, givenName, surName, email, role, affiliationId, created, modified \
+    const sql = 'SELECT id, givenName, surName, email, role, affiliationId, acceptedTerms, created, modified \
                  FROM users WHERE affiliationId = ? ORDER BY created DESC';
     return await User.query(context, sql, [affiliationId], reference);
   }
@@ -186,7 +188,7 @@ export class User extends MySqlModel {
 
       try {
         const sql = `INSERT INTO users \
-                      (email, password, role, givenName, surName, affiliationId) \
+                      (email, password, role, givenName, surName, affiliationId, acceptedTerms) \
                      VALUES(?, ?, ?, ?, ?, ?)`;
         const vals = [this.email, this.password, this.role, this.givenName, this.surName, this.affiliationId];
         const context = buildContext(logger);

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -42,6 +42,8 @@ export const typeDefs = gql`
     role: UserRole!
     "The user's organizational affiliation"
     affiliation: Affiliation
+    "Whether the user has accepted the terms and conditions of having an account"
+    acceptedTerms: Boolean
     "The user's ORCID"
     orcid: Orcid
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -652,6 +652,8 @@ export type UpdateSectionInput = {
 /** A user of the DMPTool */
 export type User = {
   __typename?: 'User';
+  /** Whether the user has accepted the terms and conditions of having an account */
+  acceptedTerms?: Maybe<Scalars['Boolean']['output']>;
   /** The user's organizational affiliation */
   affiliation?: Maybe<Affiliation>;
   /** The timestamp when the Object was created */
@@ -1225,6 +1227,7 @@ export interface UrlScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes[
 }
 
 export type UserResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  acceptedTerms?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   affiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
   created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

As described in the ticket #93, the new CreateAccount page will have a checkbox for users to accept the "terms and conditions" of having an account. 

1. Added the `acceptedTerms` boolean to the User schema for this.
2. Added `acceptedTerms` field in the "user" table
3. Updated User model to include `acceptedTerms` in the queries

Fixes # ([93](https://github.com/CDLUC3/dmsp_backend_prototype/issues/93))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
1. Since the "/data-migrations/2024-05-01-1103-create-user-table.sql" file was updated with the "acceptedTerms" field, I 
ran  "docker-compose exec apollo bash ./data-migrations/nuke-db.sh" and "docker-compose exec apollo bash ./data-migrations/process.sh"
2. Then I checked that the new acceptedTerms field was showing up in the db table
3. I used Apollo sandbox to check that the "acceptedTerms" field was being returned in queries with correct value.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules