### PR TITLE
Feature/user lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added Language model, resolver and type. Added LanguageId to User and Template
 - Fixed some bugs to allow frontend to access token change(Frontend #116)
 - Added data migrations for QuestionType, Question, QuestionCondition, VersionedQuestion and VersionedQuestionCondition
 - Added missing VersionedQuestionCondition schema file

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Resolvers](#resolvers)
     - [Models](#models)
     - [Mocks](#mocks)
+    - [Internationalization / Language support](#languages)
     - [Tests](#tests)
 - [Environment variables](#environment-variables)
 - [Routes](#routes)
@@ -352,6 +353,12 @@ In some situations, the data source will not be ready. In this scenario you can 
 To use a mock, simply import it into your resolver and then setup your Query and Mutation handlers to interact with the canned mock data.
 
 Note that mocks will refresh each time the server is restarted!
+
+### Languages
+
+The languages supported by the system can be found in the `src/models/language.ts` file.
+
+TODO: update with documentation on how to provide translation support for DB based text
 
 ### Tests
 

--- a/data-migrations/2024-10-23-1133-add-language-to-users-templates.sql
+++ b/data-migrations/2024-10-23-1133-add-language-to-users-templates.sql
@@ -1,0 +1,24 @@
+# Add the missing languageId column to the users and templates tables
+ALTER TABLE `users`
+  ADD`languageId` CHAR(5) NOT NULL DEFAULT 'en-US';
+
+ALTER TABLE `templates`
+  ADD`languageId` CHAR(5) NOT NULL DEFAULT 'en-US';
+
+# Update all of the Brazilian templates to use pt-BR
+UPDATE `templates` SET `languageId` = 'pt-BR' WHERE `ownerId` IN (
+  'https://ror.org/01xdw4k60',
+  'https://ror.org/04wffgt70',
+  'https://ror.org/036rp1748',
+  'https://ror.org/028kg9j04',
+  'https://ror.org/03srtnf24'
+);
+
+# Update the admin users for the Brazilian institutions to use pt-BR
+UPDATE `users` SET `languageId` = 'pt-BR' WHERE `affiliationId` IN (
+  'https://ror.org/01xdw4k60',
+  'https://ror.org/04wffgt70',
+  'https://ror.org/036rp1748',
+  'https://ror.org/028kg9j04',
+  'https://ror.org/03srtnf24'
+);

--- a/src/__mocks__/context.ts
+++ b/src/__mocks__/context.ts
@@ -6,6 +6,7 @@ import { DMPToolAPI } from "../datasources/dmptoolAPI";
 import { MySQLDataSource } from "../datasources/mySQLDataSource";
 import { User, UserRole } from "../models/User";
 import casual from "casual";
+import { defaultLanguageId } from "../models/Language";
 
 jest.mock('../datasources/dmphubAPI');
 jest.mock('../datasources/dmptoolAPI');
@@ -78,6 +79,7 @@ export const mockToken = (user = mockUser()): JWTAccessToken => {
     surName: user.surName,
     affiliationId: user.affiliationId,
     role: user.role,
+    languageId: defaultLanguageId,
     jti: casual.integer(1, 999999).toString(),
     expiresIn: casual.integer(1, 999999999),
   }

--- a/src/controllers/__tests__/integrationTokens.spec.ts
+++ b/src/controllers/__tests__/integrationTokens.spec.ts
@@ -11,6 +11,7 @@ import * as UserModel from '../../models/User';
 import { generalConfig } from '../../config/generalConfig';
 import { authMiddleware } from '../../middleware/auth';
 import { verifyAccessToken } from '../../services/tokenService';
+import { defaultLanguageId } from '../../models/Language';
 
 jest.mock('../../datasources/cache');
 jest.mock('../../models/User');
@@ -43,6 +44,7 @@ const mockedUser: UserModel.User = {
   role: UserModel.UserRole.RESEARCHER,
   acceptedTerms: true,
   password: casual.uuid,
+  languageId: defaultLanguageId,
   created: new Date().toISOString(),
   errors: [],
 

--- a/src/controllers/__tests__/signinController.spec.ts
+++ b/src/controllers/__tests__/signinController.spec.ts
@@ -5,6 +5,7 @@ import { generateAuthTokens, setTokenCookie } from '../../services/tokenService'
 import { generalConfig } from '../../config/generalConfig';
 import { signinController } from '../signinController';
 import * as UserModel from '../../models/User';
+import { defaultLanguageId } from '../../models/Language';
 
 // Mocking external dependencies
 jest.mock('../../datasources/cache');
@@ -20,6 +21,7 @@ const mockedUser: UserModel.User = {
   role: UserModel.UserRole.RESEARCHER,
   password: casual.uuid,
   acceptedTerms: true,
+  languageId: defaultLanguageId,
   created: new Date().toISOString(),
   errors: [],
 

--- a/src/controllers/__tests__/signupController.spec.ts
+++ b/src/controllers/__tests__/signupController.spec.ts
@@ -5,6 +5,7 @@ import { generateAuthTokens, setTokenCookie } from '../../services/tokenService'
 import { generalConfig } from '../../config/generalConfig';
 import * as UserModel from '../../models/User';
 import { signupController } from '../signupController';
+import { defaultLanguageId } from '../../models/Language';
 
 // Mocking external dependencies
 jest.mock('../../datasources/cache');
@@ -19,6 +20,7 @@ const mockedUser: UserModel.User = {
   affiliationId: casual.url,
   role: UserModel.UserRole.RESEARCHER,
   acceptedTerms: true,
+  languageId: defaultLanguageId,
   password: casual.uuid,
   created: new Date().toISOString(),
   errors: [],

--- a/src/models/Language.ts
+++ b/src/models/Language.ts
@@ -1,0 +1,10 @@
+// Language is set on the User, Template and DMP as `languageId`
+
+// Languages supported by the application
+export const supportedLanguages = [
+  { id: "en-US", name: 'English (US)' },
+  { id: "pt-BR", name: "Português (Brasil)" },
+];
+
+// The default Language
+export const defaultLanguageId = 'en-US';

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -1,5 +1,6 @@
 import { MyContext } from "../context";
 import { TemplateCollaborator } from "./Collaborator";
+import { defaultLanguageId, supportedLanguages } from "./Language";
 import { MySqlModel } from "./MySqlModel";
 
 export enum TemplateVisibility {
@@ -17,6 +18,7 @@ export class Template extends MySqlModel {
   public currentVersion?: string;
   public isDirty: boolean;
   public bestPractice: boolean;
+  public languageId: string;
 
   private tableName = 'templates';
 
@@ -31,6 +33,14 @@ export class Template extends MySqlModel {
     this.currentVersion = options.currentVersion || '';
     this.isDirty = options.isDirty || true;
     this.bestPractice = options.bestPractice || false;
+    this.languageId = options.languageId || defaultLanguageId;
+  }
+
+  // Ensure data integrity
+  cleanup() {
+    if (!supportedLanguages.map((l) => l.id).includes(this.languageId)){
+      this.languageId = defaultLanguageId;
+    }
   }
 
   // Validation to be used prior to saving the record
@@ -60,6 +70,7 @@ export class Template extends MySqlModel {
       if (current) {
         this.errors.push('Template with this name already exists');
       } else {
+        this.cleanup();
         // Save the record and then fetch it
         const newId = await Template.insert(context, this.tableName, this, 'Template.create');
         return await Template.findById('Template.create', context, newId);
@@ -91,8 +102,9 @@ export class Template extends MySqlModel {
           warningStatus: 0,
           changedRows: 1
         }
-        So, we have to make a call to findById to get the updated data to return to user 
+        So, we have to make a call to findById to get the updated data to return to user
         */
+        this.cleanup();
         await Template.update(context, this.tableName, this, 'Template.update', ['tableName']);
 
 

--- a/src/models/__tests__/Template.spec.ts
+++ b/src/models/__tests__/Template.spec.ts
@@ -3,6 +3,7 @@ import { Template, TemplateVisibility } from "../Template";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from '../../__mocks__/context';
 import { TemplateCollaborator } from '../Collaborator';
+import { defaultLanguageId } from '../Language';
 
 jest.mock('../../context.ts');
 
@@ -42,6 +43,13 @@ describe('Template', () => {
     expect(template.currentVersion).toBeFalsy();
     expect(template.isDirty).toBeTruthy();
     expect(template.errors).toEqual([]);
+    expect(template.languageId).toEqual(defaultLanguageId);
+  });
+
+  it('should cleanup the data', () => {
+    template.languageId = 'test';
+    template.cleanup();
+    expect(template.languageId).toEqual(defaultLanguageId);
   });
 
   it('isValid returns true when the record is valid', async () => {

--- a/src/models/__tests__/User.spec.ts
+++ b/src/models/__tests__/User.spec.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcryptjs';
 import casual from 'casual';
 import { logger } from '../../__mocks__/logger';
 import { buildContext } from '../../context';
+import { defaultLanguageId, supportedLanguages } from '../Language';
 
 jest.mock('../../context.ts');
 
@@ -15,6 +16,8 @@ let mockContext;
 
 describe('constructor', () => {
   it('should set the expected properties', () => {
+    const lang = supportedLanguages.find((entry) => { return entry.id !== defaultLanguageId });
+
     const props = {
       id: casual.integer(1, 99999),
       email: casual.email,
@@ -24,6 +27,7 @@ describe('constructor', () => {
       givenName: casual.first_name,
       surName: casual.last_name,
       orcid: '0000-0000-0000-000X',
+      languageId: lang.id,
     }
 
     const user = new User(props);
@@ -35,6 +39,7 @@ describe('constructor', () => {
     expect(user.surName).toEqual(props.surName);
     expect(user.orcid).toEqual(props.orcid);
     expect(user.role).toEqual(props.role);
+    expect(user.languageId).toEqual(props.languageId);
   });
 
   it('should set the defaults properly', () => {
@@ -48,6 +53,7 @@ describe('constructor', () => {
     expect(user.surName).toBeFalsy();
     expect(user.orcid).toBeFalsy();
     expect(user.role).toEqual(UserRole.RESEARCHER);
+    expect(user.languageId).toEqual(defaultLanguageId);
   });
 
   it('should ignore unexpected properties', () => {
@@ -61,12 +67,18 @@ describe('constructor', () => {
 
 describe('cleanup standardizes the format of properties', () => {
   it('should properly format the properties', () => {
-    const user = new User({ email: 'TESTer%40exaMPle.cOm', givenName: ' Test ', surName: '  user  ' });
+    const user = new User({
+      email: 'TESTer%40exaMPle.cOm',
+      givenName: ' Test ',
+      surName: '  user  ',
+      languageId: 'test',
+    });
     user.cleanup();
     expect(user.email).toEqual('TESTer@exaMPle.cOm');
     expect(user.givenName).toEqual('Test');
     expect(user.surName).toEqual('User');
     expect(user.role).toEqual(UserRole.RESEARCHER);
+    expect(user.languageId).toEqual(defaultLanguageId);
   });
 });
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -8,6 +8,7 @@ import { rorScalar } from './resolvers/scalars/ror';
 import { resolvers as affiliationResolvers } from './resolvers/affiliation';
 import { resolvers as collaboratorResolvers } from './resolvers/collaborator';
 import { resolvers as contributorRoleResolvers } from './resolvers/contributorRole';
+import { resolvers as languageResolvers } from './resolvers/language';
 import { resolvers as sectionResolvers } from './resolvers/section';
 import { resolvers as tagResolvers } from './resolvers/tag';
 import { resolvers as versionedSectionResolvers } from './resolvers/versionedSection';
@@ -26,6 +27,7 @@ export const resolvers: IResolvers = mergeResolvers([
   scalarResolvers,
   affiliationResolvers,
   collaboratorResolvers,
+  languageResolvers,
   sectionResolvers,
   tagResolvers,
   versionedSectionResolvers,

--- a/src/resolvers/language.ts
+++ b/src/resolvers/language.ts
@@ -1,0 +1,13 @@
+import { Language, Resolvers } from "../types";
+import { defaultLanguageId, supportedLanguages } from "../models/Language";
+
+export const resolvers: Resolvers = {
+  Query: {
+    // Return all of the languages supported by the system
+    languages: async (): Promise<Language[]> => {
+      return await supportedLanguages.map((entry) => {
+        return { ...entry, isDefault: entry.id === defaultLanguageId };
+      });
+    },
+  },
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4,6 +4,7 @@ import { typeDefs as baseTypeDefs } from './schemas/base';
 import { typeDefs as affiliationTypeDefs } from './schemas/affiliation';
 import { typeDefs as collaboratorTypeDefs } from './schemas/collaborator';
 import { typeDefs as contributorRoleTypeDefs } from './schemas/contributorRole';
+import { typeDefs as languageTypeDefs } from './schemas/language';
 import { typeDefs as sectionTypeDefs } from './schemas/section';
 import { typeDefs as tagTypeDefs } from './schemas/tag';
 import { typeDefs as versionedSectionTypeDefs } from './schemas/versionedSection';
@@ -16,6 +17,7 @@ export const typeDefs = mergeTypeDefs([
   baseTypeDefs,
   affiliationTypeDefs,
   collaboratorTypeDefs,
+  languageTypeDefs,
   sectionTypeDefs,
   tagTypeDefs,
   versionedSectionTypeDefs,
@@ -25,4 +27,3 @@ export const typeDefs = mergeTypeDefs([
   userTypeDefs,
   versionedTemplateTypeDefs,
 ]);
-

--- a/src/schemas/language.ts
+++ b/src/schemas/language.ts
@@ -1,0 +1,18 @@
+import gql from "graphql-tag";
+
+export const typeDefs = gql`
+  extend type Query {
+    "Get all of the supported Languages"
+    languages: [Language]
+  }
+
+  "A Language supported by the system"
+  type Language {
+    "The unique identifer for the Language using the 2 character (ISO 639-1) language code and optionally the 2 character (ISO 3166-1) country code"
+    id: String!
+    "A displayable name for the language"
+    name: String!
+    "Whether or not the language is the default"
+    isDefault: Boolean!
+  }
+`;

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -61,6 +61,8 @@ export const typeDefs = gql`
     bestPractice: Boolean!
     "The Sections associated with the template"
     sections: [Section]
+    "The template's language"
+    languageId: String!
 
     "Users from different affiliations who have been invited to collaborate on this template"
     collaborators: [TemplateCollaborator!]

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -46,5 +46,7 @@ export const typeDefs = gql`
     acceptedTerms: Boolean
     "The user's ORCID"
     orcid: Orcid
+    "The user's preferred language"
+    languageId: String!
   }
 `;

--- a/src/services/__tests__/tokenService.spec.ts
+++ b/src/services/__tests__/tokenService.spec.ts
@@ -18,6 +18,7 @@ import {
   generateCSRFToken,
 } from '../tokenService'; // assuming the original code is in auth.ts
 import { buildContext, mockToken } from '../../__mocks__/context';
+import { defaultLanguageId } from '../../models/Language';
 
 jest.mock('jsonwebtoken');
 jest.mock('../../datasources/cache');
@@ -51,6 +52,7 @@ beforeEach(() => {
     surName: casual.last_name,
     affiliationId: casual.url,
     role: UserRole.RESEARCHER,
+    languageId: defaultLanguageId,
   };
 });
 

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -9,6 +9,7 @@ import { UserRole } from '../models/User';
 import { AuthenticationError, DEFAULT_INTERNAL_SERVER_MESSAGE, DEFAULT_UNAUTHORIZED_MESSAGE, InternalServerError } from '../utils/graphQLErrors';
 import { Cache } from '../datasources/cache';
 import { MyContext } from '../context';
+import { defaultLanguageId } from '../models/Language';
 
 export interface JWTAccessToken extends JwtPayload {
   id: number,
@@ -16,6 +17,7 @@ export interface JWTAccessToken extends JwtPayload {
   givenName: string,
   surName: string,
   role: string,
+  languageId: string,
   jti: string,
   expiresIn: number,
  }
@@ -66,6 +68,7 @@ const generateAccessToken = (jti: string, user: User): string => {
       surName: user.surName,
       affiliationId: user.affiliationId,
       role: user.role.toString() || UserRole.RESEARCHER,
+      languageId: user.languageId || defaultLanguageId,
       jti,
       expiresIn: generalConfig.jwtTTL,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,17 @@ export type Identifier = {
   type: Scalars['String']['output'];
 };
 
+/** A Language supported by the system */
+export type Language = {
+  __typename?: 'Language';
+  /** The unique identifer for the Language using the 2 character (ISO 639-1) language code and optionally the 2 character (ISO 3166-1) country code */
+  id: Scalars['String']['output'];
+  /** Whether or not the language is the default */
+  isDefault: Scalars['Boolean']['output'];
+  /** A displayable name for the language */
+  name: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   _empty?: Maybe<Scalars['String']['output']>;
@@ -581,6 +592,8 @@ export type Query = {
   contributorRoles?: Maybe<Array<Maybe<ContributorRole>>>;
   /** Get the DMSP by its DMP ID */
   dmspById?: Maybe<SingleDmspResponse>;
+  /** Get all of the supported Languages */
+  languages?: Maybe<Array<Maybe<Language>>>;
   /** Returns the currently logged in user's information */
   me?: Maybe<User>;
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
@@ -952,6 +965,8 @@ export type Template = {
   id?: Maybe<Scalars['Int']['output']>;
   /** Whether or not the Template has had any changes since it was last published */
   isDirty: Scalars['Boolean']['output'];
+  /** The template's language */
+  languageId: Scalars['String']['output'];
   /** The timestamp when the Object was last modifed */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
@@ -1075,6 +1090,8 @@ export type User = {
   givenName?: Maybe<Scalars['String']['output']>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
+  /** The user's preferred language */
+  languageId?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was last modifed */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
@@ -1357,6 +1374,7 @@ export type ResolversTypes = {
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Identifier: ResolverTypeWrapper<Identifier>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  Language: ResolverTypeWrapper<Language>;
   Mutation: ResolverTypeWrapper<{}>;
   Orcid: ResolverTypeWrapper<Scalars['Orcid']['output']>;
   OrganizationIdentifier: ResolverTypeWrapper<OrganizationIdentifier>;
@@ -1421,6 +1439,7 @@ export type ResolversParentTypes = {
   ID: Scalars['ID']['output'];
   Identifier: Identifier;
   Int: Scalars['Int']['output'];
+  Language: Language;
   Mutation: {};
   Orcid: Scalars['Orcid']['output'];
   OrganizationIdentifier: OrganizationIdentifier;
@@ -1581,6 +1600,13 @@ export type IdentifierResolvers<ContextType = MyContext, ParentType extends Reso
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type LanguageResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Language'] = ResolversParentTypes['Language']> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  isDefault?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type MutationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   addAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<MutationAddAffiliationArgs, 'input'>>;
@@ -1651,6 +1677,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   contributorRoleByURL?: Resolver<Maybe<ResolversTypes['ContributorRole']>, ParentType, ContextType, RequireFields<QueryContributorRoleByUrlArgs, 'contributorRoleURL'>>;
   contributorRoles?: Resolver<Maybe<Array<Maybe<ResolversTypes['ContributorRole']>>>, ParentType, ContextType>;
   dmspById?: Resolver<Maybe<ResolversTypes['SingleDmspResponse']>, ParentType, ContextType, RequireFields<QueryDmspByIdArgs, 'dmspId'>>;
+  languages?: Resolver<Maybe<Array<Maybe<ResolversTypes['Language']>>>, ParentType, ContextType>;
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'questionId'>>;
   publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'sectionId'>>;
@@ -1782,6 +1809,7 @@ export type TemplateResolvers<ContextType = MyContext, ParentType extends Resolv
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isDirty?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  languageId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1819,6 +1847,7 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   givenName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  languageId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   orcid?: Resolver<Maybe<ResolversTypes['Orcid']>, ParentType, ContextType>;
@@ -1918,6 +1947,7 @@ export type Resolvers<ContextType = MyContext> = {
   DmspIdentifier?: DmspIdentifierResolvers<ContextType>;
   EmailAddress?: GraphQLScalarType;
   Identifier?: IdentifierResolvers<ContextType>;
+  Language?: LanguageResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Orcid?: GraphQLScalarType;
   OrganizationIdentifier?: OrganizationIdentifierResolvers<ContextType>;


### PR DESCRIPTION
## Description

Part of work for #128 

- Added `Language` model, resolver with `languages` query and supporting GraphQL types
- Added `languageId` to `User` and `Template` (we will want to add to DMPs too down the road)
- Added a `cleanup()` function to the `Template` model that gets called on `create` or `update`
- Updated the `cleanup()` function on the `Template` and `User` models so that it only allows the `languageId` to be one of the supported languages

I opted to leave the languages as a hard-coded list for now in the Model. I don't see a scenario where we would need them to be table based. Adding a new language will likely require dev work to add translation files etc. for the foreseeable future. We can reevaluate later on if we come up with a workflow that we could offer to allow admins to add new languages via the UI.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

- Updated unit tests
- Verified that languages were being returned in the Apollo server explorer interface

**Note that you need to run `bash data-migrations/process.sh` to add the `languageId` column to the `users` and `templates` tables and seed the existing records. You DO NOT need to nuke the existing DB!**

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules