### PR TITLE
Built the schemas associated with Questions (Question, QuestionType, QuestionCondition and VersionedQuestion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### Added
+- Added schemas for Question, QuestionType, QuestionCondition and VersionedQuestion
 - Added resolvers and models for Section, Tag and VersionedSection
 - Added acceptedTerms to User schema and to user sql table
 - Added schema for Section and Tag

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -1,0 +1,96 @@
+import gql from "graphql-tag";
+
+export const typedefs = gql`
+  extend type Query {
+    "Get the Questions that belong to the associated sectionId"
+    questions(sectionId: Int!): [Question]
+    "Get the specific Question based on questionId"
+    question(questionId: Int!): Question
+  }
+
+extend type Mutation {
+    "Create a new Question"
+    addQuestion(input: AddQuestionInput): Question
+    "Update a Question"
+    updateQuestion(input: UpdateQuestionInput): Question
+    "Delete a Question"
+    removeQuestion(questionId: Int!): Boolean
+  }
+
+"Question always belongs to a Section, which always belongs to a Template"
+type Question {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: DateTimeISO
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: DateTimeISO
+    "Errors associated with the Object"
+    errors: [String!]
+
+    "The unique id of the Template that the question belongs to"
+    templateId: Int!
+    "The unique id of the Section that the question belongs to"
+    sectionId: Int!
+    "The display order of the question"
+    displayOrder: Int
+    "Whether or not the Question has had any changes since the related template was last published"
+    isDirty: Boolean
+    "The type of question, such as text field, select box, radio buttons, etc"
+    questionTypeId: Int
+    "This will be used as a sort of title for the Question"
+    questionText: String
+    "Requirements associated with the Question"
+    requirementText: String
+    "Guidance to complete the question"
+    guidanceText: String
+    "Sample text to possibly provide a starting point or example to answer question"
+    sampleText: String
+    "To indicate whether the question is required to be completed"
+    required: Boolean
+}
+
+input AddQuestionInput {
+    "The unique id of the Template that the question belongs to"
+    templateId: Int!
+    "The unique id of the Section that the question belongs to"
+    sectionId: Int!
+    "The display order of the question"
+    displayOrder: Int
+    "Whether or not the Question has had any changes since it was last published"
+    isDirty: Boolean
+    "The type of question, such as text field, select box, radio buttons, etc"
+    questionTypeId: Int
+    "This will be used as a sort of title for the Question"
+    questionText: String
+    "Requirements associated with the Question"
+    requirementText: String
+    "Guidance to complete the question"
+    guidanceText: String
+    "Sample text to possibly provide a starting point or example to answer question"
+    sampleText: String
+    "To indicate whether the question is required to be completed"
+    required: Boolean
+}
+
+input UpdateQuestionInput {
+    "The unique identifier for the Question"
+    questionId: Int!
+    "The display order of the Question"
+    displayOrder: Int
+    "This will be used as a sort of title for the Question"
+    questionText: String
+    "Requirements associated with the Question"
+    requirementText: String
+    "Guidance to complete the question"
+    guidanceText: String
+    "Sample text to possibly provide a starting point or example to answer question"
+    sampleText: String
+    "To indicate whether the question is required to be completed"
+    required: Boolean
+}
+`

--- a/src/schemas/questionCondition.ts
+++ b/src/schemas/questionCondition.ts
@@ -1,0 +1,100 @@
+import gql from 'graphql-tag';
+
+export const typeDefs = gql`
+
+  extend type Query {
+    "Get the QuestionConditions that belong to a specific question"
+    questionConditions(questionId: Int!): [QuestionCondition]
+  }
+
+  extend type Mutation {
+    "Create a new QuestionCondition associated with a question"
+    addQuestionCondition(input: AddQuestionConditionInput!): QuestionCondition! 
+    "Update a QuestionCondition for a specific QuestionCondition id"
+    updateQuestionCondition(input: UpdateQuestionConditionInput!): QuestionCondition
+    "Remove a QuestionCondition using a specific QuestionCondition id"
+    removeQuestionCondition(questionConditionId: Int!): QuestionCondition
+    "Separate Question update specifically for options"
+    updateQuestionOptions(questionId: Int!, required:Boolean = false ): Question
+  }
+
+  "QuestionCondition action"
+  enum QuestionConditionActionType {
+    "Show the question"
+    SHOW_QUESTION
+    "Hide the question"
+    HIDE_QUESTION
+    "Send email"
+    SEND_EMAIL
+  }
+
+  "QuestionCondition types"
+  enum QuestionConditionCondition {
+    "When a question has an answer"
+    HAS_ANSWER
+    "When a question equals a specific value"
+    EQUAL
+    "When a question does not equal a specific value"
+    DOES_NOT_EQUAL
+    "When a question includes a specific value"
+    INCLUDES
+  }
+
+  """
+  if [Question content] [condition] [conditionMatch] then [action] on [target] so 
+  for example if 'Yes' EQUAL 'Yes' then 'SHOW_Question' 123
+  """
+  type QuestionCondition {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: DateTimeISO
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: DateTimeISO
+    "Errors associated with the Object"
+    errors: [String!]
+    "The question id that the QuestionCondition belongs to"
+    questionId: Int!
+    "The action to take on a QuestionCondition"
+    action: QuestionConditionActionType!
+    "The condition in which to take the action"
+    condition: QuestionConditionCondition!
+    "Relative to the condition type, it is the value to match on (e.g., HAS_ANSWER should equate to null here)"
+    conditionMatch: String
+    "The target of the action (e.g., an email address for SEND_EMAIL and a Question id otherwise)
+    target: String!
+}
+
+  "Input for adding a new QuestionCondition"
+  input AddQuestionConditionInput {
+    "The id of the question that the QuestionCondition belongs to"
+    questionId: Int!
+    "The action to take on a QuestionCondition"
+    action: QuestionConditionActionType!
+    "The condition in which to take the action"
+    condition: QuestionConditionCondition!
+    "Relative to the condition type, it is the value to match on (e.g., HAS_ANSWER should equate to null here)"
+    conditionMatch: String
+    "The target of the action (e.g., an email address for SEND_EMAIL and a Question id otherwise)
+    target: String!
+  }
+
+  "Input for updating a new QuestionCondition based on a QuestionCondition id"
+  input UpdateQuestionConditionInput {
+    "The id of the QuestionCondition that will be updated"
+    questionConditionId: Int!
+    "The action to take on a QuestionCondition"
+    action: QuestionConditionActionType!
+    "The condition in which to take the action"
+    condition: QuestionConditionCondition!
+    "Relative to the condition type, it is the value to match on (e.g., HAS_ANSWER should equate to null here)"
+    conditionMatch: String
+    "The target of the action (e.g., an email address for SEND_EMAIL and a Question id otherwise)
+    target: String!
+  }
+
+`

--- a/src/schemas/questionType.ts
+++ b/src/schemas/questionType.ts
@@ -1,0 +1,31 @@
+import gql from 'graphql-tag';
+
+export const typeDefs = gql`
+
+  extend type Query {
+    "Get all the QuestionTypes"
+    questionTypes: [QuestionType]
+  }
+
+
+"The type of Question, such as text field, radio buttons, etc"
+type QuestionType {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: DateTimeISO
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: DateTimeISO
+    "Errors associated with the Object"
+    errors: [String!]
+
+    "The name of the QuestionType, like 'Short text question'"
+    name: String!
+    "The description of the QuestionType"
+    usageDescription: String!
+}
+`

--- a/src/schemas/section.ts
+++ b/src/schemas/section.ts
@@ -53,31 +53,45 @@ export const typeDefs = gql`
 
   "Input for adding a new section"
   input AddSectionInput {
+    "The id of the template that the section belongs to"
     templateId: Int!
+    "The section name"
     name: String!
-    copyFromVersionedSectionId: Int
+    "The Section you want to copy from"
+    copyFromSectionId: Int
+    "The section introduction"
     introduction: String
+    "Requirements that a user must consider in this section"
     requirements: String
+    "The guidance to help user with section"
     guidance: String
+    "The Tags associated with this section. A section might not have any tags"
     tags: [TagInput!]
-    displayOrder: Int
   }
 
   "Input for updating a section"
   input UpdateSectionInput {
+   "The unique identifer for the Section"
     sectionId: Int!
+    "The section name"
     name: String
+    "The section introduction"
     introduction: String
+    "Requirements that a user must consider in this section"
     requirements: String
+    "The guidance to help user with section"
     guidance: String
+    "The Tags associated with this section. A section might not have any tags"
     tags: [TagInput!]
-    displayOrder: Int
   }
 
   "Input for Tag operations"
   input TagInput {
+    "The unique identifier for the Tag"
     id: Int
+    "The name of the Tag"
     name: String!
+    "The description of the Tag"
     description: String
   }
 

--- a/src/schemas/section.ts
+++ b/src/schemas/section.ts
@@ -21,24 +21,6 @@ export const typeDefs = gql`
   type Section {
     "The unique identifer for the Object"
     id: Int
-    "The template ID that the section belongs to"
-    templateId: Int
-    "The template that the section is associated with"
-    template: Template
-    "The order in which the section will be displayed in the template"
-    displayOrder: Int
-    "The section title"
-    name: String!
-    "The section introduction"
-    introduction: String
-    "Requirements that a user must consider in this section"
-    requirements: String
-    "The guidance to help user with section"
-    guidance: String
-    "The Tags associated with this section. A section might not have any tags"
-    tags: [Tag]
-    "Indicates whether or not the section has changed since the template was last published"
-    isDirty: Boolean!
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
@@ -49,6 +31,26 @@ export const typeDefs = gql`
     modified: String
     "Errors associated with the Object"
     errors: [String!]
+
+    "The template ID that the section belongs to"
+    templateId: Int
+    "The template that the section is associated with"
+    template: Template
+    "The section title"
+    name: String!
+    "The section introduction"
+    introduction: String
+    "Requirements that a user must consider in this section"
+    requirements: String
+    "The guidance to help user with section"
+    guidance: String
+    "The order in which the section will be displayed in the template"
+    displayOrder: Int
+    "The Tags associated with this section. A section might not have any tags"
+    tags: [Tag]
+    "Indicates whether or not the section has changed since the template was last published"
+    isDirty: Boolean!
+
   }
 
   "Input for adding a new section"
@@ -58,13 +60,15 @@ export const typeDefs = gql`
     "The section name"
     name: String!
     "The Section you want to copy from"
-    copyFromSectionId: Int
+    copyFromVersionedSectionId: Int
     "The section introduction"
     introduction: String
     "Requirements that a user must consider in this section"
     requirements: String
     "The guidance to help user with section"
     guidance: String
+    "The order in which the section will be displayed in the template"
+    displayOrder: Int
     "The Tags associated with this section. A section might not have any tags"
     tags: [TagInput!]
   }
@@ -81,6 +85,8 @@ export const typeDefs = gql`
     requirements: String
     "The guidance to help user with section"
     guidance: String
+    "The order in which the section will be displayed in the template"
+    displayOrder: Int
     "The Tags associated with this section. A section might not have any tags"
     tags: [TagInput!]
   }

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 export const typeDefs = gql`
   extend type Query {
     "Search for VersionedQuestions that belong to Section specified by sectionId"
-    publishedQuestions(sectionId: Int!): [VersionedQuestions]
+    publishedQuestions(sectionId: Int!): [VersionedQuestion]
   }
 
 "A snapshot of a Question when it became published."

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -1,0 +1,45 @@
+import gql from 'graphql-tag';
+
+export const typeDefs = gql`
+  extend type Query {
+    "Search for VersionedQuestions that belong to Section specified by sectionId"
+    publishedQuestions(sectionId: Int!): [VersionedQuestions]
+  }
+
+"A snapshot of a Question when it became published."
+type VersionedQuestion {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: DateTimeISO
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: DateTimeISO
+    "Errors associated with the Object"
+    errors: [String!]
+
+    "The unique id of the VersionedTemplate that the VersionedQuestion belongs to"
+    versionedTemplateId: Int!
+    "The unique id of the VersionedSection that the VersionedQuestion belongs to"
+    versionedSectionId: Int!
+    "The display order of the VersionedQuestion"
+    displayOrder: Int
+    "The type of question, such as text field, select box, radio buttons, etc"
+    questionTypeId: Int
+    "This will be used as a sort of title for the Question"
+    questionText: String
+    "Requirements associated with the Question"
+    requirementText: String
+    "Guidance to complete the question"
+    guidanceText: String
+    "Sample text to possibly provide a starting point or example to answer question"
+    sampleText: String
+    "To indicate whether the question is required to be completed"
+    required: Boolean
+}
+
+
+`

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,9 @@ export type AddQuestionInput = {
 /** Input for adding a new section */
 export type AddSectionInput = {
   /** The Section you want to copy from */
-  copyFromSectionId?: InputMaybe<Scalars['Int']['input']>;
+  copyFromVersionedSectionId?: InputMaybe<Scalars['Int']['input']>;
+  /** The order in which the section will be displayed in the template */
+  displayOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The guidance to help user with section */
   guidance?: InputMaybe<Scalars['String']['input']>;
   /** The section introduction */
@@ -805,6 +807,8 @@ export type UpdateQuestionInput = {
 
 /** Input for updating a section */
 export type UpdateSectionInput = {
+  /** The order in which the section will be displayed in the template */
+  displayOrder?: InputMaybe<Scalars['Int']['input']>;
   /** The guidance to help user with section */
   guidance?: InputMaybe<Scalars['String']['input']>;
   /** The section introduction */

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,15 +25,44 @@ export type Scalars = {
   URL: { input: any; output: any; }
 };
 
+export type AddQuestionInput = {
+  /** The display order of the question */
+  displayOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** Guidance to complete the question */
+  guidanceText?: InputMaybe<Scalars['String']['input']>;
+  /** Whether or not the Question has had any changes since it was last published */
+  isDirty?: InputMaybe<Scalars['Boolean']['input']>;
+  /** This will be used as a sort of title for the Question */
+  questionText?: InputMaybe<Scalars['String']['input']>;
+  /** The type of question, such as text field, select box, radio buttons, etc */
+  questionTypeId?: InputMaybe<Scalars['Int']['input']>;
+  /** To indicate whether the question is required to be completed */
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Requirements associated with the Question */
+  requirementText?: InputMaybe<Scalars['String']['input']>;
+  /** Sample text to possibly provide a starting point or example to answer question */
+  sampleText?: InputMaybe<Scalars['String']['input']>;
+  /** The unique id of the Section that the question belongs to */
+  sectionId: Scalars['Int']['input'];
+  /** The unique id of the Template that the question belongs to */
+  templateId: Scalars['Int']['input'];
+};
+
 /** Input for adding a new section */
 export type AddSectionInput = {
-  copyFromVersionedSectionId?: InputMaybe<Scalars['Int']['input']>;
-  displayOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The Section you want to copy from */
+  copyFromSectionId?: InputMaybe<Scalars['Int']['input']>;
+  /** The guidance to help user with section */
   guidance?: InputMaybe<Scalars['String']['input']>;
+  /** The section introduction */
   introduction?: InputMaybe<Scalars['String']['input']>;
+  /** The section name */
   name: Scalars['String']['input'];
+  /** Requirements that a user must consider in this section */
   requirements?: InputMaybe<Scalars['String']['input']>;
+  /** The Tags associated with this section. A section might not have any tags */
   tags?: InputMaybe<Array<TagInput>>;
+  /** The id of the template that the section belongs to */
   templateId: Scalars['Int']['input'];
 };
 
@@ -228,6 +257,8 @@ export type Mutation = {
   _empty?: Maybe<Scalars['String']['output']>;
   /** Add a new contributor role (URL and label must be unique!) */
   addContributorRole?: Maybe<ContributorRoleMutationResponse>;
+  /** Create a new Question */
+  addQuestion?: Maybe<Question>;
   /** Create a new Section. Leave the 'copyFromVersionedSectionId' blank to create a new section from scratch */
   addSection: Section;
   /** Add a new tag to available list of tags */
@@ -242,6 +273,8 @@ export type Mutation = {
   createVersion?: Maybe<Template>;
   /** Delete the contributor role */
   removeContributorRole?: Maybe<ContributorRoleMutationResponse>;
+  /** Delete a Question */
+  removeQuestion?: Maybe<Scalars['Boolean']['output']>;
   /** Delete a section */
   removeSection: Section;
   /** Delete a tag */
@@ -250,6 +283,8 @@ export type Mutation = {
   removeTemplateCollaborator?: Maybe<Scalars['Boolean']['output']>;
   /** Update the contributor role */
   updateContributorRole?: Maybe<ContributorRoleMutationResponse>;
+  /** Update a Question */
+  updateQuestion?: Maybe<Question>;
   /** Update a Section */
   updateSection: Section;
   /** Update a tag */
@@ -264,6 +299,11 @@ export type MutationAddContributorRoleArgs = {
   displayOrder: Scalars['Int']['input'];
   label: Scalars['String']['input'];
   url: Scalars['URL']['input'];
+};
+
+
+export type MutationAddQuestionArgs = {
+  input?: InputMaybe<AddQuestionInput>;
 };
 
 
@@ -307,6 +347,11 @@ export type MutationRemoveContributorRoleArgs = {
 };
 
 
+export type MutationRemoveQuestionArgs = {
+  questionId: Scalars['Int']['input'];
+};
+
+
 export type MutationRemoveSectionArgs = {
   sectionId: Scalars['Int']['input'];
 };
@@ -329,6 +374,11 @@ export type MutationUpdateContributorRoleArgs = {
   id: Scalars['ID']['input'];
   label: Scalars['String']['input'];
   url: Scalars['URL']['input'];
+};
+
+
+export type MutationUpdateQuestionArgs = {
+  input?: InputMaybe<UpdateQuestionInput>;
 };
 
 
@@ -393,10 +443,18 @@ export type Query = {
   dmspById?: Maybe<SingleDmspResponse>;
   /** Returns the currently logged in user's information */
   me?: Maybe<User>;
+  /** Search for VersionedQuestions that belong to Section specified by sectionId */
+  publishedQuestions?: Maybe<Array<Maybe<VersionedQuestion>>>;
   /** Search for VersionedSection whose name contains the search term */
   publishedSections?: Maybe<Array<Maybe<VersionedSection>>>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
   publishedTemplates?: Maybe<Array<Maybe<VersionedTemplate>>>;
+  /** Get the specific Question based on questionId */
+  question?: Maybe<Question>;
+  /** Get all the QuestionTypes */
+  questionTypes?: Maybe<Array<Maybe<QuestionType>>>;
+  /** Get the Questions that belong to the associated sectionId */
+  questions?: Maybe<Array<Maybe<Question>>>;
   /** Get the specified section */
   section?: Maybe<Section>;
   /** Get all of the VersionedSection for the specified Section ID */
@@ -447,6 +505,11 @@ export type QueryDmspByIdArgs = {
 };
 
 
+export type QueryPublishedQuestionsArgs = {
+  sectionId: Scalars['Int']['input'];
+};
+
+
 export type QueryPublishedSectionsArgs = {
   term: Scalars['String']['input'];
 };
@@ -454,6 +517,16 @@ export type QueryPublishedSectionsArgs = {
 
 export type QueryPublishedTemplatesArgs = {
   term: Scalars['String']['input'];
+};
+
+
+export type QueryQuestionArgs = {
+  questionId: Scalars['Int']['input'];
+};
+
+
+export type QueryQuestionsArgs = {
+  sectionId: Scalars['Int']['input'];
 };
 
 
@@ -494,6 +567,64 @@ export type QueryTemplateVersionsArgs = {
 
 export type QueryUserArgs = {
   userId: Scalars['Int']['input'];
+};
+
+/** Question always belongs to a Section, which always belongs to a Template */
+export type Question = {
+  __typename?: 'Question';
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** The display order of the question */
+  displayOrder?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<Array<Scalars['String']['output']>>;
+  /** Guidance to complete the question */
+  guidanceText?: Maybe<Scalars['String']['output']>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not the Question has had any changes since the related template was last published */
+  isDirty?: Maybe<Scalars['Boolean']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** This will be used as a sort of title for the Question */
+  questionText?: Maybe<Scalars['String']['output']>;
+  /** The type of question, such as text field, select box, radio buttons, etc */
+  questionTypeId?: Maybe<Scalars['Int']['output']>;
+  /** To indicate whether the question is required to be completed */
+  required?: Maybe<Scalars['Boolean']['output']>;
+  /** Requirements associated with the Question */
+  requirementText?: Maybe<Scalars['String']['output']>;
+  /** Sample text to possibly provide a starting point or example to answer question */
+  sampleText?: Maybe<Scalars['String']['output']>;
+  /** The unique id of the Section that the question belongs to */
+  sectionId: Scalars['Int']['output'];
+  /** The unique id of the Template that the question belongs to */
+  templateId: Scalars['Int']['output'];
+};
+
+/** The type of Question, such as text field, radio buttons, etc */
+export type QuestionType = {
+  __typename?: 'QuestionType';
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<Array<Scalars['String']['output']>>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The name of the QuestionType, like 'Short text question' */
+  name: Scalars['String']['output'];
+  /** The description of the QuestionType */
+  usageDescription: Scalars['String']['output'];
 };
 
 export type RelatedIdentifier = {
@@ -571,8 +702,11 @@ export type Tag = {
 
 /** Input for Tag operations */
 export type TagInput = {
+  /** The description of the Tag */
   description?: InputMaybe<Scalars['String']['input']>;
+  /** The unique identifier for the Tag */
   id?: InputMaybe<Scalars['Int']['input']>;
+  /** The name of the Tag */
   name: Scalars['String']['input'];
 };
 
@@ -652,14 +786,36 @@ export type TemplateVisibility =
   /** Visible to all users */
   | 'PUBLIC';
 
+export type UpdateQuestionInput = {
+  /** The display order of the Question */
+  displayOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** Guidance to complete the question */
+  guidanceText?: InputMaybe<Scalars['String']['input']>;
+  /** The unique identifier for the Question */
+  questionId: Scalars['Int']['input'];
+  /** This will be used as a sort of title for the Question */
+  questionText?: InputMaybe<Scalars['String']['input']>;
+  /** To indicate whether the question is required to be completed */
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Requirements associated with the Question */
+  requirementText?: InputMaybe<Scalars['String']['input']>;
+  /** Sample text to possibly provide a starting point or example to answer question */
+  sampleText?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** Input for updating a section */
 export type UpdateSectionInput = {
-  displayOrder?: InputMaybe<Scalars['Int']['input']>;
+  /** The guidance to help user with section */
   guidance?: InputMaybe<Scalars['String']['input']>;
+  /** The section introduction */
   introduction?: InputMaybe<Scalars['String']['input']>;
+  /** The section name */
   name?: InputMaybe<Scalars['String']['input']>;
+  /** Requirements that a user must consider in this section */
   requirements?: InputMaybe<Scalars['String']['input']>;
+  /** The unique identifer for the Section */
   sectionId: Scalars['Int']['input'];
+  /** The Tags associated with this section. A section might not have any tags */
   tags?: InputMaybe<Array<TagInput>>;
 };
 
@@ -699,6 +855,41 @@ export type UserRole =
   | 'ADMIN'
   | 'RESEARCHER'
   | 'SUPERADMIN';
+
+/** A snapshot of a Question when it became published. */
+export type VersionedQuestion = {
+  __typename?: 'VersionedQuestion';
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** The display order of the VersionedQuestion */
+  displayOrder?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<Array<Scalars['String']['output']>>;
+  /** Guidance to complete the question */
+  guidanceText?: Maybe<Scalars['String']['output']>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** This will be used as a sort of title for the Question */
+  questionText?: Maybe<Scalars['String']['output']>;
+  /** The type of question, such as text field, select box, radio buttons, etc */
+  questionTypeId?: Maybe<Scalars['Int']['output']>;
+  /** To indicate whether the question is required to be completed */
+  required?: Maybe<Scalars['Boolean']['output']>;
+  /** Requirements associated with the Question */
+  requirementText?: Maybe<Scalars['String']['output']>;
+  /** Sample text to possibly provide a starting point or example to answer question */
+  sampleText?: Maybe<Scalars['String']['output']>;
+  /** The unique id of the VersionedSection that the VersionedQuestion belongs to */
+  versionedSectionId: Scalars['Int']['output'];
+  /** The unique id of the VersionedTemplate that the VersionedQuestion belongs to */
+  versionedTemplateId: Scalars['Int']['output'];
+};
 
 /** A snapshot of a Section when it became published. */
 export type VersionedSection = {
@@ -858,6 +1049,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
+  AddQuestionInput: AddQuestionInput;
   AddSectionInput: AddSectionInput;
   Affiliation: ResolverTypeWrapper<Affiliation>;
   AffiliationAddress: ResolverTypeWrapper<AffiliationAddress>;
@@ -885,6 +1077,8 @@ export type ResolversTypes = {
   PersonIdentifier: ResolverTypeWrapper<PersonIdentifier>;
   PrimaryContact: ResolverTypeWrapper<PrimaryContact>;
   Query: ResolverTypeWrapper<{}>;
+  Question: ResolverTypeWrapper<Question>;
+  QuestionType: ResolverTypeWrapper<QuestionType>;
   RelatedIdentifier: ResolverTypeWrapper<RelatedIdentifier>;
   Ror: ResolverTypeWrapper<Scalars['Ror']['output']>;
   Section: ResolverTypeWrapper<Section>;
@@ -898,9 +1092,11 @@ export type ResolversTypes = {
   TemplateVersionType: TemplateVersionType;
   TemplateVisibility: TemplateVisibility;
   URL: ResolverTypeWrapper<Scalars['URL']['output']>;
+  UpdateQuestionInput: UpdateQuestionInput;
   UpdateSectionInput: UpdateSectionInput;
   User: ResolverTypeWrapper<User>;
   UserRole: UserRole;
+  VersionedQuestion: ResolverTypeWrapper<VersionedQuestion>;
   VersionedSection: ResolverTypeWrapper<VersionedSection>;
   VersionedTemplate: ResolverTypeWrapper<VersionedTemplate>;
   YesNoUnknown: YesNoUnknown;
@@ -908,6 +1104,7 @@ export type ResolversTypes = {
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
+  AddQuestionInput: AddQuestionInput;
   AddSectionInput: AddSectionInput;
   Affiliation: Affiliation;
   AffiliationAddress: AffiliationAddress;
@@ -935,6 +1132,8 @@ export type ResolversParentTypes = {
   PersonIdentifier: PersonIdentifier;
   PrimaryContact: PrimaryContact;
   Query: {};
+  Question: Question;
+  QuestionType: QuestionType;
   RelatedIdentifier: RelatedIdentifier;
   Ror: Scalars['Ror']['output'];
   Section: Section;
@@ -945,8 +1144,10 @@ export type ResolversParentTypes = {
   Template: Template;
   TemplateCollaborator: TemplateCollaborator;
   URL: Scalars['URL']['output'];
+  UpdateQuestionInput: UpdateQuestionInput;
   UpdateSectionInput: UpdateSectionInput;
   User: User;
+  VersionedQuestion: VersionedQuestion;
   VersionedSection: VersionedSection;
   VersionedTemplate: VersionedTemplate;
 };
@@ -1093,6 +1294,7 @@ export type IdentifierResolvers<ContextType = MyContext, ParentType extends Reso
 export type MutationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   addContributorRole?: Resolver<Maybe<ResolversTypes['ContributorRoleMutationResponse']>, ParentType, ContextType, RequireFields<MutationAddContributorRoleArgs, 'displayOrder' | 'label' | 'url'>>;
+  addQuestion?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, Partial<MutationAddQuestionArgs>>;
   addSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationAddSectionArgs, 'input'>>;
   addTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationAddTagArgs, 'name'>>;
   addTemplate?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationAddTemplateArgs, 'name'>>;
@@ -1100,10 +1302,12 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   archiveTemplate?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationArchiveTemplateArgs, 'templateId'>>;
   createVersion?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationCreateVersionArgs, 'templateId'>>;
   removeContributorRole?: Resolver<Maybe<ResolversTypes['ContributorRoleMutationResponse']>, ParentType, ContextType, RequireFields<MutationRemoveContributorRoleArgs, 'id'>>;
+  removeQuestion?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationRemoveQuestionArgs, 'questionId'>>;
   removeSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationRemoveSectionArgs, 'sectionId'>>;
   removeTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationRemoveTagArgs, 'tagId'>>;
   removeTemplateCollaborator?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationRemoveTemplateCollaboratorArgs, 'email' | 'templateId'>>;
   updateContributorRole?: Resolver<Maybe<ResolversTypes['ContributorRoleMutationResponse']>, ParentType, ContextType, RequireFields<MutationUpdateContributorRoleArgs, 'displayOrder' | 'id' | 'label' | 'url'>>;
+  updateQuestion?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, Partial<MutationUpdateQuestionArgs>>;
   updateSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationUpdateSectionArgs, 'input'>>;
   updateTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationUpdateTagArgs, 'name' | 'tagId'>>;
   updateTemplate?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationUpdateTemplateArgs, 'name' | 'templateId' | 'visibility'>>;
@@ -1149,8 +1353,12 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   contributorRoles?: Resolver<Maybe<Array<Maybe<ResolversTypes['ContributorRole']>>>, ParentType, ContextType>;
   dmspById?: Resolver<Maybe<ResolversTypes['SingleDmspResponse']>, ParentType, ContextType, RequireFields<QueryDmspByIdArgs, 'dmspId'>>;
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'sectionId'>>;
   publishedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
   publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType, RequireFields<QueryPublishedTemplatesArgs, 'term'>>;
+  question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
+  questionTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionType']>>>, ParentType, ContextType>;
+  questions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Question']>>>, ParentType, ContextType, RequireFields<QueryQuestionsArgs, 'sectionId'>>;
   section?: Resolver<Maybe<ResolversTypes['Section']>, ParentType, ContextType, RequireFields<QuerySectionArgs, 'sectionId'>>;
   sectionVersions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType, RequireFields<QuerySectionVersionsArgs, 'sectionId'>>;
   sections?: Resolver<Maybe<Array<Maybe<ResolversTypes['Section']>>>, ParentType, ContextType, RequireFields<QuerySectionsArgs, 'templateId'>>;
@@ -1162,6 +1370,38 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   templates?: Resolver<Maybe<Array<Maybe<ResolversTypes['Template']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'userId'>>;
   users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+};
+
+export type QuestionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Question'] = ResolversParentTypes['Question']> = {
+  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  displayOrder?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  guidanceText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isDirty?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  questionText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  questionTypeId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  requirementText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sampleText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  templateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QuestionTypeResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['QuestionType'] = ResolversParentTypes['QuestionType']> = {
+  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  usageDescription?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type RelatedIdentifierResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['RelatedIdentifier'] = ResolversParentTypes['RelatedIdentifier']> = {
@@ -1265,6 +1505,25 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type VersionedQuestionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedQuestion'] = ResolversParentTypes['VersionedQuestion']> = {
+  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  displayOrder?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  guidanceText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  questionText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  questionTypeId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  requirementText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sampleText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  versionedSectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  versionedTemplateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type VersionedSectionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedSection'] = ResolversParentTypes['VersionedSection']> = {
   created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -1330,6 +1589,8 @@ export type Resolvers<ContextType = MyContext> = {
   PersonIdentifier?: PersonIdentifierResolvers<ContextType>;
   PrimaryContact?: PrimaryContactResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  Question?: QuestionResolvers<ContextType>;
+  QuestionType?: QuestionTypeResolvers<ContextType>;
   RelatedIdentifier?: RelatedIdentifierResolvers<ContextType>;
   Ror?: GraphQLScalarType;
   Section?: SectionResolvers<ContextType>;
@@ -1339,6 +1600,7 @@ export type Resolvers<ContextType = MyContext> = {
   TemplateCollaborator?: TemplateCollaboratorResolvers<ContextType>;
   URL?: GraphQLScalarType;
   User?: UserResolvers<ContextType>;
+  VersionedQuestion?: VersionedQuestionResolvers<ContextType>;
   VersionedSection?: VersionedSectionResolvers<ContextType>;
   VersionedTemplate?: VersionedTemplateResolvers<ContextType>;
 };


### PR DESCRIPTION
## Description

Based on the results of this ticket to define schemas for Questions, https://github.com/CDLUC3/dmsp_backend_prototype/issues/64, I built the schemas:
- Question
- QuestionType
- QuestionCondition
- VersionedQuestion

Fixes # ([85](https://github.com/CDLUC3/dmsp_backend_prototype/issues/85))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
The standard unit tests and linting tests were run in pre-commit. I also ran "npm run build" to catch any bugs I didn't catch before.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules