### PR TITLE
[Bug] Switched 'created' and 'modified' dates from type DATETIMEISO to String to work with mariaDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - data-migrations/README.md with instructions on running migrations in the Docker container
 - removed old oauth-server package which had security vulnerabilities
 
+### Fixed
+- Converted DateTimeISO to String in schemas so that dates could be inserted into mariaDB database, and updated MySqlModel and associated unit test
+
 ## v0.0.1
 Initial Apollo Server build
 

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -1,13 +1,8 @@
 import { formatLogMessage } from "../logger";
 import { MyContext } from '../context';
 import { validateDate } from "../utils/helpers";
+import { getCurrentDate } from "../utils/helpers";
 
-// Get current date and put it into format that is acceptable to mariaDB
-export function getCurrentDate(): string {
-  const now = new Date().toISOString();
-  const currentDate = now.slice(0, 19).replace('T', ' ');
-  return currentDate;
-}
 export class MySqlModel {
   // Initialize with fields common to all MySQL DB tables
   constructor(

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -2,11 +2,17 @@ import { formatLogMessage } from "../logger";
 import { MyContext } from '../context';
 import { validateDate } from "../utils/helpers";
 
+// Get current date and put it into format that is acceptable to mariaDB
+export function getCurrentDate(): string {
+  const now = new Date().toISOString();
+  const currentDate = now.slice(0, 19).replace('T', ' ');
+  return currentDate;
+}
 export class MySqlModel {
   // Initialize with fields common to all MySQL DB tables
   constructor(
     public id?: number,
-    public created: string = new Date().toISOString(),
+    public created: string = getCurrentDate(),
     public createdById?: number,
     public modified?: string,
     public modifiedById?: number,
@@ -17,7 +23,7 @@ export class MySqlModel {
       this.modifiedById = this.createdById;
     }
     if (!this.modified) {
-      this.modified = this.id ? new Date().toISOString() : this.created;
+      this.modified = this.id ? getCurrentDate() : this.created;
     }
   };
 
@@ -153,8 +159,7 @@ export class MySqlModel {
     skipKeys?: string[]
   ): Promise<number> {
     // Update the creator/modifier info
-    const now = new Date().toISOString();
-    const currentDate = now.slice(0, 19).replace('T', ' ');
+    const currentDate = getCurrentDate();
     obj.createdById = apolloContext.token.id;
     obj.created = currentDate;
     obj.modifiedById = apolloContext.token.id;
@@ -189,10 +194,9 @@ export class MySqlModel {
   ): Promise<MySqlModel> {
     // Update the modifier info
     obj.modifiedById = apolloContext.token.id;
-    const now = new Date().toISOString();
-    const currentDate = now.slice(0, 19).replace('T', ' ');
+    const currentDate = getCurrentDate();
     obj.modified = currentDate;
-    obj.created = (new Date(obj.created).toISOString().slice(0, 19).replace('T', ' '));
+    obj.created = currentDate;
 
     // Fetch all of the data from the object
     const props = this.propertyInfo(obj, skipKeys);

--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -1,7 +1,8 @@
 import casual from 'casual';
-import { MySqlModel, getCurrentDate } from "../MySqlModel";
+import { MySqlModel } from "../MySqlModel";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from '../../__mocks__/context';
+import { getCurrentDate } from '../../utils/helpers';
 
 jest.mock('../../dataSources/mySQLDataSource', () => {
   return {

--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -1,5 +1,5 @@
 import casual from 'casual';
-import { MySqlModel } from "../MySqlModel";
+import { MySqlModel, getCurrentDate } from "../MySqlModel";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from '../../__mocks__/context';
 
@@ -36,21 +36,22 @@ class TestImplementation extends MySqlModel {
 describe('MySqlModel abstract class', () => {
   it('constructor should initialize as expected if it is a new record', () => {
     const createdById = casual.integer(1, 999);
-
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     expect(model.id).toBeFalsy();
     expect(model.createdById).toEqual(createdById);
     expect(model.modifiedById).toEqual(createdById);
-    expect(model.created).toBeTruthy();
-    expect(model.modified).toEqual(model.created);
+    expect(model.created).toEqual(formattedDate);
+    expect(model.modified).toEqual(formattedDate);
   });
 
   it('constructor should initialize as expected if it is an existing record', () => {
     const id = casual.integer(1, 999);
-    const created = new Date().toISOString();
+    const formattedDate = getCurrentDate();
+    const created = formattedDate;
     const createdById = casual.integer(1, 999);
-    const modified = new Date().toISOString();
+    const modified = formattedDate;
     const modifiedById = casual.integer(1, 999);
 
     const model = new MySqlModel(id, created, createdById, modified, modifiedById);
@@ -58,13 +59,14 @@ describe('MySqlModel abstract class', () => {
     expect(model.id).toEqual(id);
     expect(model.createdById).toEqual(createdById);
     expect(model.modifiedById).toEqual(modifiedById);
-    expect(model.created).toEqual(created);
-    expect(model.modified).toEqual(modified);
+    expect(model.created).toEqual(formattedDate);
+    expect(model.modified).toEqual(formattedDate);
   });
 
   it('isValid should return false when the modified date is not a Date', async () => {
     const createdById = casual.integer(1, 999);
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     model.modified = '2456247dgerg';
     expect(await model.isValid()).toBe(false);
@@ -74,7 +76,8 @@ describe('MySqlModel abstract class', () => {
 
   it('isValid should return false when the created date is not a Date', async () => {
     const createdById = casual.integer(1, 999);
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     model.created = '2456247dgerg';
     expect(await model.isValid()).toBe(false);
@@ -84,7 +87,8 @@ describe('MySqlModel abstract class', () => {
 
   it('isValid should return false when the createdById is null', async () => {
     const createdById = casual.integer(1, 999);
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     model.createdById = null;
     expect(await model.isValid()).toBe(false);
@@ -94,7 +98,8 @@ describe('MySqlModel abstract class', () => {
 
   it('isValid should return false when the modifiedById is null', async () => {
     const createdById = casual.integer(1, 999);
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     model.modifiedById = null;
     expect(await model.isValid()).toBe(false);
@@ -104,7 +109,8 @@ describe('MySqlModel abstract class', () => {
 
   it('isValid should return true when the id is null', async () => {
     const createdById = casual.integer(1, 999);
-    const model = new MySqlModel(null, new Date().toISOString(), createdById);
+    const formattedDate = getCurrentDate();
+    const model = new MySqlModel(null, formattedDate, createdById);
 
     model.id = null;
     expect(await model.isValid()).toBe(true);

--- a/src/schemas/collaborator.ts
+++ b/src/schemas/collaborator.ts
@@ -20,11 +20,11 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
-    created: DateTimeISO
+    created: String
     "The user who last modified the Object"
     modifiedById: Int
     "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
+    modified: String
     "Errors associated with the Object"
     errors: [String!]
 

--- a/src/schemas/contributorRole.ts
+++ b/src/schemas/contributorRole.ts
@@ -39,11 +39,11 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
-    created: DateTimeISO
+    created: String
     "The user who last modified the Object"
     modifiedById: Int
     "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
+    modified: String
     "Errors associated with the Object"
     errors: [String!]
 

--- a/src/schemas/dmsp.ts
+++ b/src/schemas/dmsp.ts
@@ -19,10 +19,10 @@ export const typeDefs = gql`
 
   type Dmsp {
     contact: PrimaryContact!
-    created: DateTimeISO!
+    created: String
     dmp_id: DmspIdentifier!
     ethical_issues_exist: YesNoUnknown!
-    modified: DateTimeISO!
+    modified: String
     title: String!
 
     contributor: [Contributor]

--- a/src/schemas/section.ts
+++ b/src/schemas/section.ts
@@ -21,6 +21,17 @@ export const typeDefs = gql`
   type Section {
     "The unique identifer for the Object"
     id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: [String!]
+    
     "The template ID that the section belongs to"
     templateId: Int
     "The template that the section is associated with"
@@ -39,16 +50,6 @@ export const typeDefs = gql`
     tags: [Tag]
     "Indicates whether or not the section has changed since the template was last published"
     isDirty: Boolean!
-    "The user who created the Object"
-    createdById: Int
-    "The timestamp when the Object was created"
-    created: String
-    "The user who last modified the Object"
-    modifiedById: Int
-    "The timestamp when the Object was last modifed"
-    modified: String
-    "Errors associated with the Object"
-    errors: [String!]
   }
 
   "Input for adding a new section"

--- a/src/schemas/tag.ts
+++ b/src/schemas/tag.ts
@@ -20,6 +20,17 @@ export const typeDefs = gql`
   type Tag {
     "The unique identifer for the Object"
     id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: [String!]
+    
     "The tag name"
     name: String!
     "The tag description"

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -35,11 +35,11 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
-    created: DateTimeISO
+    created: String
     "The user who last modified the Object"
     modifiedById: Int
     "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
+    modified: String
     "Errors associated with the Object"
     errors: [String!]
 

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -24,11 +24,11 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
-    created: DateTimeISO
+    created: String
     "The user who last modified the Object"
     modifiedById: Int
     "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
+    modified: String
     "Errors associated with the Object"
     errors: [String!]
 

--- a/src/schemas/versionedSection.ts
+++ b/src/schemas/versionedSection.ts
@@ -20,6 +20,17 @@ export const typeDefs = gql`
   type VersionedSection {
     "The unique identifer for the Object"
     id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: [String!]
+    
     "The parent VersionedTemplate"
     versionedTemplate: VersionedTemplate!
     "The sectionId for the snapshot section"
@@ -41,16 +52,5 @@ export const typeDefs = gql`
     guidance: String
     "The Tags associated with this VersionedSection"
     tags: [Tag]
-
-    "The user who created the Object"
-    createdById: Int
-    "The timestamp when the Object was created"
-    created: DateTimeISO
-    "The user who last modified the Object"
-    modifiedById: Int
-    "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
-    "Errors associated with the Object"
-    errors: [String!]
   }
 `;

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -23,11 +23,11 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The timestamp when the Object was created"
-    created: DateTimeISO
+    created: String
     "The user who last modified the Object"
     modifiedById: Int
     "The timestamp when the Object was last modifed"
-    modified: DateTimeISO
+    modified: String
     "Errors associated with the Object"
     errors: [String!]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export type Contributor = Person & {
 export type ContributorRole = {
   __typename?: 'ContributorRole';
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** A longer description of the contributor role useful for tooltips */
@@ -165,7 +165,7 @@ export type ContributorRole = {
   /** The Ui label to display for the contributor role */
   label: Scalars['String']['output'];
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The URL for the contributor role */
@@ -197,7 +197,7 @@ export type Dmsp = {
   __typename?: 'Dmsp';
   contact: PrimaryContact;
   contributor?: Maybe<Array<Maybe<Contributor>>>;
-  created: Scalars['DateTimeISO']['output'];
+  created?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   dmp_id: DmspIdentifier;
   dmproadmap_featured?: Maybe<Scalars['String']['output']>;
@@ -207,7 +207,7 @@ export type Dmsp = {
   ethical_issues_exist: YesNoUnknown;
   ethical_issues_report?: Maybe<Scalars['URL']['output']>;
   language?: Maybe<Scalars['String']['output']>;
-  modified: Scalars['DateTimeISO']['output'];
+  modified?: Maybe<Scalars['String']['output']>;
   title: Scalars['String']['output'];
 };
 
@@ -561,10 +561,20 @@ export type SingleDmspResponse = {
 /** A Tag is a way to group similar types of categories together */
 export type Tag = {
   __typename?: 'Tag';
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
   /** The tag description */
   description?: Maybe<Scalars['String']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<Array<Scalars['String']['output']>>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The tag name */
   name: Scalars['String']['output'];
 };
@@ -584,7 +594,7 @@ export type Template = {
   /** Users from different affiliations who have been invited to collaborate on this template */
   collaborators?: Maybe<Array<TemplateCollaborator>>;
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** The current published version */
@@ -598,7 +608,7 @@ export type Template = {
   /** Whether or not the Template has had any changes since it was last published */
   isDirty: Scalars['Boolean']['output'];
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The name/title of the template */
@@ -617,7 +627,7 @@ export type Template = {
 export type TemplateCollaborator = {
   __typename?: 'TemplateCollaborator';
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** The collaborator's email */
@@ -629,7 +639,7 @@ export type TemplateCollaborator = {
   /** The user who invited the collaborator */
   invitedBy?: Maybe<User>;
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The template the collaborator may edit */
@@ -671,7 +681,7 @@ export type User = {
   /** The user's organizational affiliation */
   affiliation?: Maybe<Affiliation>;
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** The user's primary email address */
@@ -683,7 +693,7 @@ export type User = {
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The user's ORCID */
@@ -704,7 +714,7 @@ export type UserRole =
 export type VersionedSection = {
   __typename?: 'VersionedSection';
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** The displayOrder of this VersionedSection */
@@ -718,7 +728,7 @@ export type VersionedSection = {
   /** The VersionedSection introduction */
   introduction?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The VersionedSection name/title */
@@ -747,7 +757,7 @@ export type VersionedTemplate = {
   /** A comment/note the user enters when publishing the Template */
   comment?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was created */
-  created?: Maybe<Scalars['DateTimeISO']['output']>;
+  created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** A description of the purpose of the template */
@@ -757,7 +767,7 @@ export type VersionedTemplate = {
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** The timestamp when the Object was last modifed */
-  modified?: Maybe<Scalars['DateTimeISO']['output']>;
+  modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The name/title of the template */
@@ -1021,14 +1031,14 @@ export type ContributorResolvers<ContextType = MyContext, ParentType extends Res
 };
 
 export type ContributorRoleResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ContributorRole'] = ResolversParentTypes['ContributorRole']> = {
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayOrder?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   url?: Resolver<ResolversTypes['URL'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1055,7 +1065,7 @@ export type DmpRoadmapAffiliationResolvers<ContextType = MyContext, ParentType e
 export type DmspResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Dmsp'] = ResolversParentTypes['Dmsp']> = {
   contact?: Resolver<ResolversTypes['PrimaryContact'], ParentType, ContextType>;
   contributor?: Resolver<Maybe<Array<Maybe<ResolversTypes['Contributor']>>>, ParentType, ContextType>;
-  created?: Resolver<ResolversTypes['DateTimeISO'], ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   dmp_id?: Resolver<ResolversTypes['DmspIdentifier'], ParentType, ContextType>;
   dmproadmap_featured?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1065,7 +1075,7 @@ export type DmspResolvers<ContextType = MyContext, ParentType extends ResolversP
   ethical_issues_exist?: Resolver<ResolversTypes['YesNoUnknown'], ParentType, ContextType>;
   ethical_issues_report?: Resolver<Maybe<ResolversTypes['URL']>, ParentType, ContextType>;
   language?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  modified?: Resolver<ResolversTypes['DateTimeISO'], ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1204,8 +1214,13 @@ export type SingleDmspResponseResolvers<ContextType = MyContext, ParentType exte
 };
 
 export type TagResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Tag'] = ResolversParentTypes['Tag']> = {
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1213,14 +1228,14 @@ export type TagResolvers<ContextType = MyContext, ParentType extends ResolversPa
 export type TemplateResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Template'] = ResolversParentTypes['Template']> = {
   bestPractice?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   collaborators?: Resolver<Maybe<Array<ResolversTypes['TemplateCollaborator']>>, ParentType, ContextType>;
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   currentVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isDirty?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   owner?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
@@ -1231,13 +1246,13 @@ export type TemplateResolvers<ContextType = MyContext, ParentType extends Resolv
 };
 
 export type TemplateCollaboratorResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateCollaborator'] = ResolversParentTypes['TemplateCollaborator']> = {
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   invitedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   template?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
@@ -1251,13 +1266,13 @@ export interface UrlScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes[
 export type UserResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
   acceptedTerms?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   affiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   email?: Resolver<ResolversTypes['EmailAddress'], ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   givenName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   orcid?: Resolver<Maybe<ResolversTypes['Orcid']>, ParentType, ContextType>;
   role?: Resolver<ResolversTypes['UserRole'], ParentType, ContextType>;
@@ -1266,14 +1281,14 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
 };
 
 export type VersionedSectionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedSection'] = ResolversParentTypes['VersionedSection']> = {
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   displayOrder?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   guidance?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   introduction?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   requirements?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1289,12 +1304,12 @@ export type VersionedTemplateResolvers<ContextType = MyContext, ParentType exten
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   bestPractice?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  created?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  modified?: Resolver<Maybe<ResolversTypes['DateTimeISO']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   owner?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -66,3 +66,10 @@ export function incrementVersionNumber(version: string): string {
   // If no numeric part is found, return the original version string
   return version;
 }
+
+// Get current date and put it into format that is acceptable to mariaDB
+export function getCurrentDate(): string {
+  const now = new Date().toISOString();
+  const currentDate = now.slice(0, 19).replace('T', ' ');
+  return currentDate;
+}


### PR DESCRIPTION
## Description

The `created` and `modified` fields in the schemas were initially assigned to type DateTimeISO. However, while working on [#75](https://github.com/CDLUC3/dmsp_backend_prototype/issues/75) I was getting errors when trying to update or insert new data into the database tables. I read that DateTimeISO does not work with mariaDB, and that I should switch the type to "String" instead in the schemas. This change was effective, and I was able to add and update the database tables.

Therefore, this ticket was created to update all the schemas. I also added a shared function to MySQLModel to get this formatted date for insertion, and updated the corresponding unit test.

Fixes # ([#96](https://github.com/orgs/CDLUC3/projects/14/views/3?pane=issue&itemId=80274356))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This was tested by checking the unit tests and linting. Also, I tested that data could be updated and added into the database via Apollo sandbox.

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules