### PR TITLE
Fixed issue with Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - removed old oauth-server package which had security vulnerabilities
 - moved authMiddleware function from the router.ts into its own class in src/middelware
 - updated Affiliation Schema, Resolver, Models to use new affiliations tables in the database
+- updated all of the cache key structures to wrap them in `{}` due to the way Redis handles keys in cluster mode
 
 ### Fixed
 - Converted DateTimeISO to String in schemas so that dates could be inserted into mariaDB database, and updated MySqlModel and associated unit test

--- a/src/config/cacheConfig.ts
+++ b/src/config/cacheConfig.ts
@@ -10,6 +10,8 @@ const host = process.env.CACHE_HOST;
 const port = Number.parseInt(process.env.CACHE_PORT);
 const connectTimeout = Number.parseInt(process.env.CACHE_CONNECT_TIMEOUT) || 30000; // 30 seconds
 
+export const autoFailoverEnabled = process.env.CACHE_AUTOFAILOVER_ENABLED || 'false';
+
 export const cacheConfig = { host, port, connectTimeout };
 
 export const cacheTLS = `rediss://${host}:${port}`;

--- a/src/controllers/__tests__/integrationTokens.spec.ts
+++ b/src/controllers/__tests__/integrationTokens.spec.ts
@@ -139,7 +139,7 @@ describe('CSRF', () => {
     const hashedToken = createHash('sha256')
       .update(`${resp.headers['x-csrf-token']}${generalConfig.hashTokenSecret}`)
       .digest('hex');
-    expect(mockRedis[`csrf:${resp.headers['x-csrf-token']}`]).toEqual(hashedToken);
+    expect(mockRedis[`{csrf}:${resp.headers['x-csrf-token']}`]).toEqual(hashedToken);
   });
 
   it('POST /test-protected should fail if the CSRF token is missing', async () => {
@@ -196,7 +196,7 @@ describe('Sign up', () => {
     expect(resp.body).toEqual({ success: true, message: 'ok' });
 
     // Make sure the cache contains the refresh tokens
-    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes(`dmspr:`) });
+    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes(`{dmspr}:`) });
     expect(cachedToken).toBeTruthy();
   });
 
@@ -268,7 +268,7 @@ describe('Sign in', () => {
     expect(resp.body).toEqual({ success: true, message: 'ok' });
 
     // Make sure the cache contains the refresh tokens
-    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes(`dmspr:`) });
+    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes(`{dmspr}:`) });
     expect(cachedToken).toBeTruthy();
 
     //Now make sure the user can make a call to a protected resource
@@ -347,9 +347,9 @@ describe('Sign out', () => {
     expect(signoutResp.body).toEqual({});
 
     // Make sure the cache contains the refresh tokens
-    const cachedRefresh = Object.keys(mockRedis).find((key) => { return key.includes(`dmspr:`) });
+    const cachedRefresh = Object.keys(mockRedis).find((key) => { return key.includes(`{dmspr}:`) });
     expect(cachedRefresh).toBeFalsy();
-    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes('dmspbl:') });
+    const cachedToken = Object.keys(mockRedis).find((key) => { return key.includes('{dmspbl}:') });
     expect(cachedToken).toBeTruthy();
 
     const protectedResp = await request(app)
@@ -423,7 +423,7 @@ describe('Sign out', () => {
 
     // Get the JTI from the token so we can add it to the blacklist
     const jwt = verifyAccessToken(accessToken);
-    mockRedis[`dmspbl:${jwt.jti}`] = 'testing revocation';
+    mockRedis[`{dmspbl}:${jwt.jti}`] = 'testing revocation';
 
     // Try a signout
     const signoutResp = await request(app)
@@ -491,7 +491,7 @@ describe('token refresh', () => {
     const hashedToken = createHash('sha256')
       .update(`${refreshToken}${generalConfig.hashTokenSecret}`)
       .digest('hex');
-    expect(mockRedis[`dmspr:${jwt.jti}`]).toEqual(hashedToken);
+    expect(mockRedis[`{dmspr}:${jwt.jti}`]).toEqual(hashedToken);
 
     (UserModel.User.findById as jest.Mock).mockImplementation(() => { throw new Error('testing') });
 
@@ -577,7 +577,7 @@ describe('token refresh', () => {
     const hashedToken = createHash('sha256')
       .update(`${refreshToken}${generalConfig.hashTokenSecret}`)
       .digest('hex');
-    expect(mockRedis[`dmspr:${jwt.jti}`]).toEqual(hashedToken);
+    expect(mockRedis[`{dmspr}:${jwt.jti}`]).toEqual(hashedToken);
 
     (UserModel.User.findById as jest.Mock).mockResolvedValueOnce(registeredUser);
 
@@ -718,7 +718,7 @@ describe('protected endpoint access', () => {
 
     // Get the JTI from the token so we can add it to the blacklist
     const jwt = verifyAccessToken(accessToken);
-    mockRedis[`dmspbl:${jwt.jti}`] = 'testing revocation';
+    mockRedis[`{dmspbl}:${jwt.jti}`] = 'testing revocation';
 
     const protectedResp = await request(app)
       .post('/test-protected')

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -2,7 +2,7 @@ import Keyv from "keyv";
 import KeyvRedis from "@keyv/redis";
 import Redis from "ioredis";
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
-import { autoFailoverEnabled, cacheConfig, cacheTLS } from "../config/cacheConfig";
+import { autoFailoverEnabled, cacheConfig } from "../config/cacheConfig";
 import { logger, formatLogMessage } from '../logger';
 
 export class Cache {

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -5,6 +5,9 @@ import { KeyvAdapter } from "@apollo/utils.keyvadapter";
 import { autoFailoverEnabled, cacheConfig } from "../config/cacheConfig";
 import { logger, formatLogMessage } from '../logger';
 
+// Note that Redis cache clusters require you to wrap keys in `{}` to ensure that they are stored
+// near one another and are able to be set and fetched.
+//    For example: `{csrf}:12345` instead of `csrf:12345`
 export class Cache {
   private static instance: Cache;
   public adapter: KeyvAdapter;

--- a/src/services/__tests__/tokenService.spec.ts
+++ b/src/services/__tests__/tokenService.spec.ts
@@ -246,7 +246,7 @@ describe('isRevokedCallback', () => {
 
     await isRevokedCallback(null, token as Jwt);
     const expoectedErr = 'isRevokedCallback - unable to fetch token from cache';
-    expect(mockCache.adapter.get).toHaveBeenLastCalledWith(`dmspbl:${mockJti}`);
+    expect(mockCache.adapter.get).toHaveBeenLastCalledWith(`{dmspbl}:${mockJti}`);
     expect(logger.error).toHaveBeenLastCalledWith(mockErr, expoectedErr);
   });
 
@@ -257,7 +257,7 @@ describe('isRevokedCallback', () => {
     (mockCache.adapter.get as jest.Mock).mockReturnValueOnce(mockJti);
 
     expect(await isRevokedCallback(null, token as Jwt)).toBe(true);
-    expect(mockCache.adapter.get).toHaveBeenLastCalledWith(`dmspbl:${mockJti}`);
+    expect(mockCache.adapter.get).toHaveBeenLastCalledWith(`{dmspbl}:${mockJti}`);
   });
 });
 
@@ -348,7 +348,7 @@ describe('revokeRefreshToken', () => {
     const result = await revokeRefreshToken(mockCache, mockUserJti);
 
     expect(result).toBe(true);
-    expect(mockCache.adapter.delete).toHaveBeenCalledWith(`dmspr:${mockUserJti}`);
+    expect(mockCache.adapter.delete).toHaveBeenCalledWith(`{dmspr}:${mockUserJti}`);
   });
 
   it('should throw and error and log error on failure', async () => {


### PR DESCRIPTION
## Description

Fixed the issue we were having with the AWS Elasticache. It turns out that dealing with a ValKey/Redis cache in cluster mode requires keys to be defined a little differently.

The bug/issue arose when I switched over from running the serves Redis instance to a ValKey cache cluster

- In a Redis cluster, keys are distributed across multiple node groups (shards) based on a hash slot.
- ioredis (the package we use) automatically handles the distribution of keys across shards, but we need to be mindful of how keys are hashed to ensure even distribution and avoid cross-slot operations.
- Redis clusters do not support commands that operate on keys located in different hash slots.
- To group related keys (e.g., for CSRF tokens), we need to use hash tags (`{}`) to force certain keys to the same hash slot. For example `{csrf}:7836824iugu2h4g425t23t` instead of `csrf:7836824iugu2h4g425t23t`

## Type of change
Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

I deployed to AWS and was able to login again. I also verified that all of the unit and integration tests are still passing

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules