### PR TITLE
Allow for affiliation creation when one is not selected from the typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added support for creating "other" affiliations
 - Added update and updatePassword to User
 - Added resolvers for User
 - Added userService to handle random password generation, anonymization and merging

--- a/src/models/Affiliation.ts
+++ b/src/models/Affiliation.ts
@@ -59,7 +59,7 @@ export class Affiliation extends MySqlModel {
     super(options.id, options.created, options.createdById, options.modified, options.modifiedById);
 
     this.uri = options.uri;
-    this.active = options.active || false;
+    this.active = options.active || true;
     this.provenance = options.provenance || AffiliationProvenance.DMPTOOL;
     this.name = options.name;
     this.displayName = options.displayName;
@@ -93,12 +93,13 @@ export class Affiliation extends MySqlModel {
   // Convert the name, homepage, acronyms and aliases into a search string
   buildSearchName(): string {
     const parts = [this.name, this.homepage, this.acronyms, this.aliases];
-    return parts.flat().join(' | ').substring(0, 249);
+    return parts.flat().filter((item) => item).join(' | ').substring(0, 249);
   }
 
   // Perform tasks necessary to prepare the data to be saved
   prepForSave(): void {
     this.searchName = this.buildSearchName();
+    this.displayName = this.homepage ? `${this.name} (${this.homepage})` : this.name;
   }
 
   // Save the current record
@@ -119,6 +120,7 @@ export class Affiliation extends MySqlModel {
       const newId = await Affiliation.insert(context, this.tableName, this, 'Affiliation.create');
       return await Affiliation.findById('Affiliation.create', context, newId);
     }
+
     // Otherwise return as-is with all the errors
     return this;
   }
@@ -160,18 +162,18 @@ export class Affiliation extends MySqlModel {
   // Some of the properties are stored as JSON strings in the DB so we need to parse them
   // after fetching them
   static processResult(affiliation: Affiliation): Affiliation {
-    if (affiliation.aliases && typeof affiliation.aliases === 'string') {
+    if (affiliation?.aliases && typeof affiliation.aliases === 'string') {
       affiliation.aliases = JSON.parse(affiliation.aliases);
     }
-    if (affiliation.acronyms && typeof affiliation.acronyms === 'string') {
+    if (affiliation?.acronyms && typeof affiliation.acronyms === 'string') {
       affiliation.acronyms = JSON.parse(affiliation.acronyms);
     }
-    if (affiliation.feedbackEmails && typeof affiliation.feedbackEmails === 'string') {
+    if (affiliation?.feedbackEmails && typeof affiliation.feedbackEmails === 'string') {
       affiliation.feedbackEmails = JSON.parse(affiliation.feedbackEmails);
     }
 
     // Only include types that are in the enum
-    if (affiliation.types && typeof affiliation.types === 'string') {
+    if (affiliation?.types && typeof affiliation.types === 'string') {
       const types = JSON.parse(affiliation.types);
       affiliation.types = [];
 
@@ -185,17 +187,24 @@ export class Affiliation extends MySqlModel {
   }
 
 
-  // Return the specified AffiliationEmailDomain
+  // Return the specified Affiliation  based on the DB id
   static async findById(reference: string, context: MyContext, id: string | number): Promise<Affiliation> {
     const sql = 'SELECT * FROM affiliations WHERE id = ?';
     const results = await Affiliation.query(context, sql, [id.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? this.processResult(results[0]) : null;
   }
 
-  // Return the specified AffiliationEmailDomain
+  // Return the specified Affiliation based on the URI
   static async findByURI(reference: string, context: MyContext, uri: string): Promise<Affiliation> {
     const sql = 'SELECT * FROM affiliations WHERE uri = ?';
     const results = await Affiliation.query(context, sql, [uri], reference);
+    return Array.isArray(results) && results.length > 0 ? this.processResult(results[0]) : null;
+  }
+
+  // Return the specified Affiliation based on it's name
+  static async findByName(reference: string, context: MyContext, name: string): Promise<Affiliation> {
+    const sql = 'SELECT * FROM affiliations WHERE TRIM(LOWER(name)) = ?';
+    const results = await Affiliation.query(context, sql, [name.toLowerCase().trim()], reference);
     return Array.isArray(results) && results.length > 0 ? this.processResult(results[0]) : null;
   }
 }

--- a/src/models/Affiliation.ts
+++ b/src/models/Affiliation.ts
@@ -48,7 +48,7 @@ export class Affiliation extends MySqlModel {
   public ssoEntityId: string;
   public feedbackEnabled: boolean;
   public feedbackMessage: string;
-  public feedbackEmails: string;
+  public feedbackEmails: string[];
 
   public uneditableProperties: string[];
 
@@ -98,6 +98,12 @@ export class Affiliation extends MySqlModel {
 
   // Perform tasks necessary to prepare the data to be saved
   prepForSave(): void {
+    this.managed = this.managed || false;
+    this.feedbackEnabled = this.feedbackEnabled || false;
+    this.acronyms = this.acronyms || [];
+    this.aliases = this.aliases || [];
+    this.types = this.types || [];
+    this.feedbackEmails = this.feedbackEmails || [];
     this.searchName = this.buildSearchName();
     this.displayName = this.homepage ? `${this.name} (${this.homepage})` : this.name;
   }
@@ -117,7 +123,13 @@ export class Affiliation extends MySqlModel {
     } else {
       // Save the record and then fetch it
       this.prepForSave();
-      const newId = await Affiliation.insert(context, this.tableName, this, 'Affiliation.create');
+      const newId = await Affiliation.insert(
+        context,
+        this.tableName,
+        this,
+        'Affiliation.create',
+        ['uneditableProperties']
+      );
       return await Affiliation.findById('Affiliation.create', context, newId);
     }
 
@@ -136,7 +148,7 @@ export class Affiliation extends MySqlModel {
           this.tableName,
           this,
           'Affiliation.update',
-          this.uneditableProperties
+          ['uneditableProperties', this.uneditableProperties].flat()
         );
         return result as Affiliation;
       }

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -64,13 +64,17 @@ export class MySqlModel {
     if (val === null || val === undefined) {
       return null;
     }
-
     switch (type) {
       case 'number':
         return Number(val);
       case 'json':
         return JSON.stringify(val);
+      case 'object':
+        return JSON.stringify(val);
       case Object:
+        return JSON.stringify(val);
+      case 'array':
+        return JSON.stringify(val);
       case Array:
         return JSON.stringify(val);
       case 'boolean':
@@ -89,6 +93,7 @@ export class MySqlModel {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static propertyInfo(obj: Record<string, any>, skipKeys: string[] = []): { name: string, value: string }[] {
     const excludedKeys = ['id', 'errors', 'tableName'];
+
     return Object.keys(obj)
       .filter((key) => ![...excludedKeys, ...skipKeys]
         .includes(key)).map((key) => ({
@@ -179,7 +184,6 @@ export class MySqlModel {
     const sql = `INSERT INTO ${table} \
                   (${props.map((entry) => entry.name).join(', ')}) \
                  VALUES (${Array(props.length).fill('?').join(', ')})`
-
     const vals = props.map((entry) => this.prepareValue(entry.value, typeof (entry.value)));
 
     // Send the calcuated INSERT statement to the query function

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -69,12 +69,7 @@ export class MySqlModel {
         return Number(val);
       case 'json':
         return JSON.stringify(val);
-      case 'object':
-        return JSON.stringify(val);
       case Object:
-        return JSON.stringify(val);
-      case 'array':
-        return JSON.stringify(val);
       case Array:
         return JSON.stringify(val);
       case 'boolean':
@@ -83,6 +78,10 @@ export class MySqlModel {
         if (isDate(val)) {
           const date = new Date(val).toISOString();
           return formatISO9075(date);
+
+        } else if (Array.isArray(val)) {
+          return JSON.stringify(val);
+
         } else {
           return String(val);
         }
@@ -227,7 +226,7 @@ export class MySqlModel {
     // Make sure the record id is the last value
     vals.push(obj.id.toString());
 
-    // Send the calcuated INSERT statement to the query function
+    // Send the calcuated UPDATE statement to the query function
     const result = await this.query(apolloContext, sql, vals, reference);
     return Array.isArray(result) ? result[0] : null;
   }

--- a/src/schemas/affiliation.ts
+++ b/src/schemas/affiliation.ts
@@ -104,7 +104,7 @@ export const typeDefs = gql`
     "The message to display to users when they request feedback"
     feedbackMessage: String
     "The email address(es) to notify when feedback has been requested (stored as JSON array)"
-    feedbackEmails: String
+    feedbackEmails: [String!]
     "The properties of this object that are NOT editable. Determined by the record's provenance"
     uneditableProperties: [String!]!
   }

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -141,8 +141,10 @@ export const typeDefs = gql`
     givenName: String!
     "The user's last/family name"
     surName: String!
-    "The user's organizational affiliation id"
-    affiliationId: String!
+    "The id of the affiliation if the user selected one from the typeahead list"
+    affiliationId: String
+    "The name of the affiliation if the user did not select one from the typeahead list"
+    otherAffiliationName: String
     "The user's preferred language"
     languageId: String
   }

--- a/src/services/__tests__/affiliationService.spec.ts
+++ b/src/services/__tests__/affiliationService.spec.ts
@@ -1,0 +1,84 @@
+import casual from "casual";
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { logger } from "../../__mocks__/logger";
+import { Affiliation, AffiliationProvenance, AffiliationType, DEFAULT_DMPTOOL_AFFILIATION_URL } from "../../models/Affiliation";
+import { processOtherAffiliationName } from "../affiliationService";
+import { getCurrentDate } from "../../utils/helpers";
+
+// Pulling context in here so that the MySQLDataSource gets mocked
+jest.mock('../../context.ts');
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+let context;
+let affiliationStore;
+
+let mockFindById;
+let mockFindByName;
+let mockInsert;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  context = buildContext(logger, mockToken());
+
+  affiliationStore = [];
+
+  // Fetch an item from the affiliationStore
+  mockFindById = jest.fn().mockImplementation((_, __, id) => {
+    return affiliationStore.find((entry) => { return entry.id === id });
+  });
+  (Affiliation.findById as jest.Mock) = mockFindById;
+
+  mockFindByName = jest.fn().mockImplementation((_, __, name) => {
+    return affiliationStore.find((entry) => {
+      return entry.name.toLowerCase().trim() === name.toLowerCase().trim();
+    });
+  });
+  (Affiliation.findByName as jest.Mock) = mockFindByName;
+
+  // Add an item to the affiliationStore
+  mockInsert = jest.fn().mockImplementation((context, table, obj) => {
+    const tstamp = getCurrentDate();
+    const userId = context.token.id;
+    obj.id = casual.integer(1, 9999);
+    obj.created = tstamp;
+    obj.createdById = userId;
+    obj.modifed = tstamp;
+    obj.modifiedById = userId;
+
+    affiliationStore.push(obj);
+    return obj.id;
+  });
+  (Affiliation.insert as jest.Mock) = mockInsert;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('processOtherAffiliationName', () => {
+  it('returns the id of the existing affiliation if the name already exists', async () => {
+    // Mock the finder method
+    const id = casual.integer(1, 9999);
+    const name = casual.company_name;
+    affiliationStore.push(new Affiliation({ id, name }));
+
+    const result = await processOtherAffiliationName(context, ` ${name.toLowerCase()}  `);
+    expect(result).toEqual(affiliationStore[0]);
+  });
+
+  it('returns the id of the new affiliation', async () => {
+    // Mock the finder method
+    const name = 'Other Affiliation Test';
+    affiliationStore.push(new Affiliation({ id: casual.integer(1, 9999), name: casual.company_name }));
+
+    const result = await processOtherAffiliationName(context, name);
+    expect(result.id).toEqual(affiliationStore[1].id);
+    expect(result.name).toEqual(affiliationStore[1].name);
+    expect(result.provenance).toEqual(AffiliationProvenance.DMPTOOL);
+    expect(result.uri.includes(DEFAULT_DMPTOOL_AFFILIATION_URL)).toBe(true);
+    expect(result.types).toEqual([AffiliationType.OTHER]);
+    expect(result.active).toBe(true);
+    expect(result.uneditableProperties).toEqual(['uri', 'provenance', 'searchName']);
+  });
+});

--- a/src/services/__tests__/userService.spec.ts
+++ b/src/services/__tests__/userService.spec.ts
@@ -176,9 +176,6 @@ describe('generateRandomPassword', () => {
     expect(result.match(/[A-Z]/).length > 0).toBe(true);
     expect(result.match(/[a-z]/).length > 0).toBe(true);
     expect(result.match(/[0-9]/).length > 0).toBe(true);
-
-console.log(result)
-
     expect(result.match(/[`!@#$%^&*_+\-=?~\s]/g).length).toBe(3);
     expect(result.length >= 8).toBe(true);
   })

--- a/src/services/__tests__/userService.spec.ts
+++ b/src/services/__tests__/userService.spec.ts
@@ -176,6 +176,9 @@ describe('generateRandomPassword', () => {
     expect(result.match(/[A-Z]/).length > 0).toBe(true);
     expect(result.match(/[a-z]/).length > 0).toBe(true);
     expect(result.match(/[0-9]/).length > 0).toBe(true);
+
+console.log(result)
+
     expect(result.match(/[`!@#$%^&*_+\-=?~\s]/g).length).toBe(3);
     expect(result.length >= 8).toBe(true);
   })

--- a/src/services/affiliationService.ts
+++ b/src/services/affiliationService.ts
@@ -1,0 +1,18 @@
+import { MyContext } from "../context";
+import { Affiliation } from "../models/Affiliation";
+
+export const processOtherAffiliationName = async (
+  context: MyContext,
+  name: string
+): Promise<Affiliation> => {
+  // First look to see if the affiliation name already exists
+  const existing = await Affiliation.findByName('processOtherAffiliation', context, name);
+
+  if (existing) {
+    return existing;
+  } else {
+    // Create the affiliation
+    const newAffiliation = new Affiliation({ name });
+    return await newAffiliation.create(context);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export type Affiliation = {
   /** The display name to help disambiguate similar names (typically with domain or country appended) */
   displayName: Scalars['String']['output'];
   /** The email address(es) to notify when feedback has been requested (stored as JSON array) */
-  feedbackEmails?: Maybe<Scalars['String']['output']>;
+  feedbackEmails?: Maybe<Array<Scalars['String']['output']>>;
   /** Whether or not the affiliation wants to use the feedback workflow */
   feedbackEnabled: Scalars['Boolean']['output'];
   /** The message to display to users when they request feedback */
@@ -1646,7 +1646,7 @@ export type AffiliationResolvers<ContextType = MyContext, ParentType extends Res
   contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   contactName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  feedbackEmails?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  feedbackEmails?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   feedbackEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   feedbackMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   funder?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1424,12 +1424,14 @@ export type UpdateUserNotificationsInput = {
 };
 
 export type UpdateUserProfileInput = {
-  /** The user's organizational affiliation id */
-  affiliationId: Scalars['String']['input'];
+  /** The id of the affiliation if the user selected one from the typeahead list */
+  affiliationId?: InputMaybe<Scalars['String']['input']>;
   /** The user's first/given name */
   givenName: Scalars['String']['input'];
   /** The user's preferred language */
   languageId?: InputMaybe<Scalars['String']['input']>;
+  /** The name of the affiliation if the user did not select one from the typeahead list */
+  otherAffiliationName?: InputMaybe<Scalars['String']['input']>;
   /** The user's last/family name */
   surName: Scalars['String']['input'];
 };


### PR DESCRIPTION
## Description

Fixes #138 

- Added `otherAffiliationName: String` to the `updateUserProfile` resolver
- Also allowing `otherAffiliationName: String` to be passed to the `apollo-signup` endpoint
- Created `affiliationService` that has a method that will find the name specified. If it exists, it will use that `Affiliation` otherwise it will create a new one and place the new `affiliationId` on the `User`
- Added `findByName` to the Affiliation model and fixed some minor issues with the serialization of Arrays 
- Noticed that the `MySQLModel.prepareValue` function was getting `object` instead of `Object` for the type, so added handlers for `object` and `array`

## Type of change
Please delete options that are not relevant

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added unit tests for the new affiliationService and updated existing tests.

Tested the `updateUserProfile` mutation manually via the Apollo explorer http://localhost:4000/graphql

@jupiter007 the frontend will need to pass the other affiliation text as `otherAffiliationName` when updating from the Profile page as well as the signup form. I'm not sure if that is something you set in the typeahead component or the individual pages.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules