### PR TITLE
Bug/affiliations table definition

### DIFF
--- a/data-migrations/2024-10-03-0733-create-affiliations.sql
+++ b/data-migrations/2024-10-03-0733-create-affiliations.sql
@@ -10,7 +10,7 @@ CREATE TABLE `affiliations` (
   `homepage` VARCHAR(255),
   `acronyms` JSON DEFAULT NULL,
   `aliases` JSON DEFAULT NULL,
-  `types` JSON DEFAULT '["Education"]',
+  `types` JSON DEFAULT NULL,
   `logoURI` VARCHAR(255),
   `logoName` VARCHAR(255),
   `contactName` VARCHAR(255),


### PR DESCRIPTION
## Description

Found a small bug while trying to run the latest data-migrations in the AWS environment. MySQL does not allow default values for JSON, TEXT, BLOB, etc. data types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Successfully ran the data-migrations in the AWS dev environment
