### PR TITLE
Made updates to accommodate needs of Edit Template page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added "lastPublishedDate" field to templates table, and changed "currentVersion" field to "lastPublishedVersion"
 - Added support for creating "other" affiliations
 - Added update and updatePassword to User
 - Added resolvers for User

--- a/data-migrations/2024-10-23-1133-add-language-to-users-templates.sql
+++ b/data-migrations/2024-10-23-1133-add-language-to-users-templates.sql
@@ -5,6 +5,9 @@ ALTER TABLE `users`
 ALTER TABLE `templates`
   ADD`languageId` CHAR(5) NOT NULL DEFAULT 'en-US';
 
+ALTER TABLE `versionedTemplates`
+  ADD`languageId` CHAR(5) NOT NULL DEFAULT 'en-US';
+
 # Update all of the Brazilian templates to use pt-BR
 UPDATE `templates` SET `languageId` = 'pt-BR' WHERE `ownerId` IN (
   'https://ror.org/01xdw4k60',
@@ -16,6 +19,15 @@ UPDATE `templates` SET `languageId` = 'pt-BR' WHERE `ownerId` IN (
 
 # Update the admin users for the Brazilian institutions to use pt-BR
 UPDATE `users` SET `languageId` = 'pt-BR' WHERE `affiliationId` IN (
+  'https://ror.org/01xdw4k60',
+  'https://ror.org/04wffgt70',
+  'https://ror.org/036rp1748',
+  'https://ror.org/028kg9j04',
+  'https://ror.org/03srtnf24'
+);
+
+# Update the admin users for the Brazilian institutions to use pt-BR
+UPDATE `versionedTemplates` SET `languageId` = 'pt-BR' WHERE `ownerId` IN (
   'https://ror.org/01xdw4k60',
   'https://ror.org/04wffgt70',
   'https://ror.org/036rp1748',

--- a/data-migrations/2024-12-13-0644-add-and-change-publish-columns-in-templates.sql
+++ b/data-migrations/2024-12-13-0644-add-and-change-publish-columns-in-templates.sql
@@ -1,0 +1,11 @@
+# Update templates table column 'currentVersion' to 'latestPublishVersion'
+ALTER TABLE `templates`
+CHANGE COLUMN `currentVersion` `latestPublishVersion` VARCHAR(16);
+
+# Add column 'latestPublishDate' to templates
+ALTER TABLE `templates`
+ADD COLUMN `latestPublishDate` TIMESTAMP NULL DEFAULT NULL AFTER `latestPublishVersion`;
+
+# Update 'latestPublishDate' with the 'modified' value
+UPDATE `templates`
+SET `latestPublishDate` = `modified`

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -15,7 +15,8 @@ export class Template extends MySqlModel {
   public description?: string;
   public ownerId?: string;
   public visibility: TemplateVisibility;
-  public currentVersion?: string;
+  public latestPublishVersion?: string;
+  public latestPublishDate?: string;
   public isDirty: boolean;
   public bestPractice: boolean;
   public languageId: string;
@@ -30,7 +31,8 @@ export class Template extends MySqlModel {
     this.description = options.description;
     this.sourceTemplateId = options.sourceTemplateId
     this.visibility = options.visibility || TemplateVisibility.PRIVATE;
-    this.currentVersion = options.currentVersion || '';
+    this.latestPublishVersion = options.latestPublishVersion || '';
+    this.latestPublishDate = options.latestPublishDate || null;
     this.isDirty = options.isDirty || true;
     this.bestPractice = options.bestPractice || false;
     this.languageId = options.languageId || defaultLanguageId;
@@ -38,7 +40,7 @@ export class Template extends MySqlModel {
 
   // Ensure data integrity
   cleanup() {
-    if (!supportedLanguages.map((l) => l.id).includes(this.languageId)){
+    if (!supportedLanguages.map((l) => l.id).includes(this.languageId)) {
       this.languageId = defaultLanguageId;
     }
   }
@@ -88,7 +90,7 @@ export class Template extends MySqlModel {
     if (await this.isValid()) {
       if (id) {
         // if the template is versioned then set the isDirty flag
-        if (this.currentVersion && noTouch !== true) {
+        if (this.latestPublishVersion && noTouch !== true) {
           this.isDirty = true;
         }
 

--- a/src/models/__tests__/Template.spec.ts
+++ b/src/models/__tests__/Template.spec.ts
@@ -40,7 +40,7 @@ describe('Template', () => {
     expect(template.visibility).toEqual(TemplateVisibility.PRIVATE);
     expect(template.created).toBeTruthy();
     expect(template.modified).toBeTruthy();
-    expect(template.currentVersion).toBeFalsy();
+    expect(template.latestPublishVersion).toBeFalsy();
     expect(template.isDirty).toBeTruthy();
     expect(template.errors).toEqual([]);
     expect(template.languageId).toEqual(defaultLanguageId);

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -56,6 +56,7 @@ export const resolvers: Resolvers = {
           template.name = name;
         }
         if (!template) {
+
           // Create a new blank template
           template = new Template({ name, ownerId: context.token.affiliationId });
         }
@@ -98,9 +99,13 @@ export const resolvers: Resolvers = {
         //       get deleted and orphan those records but instead just unpublishes and sets a flag
 
         const template = await Template.findById('archiveTemplate resolver', context, templateId);
-        if (template) {
+        // Need to create an instance of template in order to access the "delete" method below
+        const templateInstance = new Template({
+          ...template
+        });
+        if (templateInstance) {
           if (hasPermissionOnTemplate(context, template)) {
-            return await template.delete(context);
+            return await templateInstance.delete(context);
           }
           throw ForbiddenError();
         }
@@ -111,7 +116,7 @@ export const resolvers: Resolvers = {
 
     // Publish the template or save as a draft
     //     - called from the Template overview page
-    createTemplateVersion: async (_, { templateId, comment, versionType }, context: MyContext): Promise<Template> => {
+    createTemplateVersion: async (_, { templateId, comment, versionType, visibility }, context: MyContext): Promise<Template> => {
       if (isAdmin(context.token)) {
         const reference = 'createVersion resolver';
         const template = await Template.findById(reference, context, templateId);
@@ -131,6 +136,7 @@ export const resolvers: Resolvers = {
               versions,
               context.token.id,
               comment,
+              visibility as TemplateVisibility,
               TemplateVersionType[versionType]
             );
 

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -17,7 +17,7 @@ export const typeDefs = gql`
     archiveTemplate(templateId: Int!): Boolean
 
     "Publish the template or save as a draft"
-    createTemplateVersion(templateId: Int!, comment: String, versionType: TemplateVersionType): Template
+    createTemplateVersion(templateId: Int!, comment: String, versionType: TemplateVersionType, visibility: TemplateVisibility!): Template
   }
 
   "Template visibility"
@@ -53,8 +53,10 @@ export const typeDefs = gql`
     owner: Affiliation
     "The template's availability setting: Public is available to everyone, Private only your affiliation"
     visibility: TemplateVisibility!
-    "The current published version"
-    currentVersion: String
+    "The last published version"
+    latestPublishVersion: String
+    "The last published date"
+    latestPublishDate: String
     "Whether or not the Template has had any changes since it was last published"
     isDirty: Boolean!
     "Whether or not this Template is designated as a 'Best Practice' template"

--- a/src/services/__tests__/integrationVersioning.spec.ts
+++ b/src/services/__tests__/integrationVersioning.spec.ts
@@ -126,7 +126,7 @@ describe('Integration test: Template Versioning', () => {
       obj.modifed = tstamp;
       obj.modifiedById = userId;
 
-      switch(table) {
+      switch (table) {
         case 'templates': {
           templateStore.push(obj);
           break;
@@ -174,7 +174,7 @@ describe('Integration test: Template Versioning', () => {
         obj.modifiedById = userId;
       }
 
-      switch(table) {
+      switch (table) {
         case 'templates': {
           updateStore(templateStore, 'templateStore', obj);
           break;
@@ -222,7 +222,7 @@ describe('Integration test: Template Versioning', () => {
         description: casual.sentences(5),
         ownerId: casual.url,
         visibility: getRandomEnumValue(TemplateVisibility),
-        currentVersion: '',
+        latestPublishVersion: '',
         isDirty: true,
         bestPractice: false,
         createdById: casual.integer(1, 999),

--- a/src/services/__tests__/templateService.spec.ts
+++ b/src/services/__tests__/templateService.spec.ts
@@ -130,7 +130,7 @@ describe('cloneTemplate', () => {
     expect(copy.name).toEqual(`Copy of ${tmplt.name}`);
     expect(copy.ownerId).toEqual(newOwnerId);
     expect(copy.visibility).toEqual(TemplateVisibility.PRIVATE);
-    expect(copy.currentVersion).toBeFalsy();
+    expect(copy.latestPublishVersion).toBeFalsy();
     expect(copy.errors).toEqual([]);
     expect(copy.description).toEqual(description);
     expect(copy.created).toBeTruthy();
@@ -159,7 +159,7 @@ describe('cloneTemplate', () => {
     expect(copy.name).toEqual(`Copy of ${published.name}`);
     expect(copy.ownerId).toEqual(newOwnerId);
     expect(copy.visibility).toEqual(TemplateVisibility.PRIVATE);
-    expect(copy.currentVersion).toBeFalsy();
+    expect(copy.latestPublishVersion).toBeFalsy();
     expect(copy.errors).toEqual([]);
     expect(copy.createdById).toEqual(clonedById);
     expect(copy.description).toEqual(description);
@@ -191,7 +191,7 @@ describe('template versioning', () => {
         description: casual.sentences(5),
         ownerId: casual.url,
         visibility: getRandomEnumValue(TemplateVisibility),
-        currentVersion: '',
+        latestPublishVersion: '',
         isDirty: true,
         bestPractice: false,
         createdById: casual.integer(1, 999),
@@ -222,7 +222,7 @@ describe('template versioning', () => {
       obj.modifed = tstamp;
       obj.modifiedById = userId;
 
-      switch(table) {
+      switch (table) {
         case 'templates': {
           templateStore.push(obj);
           break;
@@ -245,7 +245,7 @@ describe('template versioning', () => {
         obj.modifiedById = userId;
       }
 
-      switch(table) {
+      switch (table) {
         case 'templates': {
           const existing = templateStore.find((entry) => { return entry.id === obj.id });
           if (!existing) {
@@ -279,7 +279,7 @@ describe('template versioning', () => {
     const tmplt = new Template({
       id: casual.integer(1, 99),
       name: casual.words(4),
-      currentVersion: 'v1',
+      latestPublishVersion: 'v1',
     });
 
     // isDirty is true when the class is instantiated, so reset it
@@ -326,6 +326,7 @@ describe('template versioning', () => {
   it('versions the Template when it has no prior versions', async () => {
     const tmplt = new Template(templateStore[0]);
     const comment = casual.sentences(3);
+    const visibility = TemplateVisibility.PRIVATE;
     const versionType = getRandomEnumValue(TemplateVersionType);
 
     (VersionedTemplate.insert as jest.Mock) = mockInsert;
@@ -339,6 +340,7 @@ describe('template versioning', () => {
       [],
       context.token.id,
       comment,
+      visibility,
       versionType
     );
 
@@ -353,7 +355,7 @@ describe('template versioning', () => {
     expect(newVersion.name).toEqual(tmplt.name);
     expect(newVersion.description).toEqual(tmplt.description);
     expect(newVersion.ownerId).toEqual(tmplt.ownerId);
-    expect(newVersion.visibility).toEqual(tmplt.visibility);
+    expect(newVersion.visibility).toEqual(visibility);
     expect(newVersion.bestPractice).toEqual(tmplt.bestPractice);
     expect(newVersion.version).toEqual('v1');
     expect(newVersion.versionedById).toEqual(context.token.id);
@@ -366,13 +368,13 @@ describe('template versioning', () => {
     const updated = templateStore.find((entry) => { return entry.id === tmplt.id; });
     expect(updated.modifiedById).toEqual(tmplt.modifiedById);
     expect(updated.modified).toEqual(tmplt.modified);
-    expect(updated.currentVersion).toEqual(newVersion.version);
+    expect(updated.latestPublishVersion).toEqual(newVersion.version);
     expect(updated.isDirty).toEqual(false);
   });
 
   it('versions the Template when there are prior versions', async () => {
     const tmplt = new Template(templateStore[0]);
-    tmplt.currentVersion = 'v1';
+    tmplt.latestPublishVersion = 'v1';
 
     const oldVersion = new VersionedTemplate({
       templateId: tmplt.id,
@@ -390,6 +392,7 @@ describe('template versioning', () => {
     versionedTemplateStore.push(oldVersion);
     const comment = casual.sentences(3);
     const versionType = getRandomEnumValue(TemplateVersionType);
+    const visibility = TemplateVisibility.PUBLIC;
 
     (VersionedTemplate.insert as jest.Mock) = mockInsert;
     (VersionedTemplate.findVersionedTemplateById as jest.Mock) = mockFindVersionedTemplatebyId;
@@ -402,6 +405,7 @@ describe('template versioning', () => {
       [oldVersion],
       context.token.id,
       comment,
+      visibility,
       versionType
     );
 
@@ -416,7 +420,7 @@ describe('template versioning', () => {
     expect(newVersion.name).toEqual(tmplt.name);
     expect(newVersion.description).toEqual(tmplt.description);
     expect(newVersion.ownerId).toEqual(tmplt.ownerId);
-    expect(newVersion.visibility).toEqual(tmplt.visibility);
+    expect(newVersion.visibility).toEqual(visibility);
     expect(newVersion.bestPractice).toEqual(tmplt.bestPractice);
     expect(newVersion.version).toEqual('v2');
     expect(newVersion.versionedById).toEqual(context.token.id);
@@ -429,7 +433,7 @@ describe('template versioning', () => {
     const updated = templateStore.find((entry) => { return entry.id === tmplt.id; });
     expect(updated.modifiedById).toEqual(tmplt.modifiedById);
     expect(updated.modified).toEqual(tmplt.modified);
-    expect(updated.currentVersion).toEqual(newVersion.version);
+    expect(updated.latestPublishVersion).toEqual(newVersion.version);
     expect(updated.isDirty).toEqual(false);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -498,6 +498,7 @@ export type MutationCreateTemplateVersionArgs = {
   comment?: InputMaybe<Scalars['String']['input']>;
   templateId: Scalars['Int']['input'];
   versionType?: InputMaybe<TemplateVersionType>;
+  visibility: TemplateVisibility;
 };
 
 
@@ -1039,8 +1040,6 @@ export type Template = {
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
-  /** The current published version */
-  currentVersion?: Maybe<Scalars['String']['output']>;
   /** A description of the purpose of the template */
   description?: Maybe<Scalars['String']['output']>;
   /** Errors associated with the Object */
@@ -1051,6 +1050,10 @@ export type Template = {
   isDirty: Scalars['Boolean']['output'];
   /** The template's language */
   languageId: Scalars['String']['output'];
+  /** The last published date */
+  latestPublishDate?: Maybe<Scalars['String']['output']>;
+  /** The last published version */
+  latestPublishVersion?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was last modifed */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
@@ -1789,7 +1792,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addTemplateCollaborator?: Resolver<Maybe<ResolversTypes['TemplateCollaborator']>, ParentType, ContextType, RequireFields<MutationAddTemplateCollaboratorArgs, 'email' | 'templateId'>>;
   addUserEmail?: Resolver<Maybe<ResolversTypes['UserEmail']>, ParentType, ContextType, RequireFields<MutationAddUserEmailArgs, 'email' | 'isPrimary'>>;
   archiveTemplate?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationArchiveTemplateArgs, 'templateId'>>;
-  createTemplateVersion?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationCreateTemplateVersionArgs, 'templateId'>>;
+  createTemplateVersion?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationCreateTemplateVersionArgs, 'templateId' | 'visibility'>>;
   deactivateUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationDeactivateUserArgs, 'userId'>>;
   mergeUsers?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationMergeUsersArgs, 'userIdToBeMerged' | 'userIdToKeep'>>;
   removeAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<MutationRemoveAffiliationArgs, 'affiliationId'>>;
@@ -1986,12 +1989,13 @@ export type TemplateResolvers<ContextType = MyContext, ParentType extends Resolv
   collaborators?: Resolver<Maybe<Array<ResolversTypes['TemplateCollaborator']>>, ParentType, ContextType>;
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  currentVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isDirty?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   languageId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  latestPublishDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  latestPublishVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Changed `currentVersion` to be `latestPublishVersion` in the template table, and added `latestPublishDate`
- Added `visibility` field to versionedTemplate table
- Added missing `languageId` to versionedTemplate table

Fixes # ([153](https://github.com/CDLUC3/dmsp_backend_prototype/issues/153))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested manually and via unit tests

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (will merge this branch before merging the dependent "feature/JS-hook-up-publish-page" branch (PR for that is here: https://github.com/CDLUC3/dmsp_frontend_prototype/pull/210)