### PR TITLE
Chore/aws cache

### DIFF
--- a/src/config/cacheConfig.ts
+++ b/src/config/cacheConfig.ts
@@ -6,8 +6,10 @@ dotenv.config();
 verifyCriticalEnvVariable('CACHE_HOST');
 verifyCriticalEnvVariable('CACHE_PORT');
 
-export const cacheConfig = {
-  host: process.env.CACHE_HOST,
-  port: Number.parseInt(process.env.CACHE_PORT),
-  connectTimeout: Number.parseInt(process.env.CACHE_CONNECT_TIMEOUT) || 30000, // 30 seconds
-};
+const host = process.env.CACHE_HOST;
+const port = Number.parseInt(process.env.CACHE_PORT);
+const connectTimeout = Number.parseInt(process.env.CACHE_CONNECT_TIMEOUT) || 30000; // 30 seconds
+
+export const cacheConfig = { host, port, connectTimeout };
+
+export const cacheTLS = `rediss://${host}:${port}`;

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -2,7 +2,7 @@ import Keyv from "keyv";
 import KeyvRedis from "@keyv/redis";
 import Redis from "ioredis";
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
-import { cacheConfig } from "../config/cacheConfig";
+import { cacheConfig, cacheTLS } from "../config/cacheConfig";
 import { logger, formatLogMessage } from '../logger';
 
 export class Cache {
@@ -11,8 +11,15 @@ export class Cache {
 
   private constructor() {
     // Setup the Redis Cluster
-    // const cluster = new Redis.Cluster(cacheConfig.cluster);
-    const cache = new Redis(cacheConfig);
+    let cache;
+    if (process.env.NODE_ENV !== 'development') {
+      console.log('Connecting to local Redis');
+      cache = new Redis(cacheConfig);
+    } else {
+      console.log(`Using TLS to connect to Redis - ${cacheTLS}`);
+      // The AWS env uses TLS
+      cache = new Redis(cacheTLS);
+    }
 
     // Having trouble figuring how how to type `Keyv` as `Keyv<string, Record<string, any>>`
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Was able to setup SessionManager and log onto one of the ECS containers. From there I was able to connect to the Redis cache but had to use TLS.

This PR contains a modification to the config for the cache to use TLS when not in development mode. I also added a couple of debug lines (which I will remove once it's working).