### PR TITLE
Chore/aws cache

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,7 @@ services:
     env_file:
       - .env
     environment:
+      - "NODE_ENV=development"
       - "MYSQL_CONNECTION_LIMIT=5"
       - "MYSQL_HOST=apollo-mariadb"
       - "MYSQL_PORT=3306"

--- a/src/config/cacheConfig.ts
+++ b/src/config/cacheConfig.ts
@@ -10,6 +10,13 @@ const host = process.env.CACHE_HOST;
 const port = Number.parseInt(process.env.CACHE_PORT);
 const connectTimeout = Number.parseInt(process.env.CACHE_CONNECT_TIMEOUT) || 30000; // 30 seconds
 
-export const cacheConfig = { host, port, connectTimeout };
+let cache = {};
+if (process.env.NODE_ENV !== 'development') {
+  cache = { host, port, connectTimeout, tls: {} };
+} else {
+  cache = { host, port, connectTimeout };
+}
+
+export const cacheConfig = cache;
 
 export const cacheTLS = `rediss://${host}:${port}`;

--- a/src/config/cacheConfig.ts
+++ b/src/config/cacheConfig.ts
@@ -10,13 +10,6 @@ const host = process.env.CACHE_HOST;
 const port = Number.parseInt(process.env.CACHE_PORT);
 const connectTimeout = Number.parseInt(process.env.CACHE_CONNECT_TIMEOUT) || 30000; // 30 seconds
 
-let cache = {};
-if (process.env.NODE_ENV !== 'development') {
-  cache = { host, port, connectTimeout, tls: {} };
-} else {
-  cache = { host, port, connectTimeout };
-}
-
-export const cacheConfig = cache;
+export const cacheConfig = { host, port, connectTimeout };
 
 export const cacheTLS = `rediss://${host}:${port}`;

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -10,14 +10,13 @@ export class Cache {
   public adapter: KeyvAdapter;
 
   private constructor() {
+    let cache;
+
     // Setup the Redis Cluster
     formatLogMessage(logger).info(cacheConfig, 'Attempting to connect to Redis');
-    //const cache = new Redis(cacheConfig);
-
-    let cache;
     if (process.env.NODE_ENV !== 'development') {
       console.log(`Using TLS to connect to Redis - ${cacheTLS}`);
-      // The AWS env uses TLS
+      // The AWS env uses TLS!
       cache = new Redis(cacheTLS);
     } else {
       cache = new Redis(cacheConfig);

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -11,14 +11,16 @@ export class Cache {
 
   private constructor() {
     // Setup the Redis Cluster
+    formatLogMessage(logger).info(cacheConfig, 'Attempting to connect to Redis');
+    //const cache = new Redis(cacheConfig);
+
     let cache;
     if (process.env.NODE_ENV !== 'development') {
-      console.log('Connecting to local Redis');
-      cache = new Redis(cacheConfig);
-    } else {
       console.log(`Using TLS to connect to Redis - ${cacheTLS}`);
       // The AWS env uses TLS
       cache = new Redis(cacheTLS);
+    } else {
+      cache = new Redis(cacheConfig);
     }
 
     // Having trouble figuring how how to type `Keyv` as `Keyv<string, Record<string, any>>`

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -39,6 +39,7 @@ export class Cache {
       formatLogMessage(logger).info( null, `Redis connection closed`);
     });
 
+
     // Set the Adapter which will be used to interact with the cache
     this.adapter = new KeyvAdapter(keyV);
   }

--- a/src/datasources/mySQLDataSource.ts
+++ b/src/datasources/mySQLDataSource.ts
@@ -36,6 +36,8 @@ export class MySQLDataSource {
     const queueLimit = Number.parseInt(process.env.MYSQL_QUEUE_LIMIT) || 100;
     const connectTimeout = Number.parseInt(process.env.MYSQL_CONNECT_TIMEOUT) || 60000;
 
+    formatLogMessage(logger).info('Establishing MySQL connection pool ...');
+
     try {
       this.pool = mysql.createPool({
         ...mysqlConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import router from './router';
 import { MySQLDataSource } from './datasources/mySQLDataSource';
 import { Cache } from './datasources/cache';
 import { csrfMiddleware } from './middleware/csrf';
+import { verifyCriticalEnvVariable } from './utils/helpers';
+
+verifyCriticalEnvVariable('NODE_ENV');
+console.log(`DMPTool Apollo server backend starting in ${process.env.NODE_ENV} mode.`)
 
 // TODO: Make this configurable and pass in as ENV variable
 const PORT = 4000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import { attachApolloServer } from './middleware/express';
 import router from './router';
 import { MySQLDataSource } from './datasources/mySQLDataSource';
 import { Cache } from './datasources/cache';
-import { csrfMiddleware } from './middleware/csrf';
 import { verifyCriticalEnvVariable } from './utils/helpers';
 
 verifyCriticalEnvVariable('NODE_ENV');
@@ -40,7 +39,6 @@ const startServer = async () => {
   app.use(
     cookieParser(),
     cors(),
-    csrfMiddleware,
     express.urlencoded({ extended: false }),
     express.json({ limit: '50mb' }),
   )

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -3,8 +3,10 @@ import { JWTAccessToken } from '../services/tokenService';
 import { buildContext } from '../context';
 import { ApolloServer } from '@apollo/server';
 import { Request } from 'express-jwt';
+import { formatLogMessage } from '../logger';
 
 export async function attachApolloServer(apolloServer: ApolloServer, cache, logger) {
+  formatLogMessage(logger).info(null, 'Attaching Apollo server');
   // expressMiddleware accepts the same arguments:
   //   an Apollo Server instance and optional configuration options
   return expressMiddleware(apolloServer, {

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,28 +4,40 @@ import { signinController } from './controllers/signinController';
 import { signupController } from './controllers/signupController';
 import { refreshTokenController } from './controllers/refreshTokenController';
 import { signoutController } from './controllers/signoutController';
+import { csrfMiddleware } from './middleware/csrf';
 
 const router = express.Router();
 
 // Support for acquiring an initial CSRF token
-router.get('/apollo-csrf', (req: Request, res: Response) => { res.status(200).send('ok'); });
+router.get('/apollo-csrf',
+  csrfMiddleware,
+  (_req: Request, res: Response) => { res.status(200).send('ok'); }
+);
 
-// Support for user auth
-router.post('/apollo-signin', (req: Request, res: Response) => signinController(req, res));
-router.post('/apollo-signup', (req: Request, res: Response) => signupController(req, res));
-router.post('/apollo-signout', authMiddleware, (req: Request, res: Response) => signoutController(req, res));
-router.post('/apollo-refresh', authMiddleware, (req: Request, res: Response) => refreshTokenController(req, res));
+// Support for user sign in/up - requires a valid CSRF token
+router.post('/apollo-signin',
+  csrfMiddleware,
+  (req: Request, res: Response) => signinController(req, res)
+);
+router.post('/apollo-signup',
+  csrfMiddleware,
+  (req: Request, res: Response) => signupController(req, res)
+);
+// Support for refreshing access tokens - requires a valid CSRF and Refresh token
+router.post('/apollo-refresh',
+  csrfMiddleware,
+  authMiddleware,
+  (req: Request, res: Response) => refreshTokenController(req, res)
+);
+// Support for user sign out
+router.post('/apollo-signout',
+  authMiddleware,
+  (req: Request, res: Response) => signoutController(req, res)
+);
 
 // GraphQL operations
+// Apollo server has it's own built-in way of dealing with CSRF so no need to use our homegrown
+// version here. See: https://www.apollographql.com/docs/router/configuration/csrf/
 router.use('/graphql', authMiddleware);
-
-// Sample protected endpoint
-router.post("/protected", authMiddleware, (req: Request, res: Response) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (!(req as any).auth.admin) {
-    return res.sendStatus(401);
-  }
-  res.sendStatus(200);
-});
 
 export default router;


### PR DESCRIPTION
## Description

Updates to get the backend application talking to the Redis cache  in the AWS environment.
Also removed CSRF from the `/graphql` endpoint. Apollo server has builtin CSRF protections.

Fixes [aws repo issue #82](https://github.com/CDLUC3/dmsp_aws_prototype/issues/82)

## Type of change
Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

Deployed code to AWS and am now able to get a token by calling `/apollo-csrf` endpoint and the Apollo sandbox at the `/graphql` endpoint loads again.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules