### PR TITLE
Made changes to allow the deletion of sectionTags when user edits their Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added "remove" method to SectionTag model. Updated "updateSection" method in Section resolvers to remove sectionTags when user is updating their Section. Added "getTagsToRemove" method to the Section resolver. Added associated unit tests.
 - Added "lastPublishedDate" field to templates table, and changed "currentVersion" field to "lastPublishedVersion"
 - Added support for creating "other" affiliations
 - Added update and updatePassword to User

--- a/src/models/SectionTag.ts
+++ b/src/models/SectionTag.ts
@@ -15,10 +15,17 @@ export class SectionTag extends MySqlModel {
     }
 
 
-    // Save the current record
+    // Create a sectionTag record
     async create(context: MyContext): Promise<SectionTag> {
         // Insert new SectionTag records
         await SectionTag.insert(context, tableName, this, 'SectionTag.create');
+        return this;
+    }
+
+    // Delete a sectionTag record
+    async remove(context: MyContext): Promise<SectionTag> {
+        // Delete SectionTag records
+        await SectionTag.delete(context, tableName, this.tagId, 'SectionTag.create');
         return this;
     }
 

--- a/src/models/__tests__/SectionTags.spec.ts
+++ b/src/models/__tests__/SectionTags.spec.ts
@@ -53,6 +53,34 @@ describe('create', () => {
   });
 });
 
+describe('remove', () => {
+  const originalDelete = SectionTag.delete;
+  let deleteQuery;
+  let sectionTag;
+
+  beforeEach(() => {
+    deleteQuery = jest.fn();
+    (SectionTag.delete as jest.Mock) = deleteQuery;
+
+    sectionTag = new SectionTag({
+      sectionId: casual.integer(1, 9),
+      tagId: casual.integer(1, 999),
+    })
+  });
+
+  afterEach(() => {
+    SectionTag.delete = originalDelete;
+  });
+
+
+  it('returns the SectionTag ', async () => {
+    const localValidator = jest.fn();
+    localValidator.mockResolvedValueOnce(false);
+
+    expect(await sectionTag.remove(context)).toBe(sectionTag);
+  });
+});
+
 describe('getSectionTagsBySectionId', () => {
   const originalQuery = SectionTag.query;
 

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -137,7 +137,7 @@ export const getTagsToAdd = async (tags: Tag[], context: MyContext, sectionId: n
 
 export const getTagsToRemove = async (tags: Tag[], context: MyContext, sectionId: number): Promise<SectionTag[]> => {
   //Get all the existing tags associated with this section in SectionTags
-  const existingTags = await SectionTag.getSectionTagsBySectionId('updateSection resolver', context, sectionId);
+  const existingTags = await SectionTag.getSectionTagsBySectionId('sectionService-updateSection', context, sectionId);
 
   // Create a Set of tag ids
   const tagIds = new Set(tags.map(tag => tag.id));
@@ -145,6 +145,5 @@ export const getTagsToRemove = async (tags: Tag[], context: MyContext, sectionId
   // Get tags that exist in db table, but are not included in updated tags
   const tagsToRemove = existingTags.filter(existing => !tagIds.has(existing.tagId))
 
-  console.log("****TAGS TO REMOVE", tagsToRemove);
   return Array.isArray(tagsToRemove) ? tagsToRemove : [];
 }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -122,6 +122,7 @@ export const hasPermissionOnSection = async (context: MyContext, templateId: num
 }
 
 export const getTagsToAdd = async (tags: Tag[], context: MyContext, sectionId: number): Promise<Tag[]> => {
+
   //Get all the existing tags associated with this section in SectionTags
   const existingTags = await SectionTag.getSectionTagsBySectionId('updateSection resolver', context, sectionId);
 
@@ -132,4 +133,18 @@ export const getTagsToAdd = async (tags: Tag[], context: MyContext, sectionId: n
   const tagsToAdd = tags.filter(tag => !existingTagIds.has(tag.id));
 
   return Array.isArray(tagsToAdd) ? tagsToAdd : [];
+}
+
+export const getTagsToRemove = async (tags: Tag[], context: MyContext, sectionId: number): Promise<SectionTag[]> => {
+  //Get all the existing tags associated with this section in SectionTags
+  const existingTags = await SectionTag.getSectionTagsBySectionId('updateSection resolver', context, sectionId);
+
+  // Create a Set of tag ids
+  const tagIds = new Set(tags.map(tag => tag.id));
+
+  // Get tags that exist in db table, but are not included in updated tags
+  const tagsToRemove = existingTags.filter(existing => !tagIds.has(existing.tagId))
+
+  console.log("****TAGS TO REMOVE", tagsToRemove);
+  return Array.isArray(tagsToRemove) ? tagsToRemove : [];
 }


### PR DESCRIPTION
Currently, there is no way for a user to remove sectionTags from their Section when they are editing it.

## Description

- Added ‘remove’ method to SectionTag model. 
- Updated ‘updateSection’ method in Section resolvers to remove sectionTags when user is updating their Section. 
- Added ‘getTagsToRemove’ method to the Section resolver. 
- Added associated unit tests.

Fixes # ([165](https://github.com/CDLUC3/dmsp_backend_prototype/issues/165))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
I tested the new code manually by adding a new Section with several tags selected, and then testing that I could delete the ones that were "unchecked" in the form.

I also added unit tests.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules