### PR TITLE
Made some updates to user resolver while using the user queries and mutations for the user profile page

### DIFF
--- a/src/models/UserEmail.ts
+++ b/src/models/UserEmail.ts
@@ -1,5 +1,6 @@
 import { MyContext } from "../context";
 import { sendEmailConfirmationNotification } from "../services/emailService";
+import { validateEmail } from '../utils/helpers';
 import { TemplateCollaborator } from "./Collaborator";
 import { MySqlModel } from "./MySqlModel";
 
@@ -25,13 +26,13 @@ export class UserEmail extends MySqlModel {
   // Validation to be used prior to saving the record
   async isValid(): Promise<boolean> {
     await super.isValid();
-
     if (this.userId === null) {
       this.errors.push('User can\'t be blank');
     }
-    if (!this.email) {
-      this.errors.push('Email can\'t be blank');
+    if (!validateEmail(this.email)) {
+      this.errors.push('Enter valid email');
     }
+
     return this.errors.length <= 0;
   }
 
@@ -94,7 +95,7 @@ export class UserEmail extends MySqlModel {
         this.errors.push('Email has already been confirmed by another account');
       }
 
-      if (this.errors.length <= 0){
+      if (this.errors.length <= 0) {
         // Save the record and then fetch it
         const newId = await UserEmail.insert(context, this.tableName, this, ref);
         const created = await UserEmail.findById(ref, context, newId);

--- a/src/models/__tests__/UserEmail.spec.ts
+++ b/src/models/__tests__/UserEmail.spec.ts
@@ -88,7 +88,7 @@ describe('validate a new UserEmail', () => {
     mockUserEmail.email = null;
     expect(await mockUserEmail.isValid()).toBe(false);
     expect(mockUserEmail.errors.length).toBe(1);
-    expect(mockUserEmail.errors[0].includes('Email can\'t be blank')).toBe(true);
+    expect(mockUserEmail.errors[0].includes('Enter valid email')).toBe(true);
   });
 
   it('should return false when the userId is missing', async () => {
@@ -208,8 +208,8 @@ describe('confirmEmail', () => {
     mockUserEmail = new UserEmail({ id: casual.integer(1, 99), email: mockUser.email, userId: mockUser.id });
 
     mockOtherEmails = [
-      new UserEmail({ id: 1, email: mockUser.email, userId: casual.integer(99991, 999999)}),
-      new UserEmail({ id: 2, email: mockUser.email, userId: casual.integer(99991, 999999)}),
+      new UserEmail({ id: 1, email: mockUser.email, userId: casual.integer(99991, 999999) }),
+      new UserEmail({ id: 2, email: mockUser.email, userId: casual.integer(99991, 999999) }),
     ];
 
     mockTemplateCollaborators = [


### PR DESCRIPTION

## Description

While working on the User Profile page, noticed a few bugs while using the user queries and mutations. This ticket includes those updates.

- Update user resolver
-- Updated the "me" query to `findById` rather than `findByEmail`, since data was disappearing on the user profile page when a user updated their email preference.
-- Switched to returning `created` in `addUserEmail` function, instead of `userEmail`, so that errors would be returned to the client
-- Updated `removeUserEmail` to return the data with any possible errors
-- Updated `setPrimaryUserEmail` to only update `oldPrimary` if there were no errors when making the `set primary` update. Also, if there are errors, we should return the original data, not the updated data, with the errors. What was happening was that the user was setting an email to be primary, and the backend response returned data showing that that email's isPrimary was true, even when the change wasn't made. So the page would falsely reflect that update.
- Updated UserEmail  model
-- Updated isValid to use the shared "validatedEmail" function

Fixes # (#141 )

## Type of change
Please delete options that are not relevant
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
I ran unit tests, and manually tested via Apollo Sandbox/Explorer. I also tested with the User Profile page which is still in development.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules