### PR TITLE
Feature/js updates to accommodate question types with options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `questionOptions` schema, resolver and `QuestionOption` model, which will be used for `option` question types
 - Added a new query to get all versionedTemplates, called `myVersionedTemplates`, under user's affiliation, and added a new method in the model called `findByAffiliationId`
 - Updated `templates` resolver to handle updates to `sections` and `questions` when copying a `template`
 - Added "remove" method to SectionTag model. Updated "updateSection" method in Section resolvers to remove sectionTags when user is updating their Section. Added "getTagsToRemove" method to the Section resolver. Added associated unit tests.

--- a/data-migrations/2025-01-24-0318-create-question-options-table.sql
+++ b/data-migrations/2025-01-24-0318-create-question-options-table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `questionOptions` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
   `questionId` INT NOT NULL,
-  `text` TEXT NOT NULL,
+  `text` VARCHAR(255) NOT NULL,
   `orderNumber` INT NOT NULL,
   `isDefault` TINYINT(1) NOT NULL DEFAULT 0,
   `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -9,4 +9,6 @@ CREATE TABLE `questionOptions` (
   `modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modifiedById` int,
   FOREIGN KEY (questionId) REFERENCES questions(id) ON DELETE CASCADE
+  CONSTRAINT unique_question_option UNIQUE (`questionId`, `text`),
+  CONSTRAINT unique_question_option UNIQUE (`questionId`, `orderNumber`)`
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb3;

--- a/data-migrations/2025-01-24-0318-create-question-options-table.sql
+++ b/data-migrations/2025-01-24-0318-create-question-options-table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `questionOptions` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `questionId` INT NOT NULL,
+  `text` TEXT NOT NULL,
+  `orderNumber` INT NOT NULL,
+  `isDefault` TINYINT(1) NOT NULL DEFAULT 0,
+  `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `createdById` int,
+  `modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedById` int,
+  FOREIGN KEY (questionId) REFERENCES questions(id) ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb3;

--- a/data-migrations/2025-01-24-0324-seed-question-options.sql
+++ b/data-migrations/2025-01-24-0324-seed-question-options.sql
@@ -1,0 +1,16 @@
+INSERT INTO questionOptions (questionId, text, orderNumber, isDefault, createdById, created, modifiedById, modified)
+VALUES
+  (67, 'Option 1', 1, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13'),
+  (67, 'Option 2', 2, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13'),
+  (67, 'Option 3', 3, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13');
+
+INSERT INTO questionOptions (questionId, text, orderNumber, isDefault, createdById, created, modifiedById, modified)
+VALUES
+  (68, 'Dropdown 1', 1, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13'),
+  (68, 'Dropwdown 2', 2, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13'),
+  (68, 'Dropdown 3', 3, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13');
+
+INSERT INTO questionOptions (questionId, text, orderNumber, isDefault, createdById, created, modifiedById, modified)
+VALUES
+  (69, 'Applicable', 1, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13'),
+  (69, 'Not applicable', 2, false, 5,'2025-01-24 03:40:13',5,'2025-01-24 03:45:13');

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -1,5 +1,6 @@
 import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
+import { QuestionOption } from "../types";
 
 export class Question extends MySqlModel {
   public templateId: number;
@@ -13,6 +14,7 @@ export class Question extends MySqlModel {
   public required: boolean;
   public displayOrder: number;
   public isDirty: boolean;
+  public questionOptions: QuestionOption[];
 
   private tableName = 'questions';
 
@@ -30,6 +32,7 @@ export class Question extends MySqlModel {
     this.required = options.required || false;
     this.displayOrder = options.displayOrder;
     this.isDirty = options.isDirty || false;
+    this.questionOptions = options.questionOptions;
   }
 
   // Validation to be used prior to saving the record
@@ -81,7 +84,7 @@ export class Question extends MySqlModel {
         this.cleanup();
 
         // Save the record and then fetch it
-        const newId = await Question.insert(context, this.tableName, this, 'Question.create');
+        const newId = await Question.insert(context, this.tableName, this, 'Question.create', ['questionOptions']);
         const response = await Question.findById('Section.create', context, newId);
         return response;
       }

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -101,7 +101,7 @@ export class Question extends MySqlModel {
       if (id) {
         this.cleanup();
 
-        await Question.update(context, this.tableName, this, 'Question.update', [], noTouch);
+        await Question.update(context, this.tableName, this, 'Question.update', ['questionOptions'], noTouch);
         return await Question.findById('Question.update', context, id);
       }
       // This template has never been saved before so we cannot update it!

--- a/src/models/QuestionOption.ts
+++ b/src/models/QuestionOption.ts
@@ -25,6 +25,14 @@ export class QuestionOption extends MySqlModel {
     if (!this.questionId) {
       this.errors.push('Question ID can\'t be blank');
     }
+
+    if (!this.text) {
+      this.errors.push('Text can\'t be blank');
+    }
+
+    if (!this.orderNumber) {
+      this.errors.push('Order number can\'t be blank');
+    }
     return this.errors.length <= 0;
   }
 

--- a/src/models/QuestionOption.ts
+++ b/src/models/QuestionOption.ts
@@ -42,7 +42,7 @@ export class QuestionOption extends MySqlModel {
 
       // Save the record and then fetch it
       const newId = await QuestionOption.insert(context, this.tableName, this, 'QuestionOption.create');
-      const response = await QuestionOption.findById('QuestionOption.create', context, newId);
+      const response = await QuestionOption.findByQuestionOptionId('QuestionOption.create', context, newId);
       return response;
     }
     // Otherwise return as-is with all the errors
@@ -58,7 +58,7 @@ export class QuestionOption extends MySqlModel {
         this.cleanup();
 
         await QuestionOption.update(context, this.tableName, this, 'QuestionOption.update', [], noTouch);
-        return await QuestionOption.findById('QuestionOption.update', context, id);
+        return await QuestionOption.findByQuestionOptionId('QuestionOption.update', context, id);
       }
       // This question option has never been saved before so we cannot update it!
       this.errors.push('QuestionOption has never been saved');
@@ -71,7 +71,7 @@ export class QuestionOption extends MySqlModel {
     if (this.id) {
       /*First get the questionOption to be deleted so we can return this info to the user
       since calling 'delete' doesn't return anything*/
-      const deletedQuestionOption = await QuestionOption.findById('QuestionOption.delete', context, this.id);
+      const deletedQuestionOption = await QuestionOption.findByQuestionOptionId('QuestionOption.delete', context, this.id);
 
       const successfullyDeleted = await QuestionOption.delete(context, this.tableName, this.id, 'QuestionOption.delete');
       if (successfullyDeleted) {
@@ -84,14 +84,14 @@ export class QuestionOption extends MySqlModel {
   }
 
   // Find the QuestionOption by it's id
-  static async findById(reference: string, context: MyContext, questionOptionId: number): Promise<QuestionOption> {
+  static async findByQuestionOptionId(reference: string, context: MyContext, questionOptionId: number): Promise<QuestionOption> {
     const sql = 'SELECT * FROM questionOptions WHERE id = ?';
     const result = await QuestionOption.query(context, sql, [questionOptionId.toString()], reference);
     return Array.isArray(result) && result.length > 0 ? result[0] : null;
   }
 
-  // Fetch all of the QuestionOptions for the specified QuestionId
-  static async findByQuestionOptionId(reference: string, context: MyContext, questionId: number): Promise<QuestionOption[]> {
+  // Fetch all of the QuestionOptions for the specified questionId
+  static async findByQuestionId(reference: string, context: MyContext, questionId: number): Promise<QuestionOption[]> {
     const sql = 'SELECT * FROM questionOptions WHERE questionId = ?';
     const results = await QuestionOption.query(context, sql, [questionId.toString()], reference);
     return Array.isArray(results) ? results : [];

--- a/src/models/QuestionOption.ts
+++ b/src/models/QuestionOption.ts
@@ -1,0 +1,99 @@
+import { MyContext } from "../context";
+import { MySqlModel } from "./MySqlModel";
+
+export class QuestionOption extends MySqlModel {
+  public questionId: number;
+  public text: string;
+  public orderNumber: number;
+  public isDefault: boolean;
+
+  private tableName = 'questionOptions';
+
+  constructor(options) {
+    super(options.id, options.created, options.createdById, options.modified, options.modifiedById);
+
+    this.questionId = options.questionId;
+    this.text = options.text;
+    this.orderNumber = options.orderNumber;
+    this.isDefault = options.isDefault;
+  }
+
+  // Validation to be used prior to saving the record
+  async isValid(): Promise<boolean> {
+    await super.isValid();
+
+    if (!this.questionId) {
+      this.errors.push('Question ID can\'t be blank');
+    }
+    return this.errors.length <= 0;
+  }
+
+  // Ensure data integrity
+  cleanup(): void {
+    // Remove leading/trailing blank spaces
+    this.text = this.text?.trim();
+  }
+
+  //Create a new QuestionOption
+  async create(context: MyContext): Promise<QuestionOption> {
+    // First make sure the record is valid
+    if (await this.isValid()) {
+      this.cleanup();
+
+      // Save the record and then fetch it
+      const newId = await QuestionOption.insert(context, this.tableName, this, 'QuestionOption.create');
+      const response = await QuestionOption.findById('QuestionOption.create', context, newId);
+      return response;
+    }
+    // Otherwise return as-is with all the errors
+    return this;
+  }
+
+  //Update an existing QuestionOption
+  async update(context: MyContext, noTouch = false): Promise<QuestionOption> {
+    const id = this.id;
+
+    if (await this.isValid()) {
+      if (id) {
+        this.cleanup();
+
+        await QuestionOption.update(context, this.tableName, this, 'QuestionOption.update', [], noTouch);
+        return await QuestionOption.findById('QuestionOption.update', context, id);
+      }
+      // This question option has never been saved before so we cannot update it!
+      this.errors.push('QuestionOption has never been saved');
+    }
+    return this;
+  }
+
+  //Delete QuestionOption based on the QuestionOption's id and return
+  async delete(context: MyContext): Promise<QuestionOption> {
+    if (this.id) {
+      /*First get the questionOption to be deleted so we can return this info to the user
+      since calling 'delete' doesn't return anything*/
+      const deletedQuestionOption = await QuestionOption.findById('QuestionOption.delete', context, this.id);
+
+      const successfullyDeleted = await QuestionOption.delete(context, this.tableName, this.id, 'QuestionOption.delete');
+      if (successfullyDeleted) {
+        return deletedQuestionOption;
+      } else {
+        return null
+      }
+    }
+    return null;
+  }
+
+  // Find the QuestionOption by it's id
+  static async findById(reference: string, context: MyContext, questionOptionId: number): Promise<QuestionOption> {
+    const sql = 'SELECT * FROM questionOptions WHERE id = ?';
+    const result = await QuestionOption.query(context, sql, [questionOptionId.toString()], reference);
+    return Array.isArray(result) && result.length > 0 ? result[0] : null;
+  }
+
+  // Fetch all of the QuestionOptions for the specified QuestionId
+  static async findByQuestionOptionId(reference: string, context: MyContext, questionId: number): Promise<QuestionOption[]> {
+    const sql = 'SELECT * FROM questionOptions WHERE questionId = ?';
+    const results = await QuestionOption.query(context, sql, [questionId.toString()], reference);
+    return Array.isArray(results) ? results : [];
+  }
+}

--- a/src/models/__tests__/QuestionOption.spec.ts
+++ b/src/models/__tests__/QuestionOption.spec.ts
@@ -60,37 +60,37 @@ describe('findBy Queries', () => {
     QuestionOption.query = originalQuery;
   });
 
-  it('findById should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([questionOption]);
-    const id = 10;
-    const result = await QuestionOption.findById('testing', context, id);
-    const expectedSql = 'SELECT * FROM questionOptions WHERE id = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'testing')
-    expect(result).toEqual(questionOption);
-  });
-
-  it('findById should return null if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const id = casual.integer(1, 999);
-    const result = await QuestionOption.findById('testing', context, id);
-    expect(result).toEqual(null);
-  });
-
   it('findByQuestionOptionId should call query with correct params and return the default', async () => {
     localQuery.mockResolvedValueOnce([questionOption]);
-    const questionOptionId = casual.integer(1, 999);
+    const questionOptionId = 10;
     const result = await QuestionOption.findByQuestionOptionId('testing', context, questionOptionId);
-    const expectedSql = 'SELECT * FROM questionOptions WHERE questionId = ?';
+    const expectedSql = 'SELECT * FROM questionOptions WHERE id = ?';
     expect(localQuery).toHaveBeenCalledTimes(1);
     expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [questionOptionId.toString()], 'testing')
-    expect(result).toEqual([questionOption]);
+    expect(result).toEqual(questionOption);
   });
 
   it('findByQuestionOptionId should return null if it finds no default', async () => {
     localQuery.mockResolvedValueOnce([]);
+    const questionOptionId = casual.integer(1, 999);
+    const result = await QuestionOption.findByQuestionOptionId('testing', context, questionOptionId);
+    expect(result).toEqual(null);
+  });
+
+  it('findByQuestionId should call query with correct params and return the default', async () => {
+    localQuery.mockResolvedValueOnce([questionOption]);
     const questionId = casual.integer(1, 999);
-    const result = await QuestionOption.findByQuestionOptionId('testing', context, questionId);
+    const result = await QuestionOption.findByQuestionId('testing', context, questionId);
+    const expectedSql = 'SELECT * FROM questionOptions WHERE questionId = ?';
+    expect(localQuery).toHaveBeenCalledTimes(1);
+    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [questionId.toString()], 'testing')
+    expect(result).toEqual([questionOption]);
+  });
+
+  it('findByQuestionId should return an empty array if it finds no default', async () => {
+    localQuery.mockResolvedValueOnce([]);
+    const questionId = casual.integer(1, 999);
+    const result = await QuestionOption.findByQuestionId('testing', context, questionId);
     expect(result).toEqual([]);
   });
 });
@@ -140,7 +140,7 @@ describe('create', () => {
     localValidator.mockResolvedValueOnce(true);
 
     const mockFindById = jest.fn();
-    (QuestionOption.findById as jest.Mock) = mockFindById;
+    (QuestionOption.findByQuestionOptionId as jest.Mock) = mockFindById;
     mockFindById.mockResolvedValueOnce(questionOption);
 
     const result = await questionOption.create(context);
@@ -192,7 +192,7 @@ describe('update', () => {
     updateQuery.mockResolvedValueOnce(questionOption);
 
     const mockFindById = jest.fn();
-    (QuestionOption.findById as jest.Mock) = mockFindById;
+    (QuestionOption.findByQuestionOptionId as jest.Mock) = mockFindById;
     mockFindById.mockResolvedValueOnce(questionOption);
 
     const result = await questionOption.update(context);
@@ -234,7 +234,7 @@ describe('delete', () => {
     deleteQuery.mockResolvedValueOnce(questionOption);
 
     const mockFindById = jest.fn();
-    (QuestionOption.findById as jest.Mock) = mockFindById;
+    (QuestionOption.findByQuestionOptionId as jest.Mock) = mockFindById;
     mockFindById.mockResolvedValueOnce(questionOption);
 
     const result = await questionOption.delete(context);

--- a/src/models/__tests__/QuestionOption.spec.ts
+++ b/src/models/__tests__/QuestionOption.spec.ts
@@ -1,0 +1,244 @@
+import casual from "casual";
+import { logger } from '../../__mocks__/logger';
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { QuestionOption } from "../QuestionOption";
+
+let context;
+jest.mock('../../context.ts');
+
+describe('QuestionOption', () => {
+  let questionOption;
+
+  const questionOptionData = {
+    questionId: casual.integer(1, 999),
+    text: casual.words(3),
+    orderNumber: casual.integer(1, 10),
+    isDefault: false
+  }
+  beforeEach(() => {
+    questionOption = new QuestionOption(questionOptionData);
+  });
+
+  it('should initialize options as expected', () => {
+    expect(questionOption.questionId).toEqual(questionOptionData.questionId);
+    expect(questionOption.text).toEqual(questionOptionData.text);
+    expect(questionOption.orderNumber).toEqual(questionOptionData.orderNumber);
+    expect(questionOption.isDefault).toEqual(questionOptionData.isDefault);
+  });
+
+  it('should return true when calling isValid with a questionId', async () => {
+    expect(await questionOption.isValid()).toBe(true);
+  });
+});
+
+describe('findBy Queries', () => {
+  const originalQuery = QuestionOption.query;
+
+  let localQuery;
+  let context;
+  let questionOption;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    localQuery = jest.fn();
+    (QuestionOption.query as jest.Mock) = localQuery;
+
+    context = buildContext(logger, mockToken());
+
+    questionOption = new QuestionOption({
+      id: 10,
+      questionId: 67,
+      text: "Yes",
+      orderNumber: 1,
+      isDefault: false
+    })
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    QuestionOption.query = originalQuery;
+  });
+
+  it('findById should call query with correct params and return the default', async () => {
+    localQuery.mockResolvedValueOnce([questionOption]);
+    const id = 10;
+    const result = await QuestionOption.findById('testing', context, id);
+    const expectedSql = 'SELECT * FROM questionOptions WHERE id = ?';
+    expect(localQuery).toHaveBeenCalledTimes(1);
+    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'testing')
+    expect(result).toEqual(questionOption);
+  });
+
+  it('findById should return null if it finds no default', async () => {
+    localQuery.mockResolvedValueOnce([]);
+    const id = casual.integer(1, 999);
+    const result = await QuestionOption.findById('testing', context, id);
+    expect(result).toEqual(null);
+  });
+
+  it('findByQuestionOptionId should call query with correct params and return the default', async () => {
+    localQuery.mockResolvedValueOnce([questionOption]);
+    const questionOptionId = casual.integer(1, 999);
+    const result = await QuestionOption.findByQuestionOptionId('testing', context, questionOptionId);
+    const expectedSql = 'SELECT * FROM questionOptions WHERE questionId = ?';
+    expect(localQuery).toHaveBeenCalledTimes(1);
+    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [questionOptionId.toString()], 'testing')
+    expect(result).toEqual([questionOption]);
+  });
+
+  it('findByQuestionOptionId should return null if it finds no default', async () => {
+    localQuery.mockResolvedValueOnce([]);
+    const questionId = casual.integer(1, 999);
+    const result = await QuestionOption.findByQuestionOptionId('testing', context, questionId);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('create', () => {
+  const originalInsert = QuestionOption.insert;
+  let insertQuery;
+  let questionOption;
+
+  beforeEach(() => {
+    // jest.resetAllMocks();
+
+    insertQuery = jest.fn();
+    (QuestionOption.insert as jest.Mock) = insertQuery;
+
+    questionOption = new QuestionOption({
+      questionId: 10,
+      text: "Option 1",
+      orderNumber: 1,
+      isDefault: true
+    })
+  });
+
+  afterEach(() => {
+    // jest.resetAllMocks();
+    QuestionOption.insert = originalInsert;
+  });
+
+  it('returns the QuestionOption without errors if it is valid', async () => {
+    const localValidator = jest.fn();
+    (questionOption.isValid as jest.Mock) = localValidator;
+    localValidator.mockResolvedValueOnce(false);
+
+    expect(await questionOption.create(context)).toBe(questionOption);
+    expect(localValidator).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the QuestionOption with an error if questionId is undefined', async () => {
+    questionOption.questionId = undefined;
+    const response = await questionOption.create(context);
+    expect(response.errors[0]).toBe('Question ID can\'t be blank');
+  });
+
+  it('returns the newly added QuestionOption', async () => {
+    const localValidator = jest.fn();
+    (questionOption.isValid as jest.Mock) = localValidator;
+    localValidator.mockResolvedValueOnce(true);
+
+    const mockFindById = jest.fn();
+    (QuestionOption.findById as jest.Mock) = mockFindById;
+    mockFindById.mockResolvedValueOnce(questionOption);
+
+    const result = await questionOption.create(context);
+    expect(localValidator).toHaveBeenCalledTimes(1);
+    expect(mockFindById).toHaveBeenCalledTimes(1);
+    expect(insertQuery).toHaveBeenCalledTimes(1);
+    expect(result.errors.length).toBe(0);
+    expect(result).toEqual(questionOption);
+  });
+});
+
+describe('update', () => {
+  let updateQuery;
+  let questionOption;
+
+  beforeEach(() => {
+    updateQuery = jest.fn();
+    (QuestionOption.update as jest.Mock) = updateQuery;
+
+    questionOption = new QuestionOption({
+      id: 2,
+      questionId: 67,
+      text: "Option 2",
+      orderNumber: 2,
+      isDefault: true
+    })
+  });
+
+  it('returns the QuestionOption with errors if it is not valid', async () => {
+    const localValidator = jest.fn();
+    (questionOption.isValid as jest.Mock) = localValidator;
+    localValidator.mockResolvedValueOnce(false);
+
+    expect(await questionOption.update(context)).toBe(questionOption);
+  });
+
+  it('returns an error if the QuestionOption has no id', async () => {
+    const localValidator = jest.fn();
+    (questionOption.isValid as jest.Mock) = localValidator;
+    localValidator.mockResolvedValueOnce(true);
+
+    questionOption.id = null;
+    const result = await questionOption.update(context);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toEqual('QuestionOption has never been saved');
+  });
+
+  it('returns the updated QuestionOption', async () => {
+    updateQuery.mockResolvedValueOnce(questionOption);
+
+    const mockFindById = jest.fn();
+    (QuestionOption.findById as jest.Mock) = mockFindById;
+    mockFindById.mockResolvedValueOnce(questionOption);
+
+    const result = await questionOption.update(context);
+    expect(updateQuery).toHaveBeenCalledTimes(1);
+    expect(result.errors.length).toBe(0);
+    expect(result).toEqual(questionOption);
+  });
+});
+
+describe('delete', () => {
+  let questionOption;
+
+  beforeEach(() => {
+    questionOption = new QuestionOption({
+      id: 2,
+      questionId: 68,
+      text: "No",
+      orderNumber: 2,
+      isDefault: false
+    })
+  })
+
+  it('returns null if the QuestionOption has no id', async () => {
+    questionOption.id = null;
+    expect(await questionOption.delete(context)).toBe(null);
+  });
+
+  it('returns null if it was not able to delete the record', async () => {
+    const deleteQuery = jest.fn();
+    (QuestionOption.delete as jest.Mock) = deleteQuery;
+
+    deleteQuery.mockResolvedValueOnce(null);
+    expect(await questionOption.delete(context)).toBe(null);
+  });
+
+  it('returns the QuestionOption if it was able to delete the record', async () => {
+    const deleteQuery = jest.fn();
+    (QuestionOption.delete as jest.Mock) = deleteQuery;
+    deleteQuery.mockResolvedValueOnce(questionOption);
+
+    const mockFindById = jest.fn();
+    (QuestionOption.findById as jest.Mock) = mockFindById;
+    mockFindById.mockResolvedValueOnce(questionOption);
+
+    const result = await questionOption.delete(context);
+    expect(result.errors.length).toBe(0);
+    expect(result).toEqual(questionOption);
+  });
+});

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -13,6 +13,7 @@ import { resolvers as licenseResolvers } from './resolvers/license';
 import { resolvers as metadataStandardResolvers } from './resolvers/metadataStandard';
 import { resolvers as questionResolvers } from './resolvers/question';
 import { resolvers as questionConditionResolvers } from './resolvers/questionCondition';
+import { resolvers as questionOptionResolvers } from './resolvers/questionOption';
 import { resolvers as questionTypeResolvers } from './resolvers/questionType';
 import { resolvers as templateResolvers } from './resolvers/template';
 import { resolvers as repositoryResolvers } from './resolvers/repository';
@@ -41,6 +42,7 @@ export const resolvers: IResolvers = mergeResolvers([
   contributorRoleResolvers,
   questionResolvers,
   questionConditionResolvers,
+  questionOptionResolvers,
   questionTypeResolvers,
   repositoryResolvers,
   researchDomainResolvers,

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -1,5 +1,6 @@
 import { Resolvers } from "../types";
 import { MyContext } from "../context";
+import { QuestionOption } from "../models/QuestionOption";
 import { Question } from "../models/Question";
 import { Section } from "../models/Section";
 import { hasPermissionOnQuestion } from "../services/questionService";
@@ -184,6 +185,13 @@ export const resolvers: Resolvers = {
     questionConditions: async (parent: Question, _, context: MyContext): Promise<QuestionCondition[]> => {
       return await QuestionCondition.findByQuestionId(
         'Chained Question.questionConditions',
+        context,
+        parent.id
+      );
+    },
+    questionOptions: async (parent: Question, _, context: MyContext): Promise<QuestionOption[]> => {
+      return await QuestionOption.findByQuestionOptionId(
+        'Chained Question.questionOptions',
         context,
         parent.id
       );

--- a/src/resolvers/questionOption.ts
+++ b/src/resolvers/questionOption.ts
@@ -1,0 +1,95 @@
+import { Resolvers } from "../types";
+import { MyContext } from "../context";
+import { QuestionOption } from "../models/QuestionOption";
+import { NotFoundError, BadUserInputError } from "../utils/graphQLErrors";
+
+
+export const resolvers: Resolvers = {
+  Query: {
+    questionOptions: async (_, { questionId }, context: MyContext): Promise<QuestionOption[]> => {
+      return await QuestionOption.findByQuestionOptionId('questionOption resolver', context, questionId);
+    },
+    questionOption: async (_, { questionOptionId }, context: MyContext): Promise<QuestionOption> => {
+      return await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+    },
+  },
+  Mutation: {
+    addQuestionOption: async (_, { input: {
+      questionId,
+      text,
+      orderNumber,
+      isDefault } }, context: MyContext): Promise<QuestionOption> => {
+
+      const questionOption = new QuestionOption({
+        questionId,
+        text,
+        orderNumber,
+        isDefault
+      });
+
+      // create the new QuestionOption
+      const newQuestionOption = await questionOption.create(context, questionId, text, orderNumber, isDefault);
+
+      // If there are errors than throw a Bad User Input error
+      if (newQuestionOption.errors) {
+        const errorMessages = newQuestionOption.errors.join(', ');
+        throw BadUserInputError(errorMessages);
+      } else {
+        const questionOptionId = newQuestionOption.id;
+
+        // Return newly created questionOption
+        return await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+      }
+    },
+    updateQuestionOption: async (_, { input: {
+      questionOptionId,
+      text,
+      orderNumber,
+      isDefault } }, context: MyContext): Promise<QuestionOption> => {
+
+      // Get QuestionOption based on provided questionOptionId
+      const questionOptionData = await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+
+      // Throw Not Found error if QuestionOption data is not found
+      if (!questionOptionData) {
+        throw NotFoundError('QuestionOption not found')
+      }
+
+      const questionOption = new QuestionOption({
+        id: questionOptionId,
+        questionId: questionOptionData.questionId,
+        text: text || questionOptionData.text,
+        orderNumber: orderNumber || questionOptionData.orderNumber,
+        isDefault: isDefault || questionOptionData.isDefault
+      });
+
+      const updatedQuestionOption = await questionOption.update(context);
+
+      // If there are errors than throw a Bad User Input error
+      if (updatedQuestionOption.errors) {
+        const errorMessages = updatedQuestionOption.errors.join(', ');
+        throw BadUserInputError(errorMessages);
+      } else {
+        // Return newly created question
+        return await QuestionOption.findById('updateQuestion resolver', context, updatedQuestionOption.id);
+      }
+    },
+    removeQuestionOption: async (_, { questionOptionId }, context: MyContext): Promise<QuestionOption> => {
+      // Retrieve existing questionOption
+      const questionOptionData = await QuestionOption.findById('removeQuestion resolver', context, questionOptionId);
+
+      // Throw Not Found error if QuestionOption is not found
+      if (!questionOptionData) {
+        throw NotFoundError('QuestionOption not found')
+      }
+
+      //Need to create a new instance of QuestionOption so that it recognizes the 'delete' function of that instance
+      const questionOption = new QuestionOption({
+        ...questionOptionData,
+        id: questionOptionId
+      });
+
+      return await questionOption.delete(context);
+    },
+  },
+};

--- a/src/resolvers/questionOption.ts
+++ b/src/resolvers/questionOption.ts
@@ -7,10 +7,10 @@ import { NotFoundError, BadUserInputError } from "../utils/graphQLErrors";
 export const resolvers: Resolvers = {
   Query: {
     questionOptions: async (_, { questionId }, context: MyContext): Promise<QuestionOption[]> => {
-      return await QuestionOption.findByQuestionOptionId('questionOption resolver', context, questionId);
+      return await QuestionOption.findByQuestionId('questionOption resolver', context, questionId);
     },
     questionOption: async (_, { questionOptionId }, context: MyContext): Promise<QuestionOption> => {
-      return await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+      return await QuestionOption.findByQuestionOptionId('questionOption resolver', context, questionOptionId);
     },
   },
   Mutation: {
@@ -38,7 +38,7 @@ export const resolvers: Resolvers = {
         const questionOptionId = newQuestionOption.id;
 
         // Return newly created questionOption
-        return await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+        return await QuestionOption.findByQuestionOptionId('questionOption resolver', context, questionOptionId);
       }
     },
     updateQuestionOption: async (_, { input: {
@@ -48,7 +48,7 @@ export const resolvers: Resolvers = {
       isDefault } }, context: MyContext): Promise<QuestionOption> => {
 
       // Get QuestionOption based on provided questionOptionId
-      const questionOptionData = await QuestionOption.findById('questionOption resolver', context, questionOptionId);
+      const questionOptionData = await QuestionOption.findByQuestionOptionId('questionOption resolver', context, questionOptionId);
 
       // Throw Not Found error if QuestionOption data is not found
       if (!questionOptionData) {
@@ -71,12 +71,12 @@ export const resolvers: Resolvers = {
         throw BadUserInputError(errorMessages);
       } else {
         // Return newly created question
-        return await QuestionOption.findById('updateQuestion resolver', context, updatedQuestionOption.id);
+        return await QuestionOption.findByQuestionOptionId('updateQuestion resolver', context, updatedQuestionOption.id);
       }
     },
     removeQuestionOption: async (_, { questionOptionId }, context: MyContext): Promise<QuestionOption> => {
       // Retrieve existing questionOption
-      const questionOptionData = await QuestionOption.findById('removeQuestion resolver', context, questionOptionId);
+      const questionOptionData = await QuestionOption.findByQuestionOptionId('removeQuestion resolver', context, questionOptionId);
 
       // Throw Not Found error if QuestionOption is not found
       if (!questionOptionData) {

--- a/src/resolvers/questionOption.ts
+++ b/src/resolvers/questionOption.ts
@@ -28,7 +28,7 @@ export const resolvers: Resolvers = {
       });
 
       // create the new QuestionOption
-      const newQuestionOption = await questionOption.create(context, questionId, text, orderNumber, isDefault);
+      const newQuestionOption = await questionOption.create(context);
 
       // If there are errors than throw a Bad User Input error
       if (newQuestionOption.errors) {

--- a/src/resolvers/repository.ts
+++ b/src/resolvers/repository.ts
@@ -45,7 +45,7 @@ export const resolvers: Resolvers = {
             }
           }
           return created
-        } catch(err) {
+        } catch (err) {
           formatLogMessage(context.logger).error(err, 'Failure in addRepository resolver');
           throw InternalServerError();
         }
@@ -82,7 +82,7 @@ export const resolvers: Resolvers = {
             }
           }
           return updated;
-        } catch(err) {
+        } catch (err) {
           formatLogMessage(context.logger).error(err, 'Failure in updateRepository resolver');
           throw InternalServerError();
         }
@@ -113,7 +113,7 @@ export const resolvers: Resolvers = {
             }
           }
           return deleted
-        } catch(err) {
+        } catch (err) {
           formatLogMessage(context.logger).error(err, 'Failure in removeRepository resolver');
           throw InternalServerError();
         }
@@ -148,17 +148,17 @@ export const resolvers: Resolvers = {
             // Merge the keywords
             if (toRemove.keywords && Array.isArray(toRemove.keywords)) {
               toRemove.keywords.filter((k) => !toKeep.keywords.includes(k))
-                               .forEach((key) => toKeep.keywords.push(key));
+                .forEach((key) => toKeep.keywords.push(key));
             }
             // Merge the repositoryTypes
             if (toRemove.repositoryTypes && Array.isArray(toRemove.repositoryTypes)) {
               toRemove.repositoryTypes.filter((rt) => !toKeep.repositoryTypes.includes(rt))
-                                      .forEach((typ) => toKeep.repositoryTypes.push(typ));
+                .forEach((typ) => toKeep.repositoryTypes.push(typ));
             }
             // Merge the researchDomains
             if (toRemove.researchDomains && Array.isArray(toRemove.researchDomains)) {
               toRemove.researchDomains.filter((rd) => !toKeep.researchDomains.includes(rd))
-                                      .forEach((dom) => toKeep.researchDomains.push(dom));
+                .forEach((dom) => toKeep.researchDomains.push(dom));
             }
             await toKeep.update(context);
           }
@@ -168,7 +168,7 @@ export const resolvers: Resolvers = {
           // Delete the one we want to remove
           await toRemove.delete(context);
           return toKeep;
-        } catch(err) {
+        } catch (err) {
           formatLogMessage(context.logger).error(err, 'Failure in removeRepository resolver');
           throw InternalServerError();
         }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -17,6 +17,7 @@ import { typeDefs as projectFunderTypeDefs } from './schemas/projectFunder';
 import { typeDefs as projectOutputTypeDefs } from './schemas/projectOutput';
 import { typeDefs as questionTypeDefs } from './schemas/question';
 import { typeDefs as questionConditionTypeDefs } from './schemas/questionCondition';
+import { typeDefs as questionOptionTypeDefs } from './schemas/questionOption';
 import { typeDefs as questionTypeTypeDefs } from './schemas/questionType';
 import { typeDefs as repositoryTypeDefs } from './schemas/repository';
 import { typeDefs as researchDomainTypeDefs } from './schemas/researchDomain';
@@ -50,6 +51,7 @@ export const typeDefs = mergeTypeDefs([
   contributorTypeDefs,
   questionTypeDefs,
   questionConditionTypeDefs,
+  questionOptionTypeDefs,
   questionTypeTypeDefs,
   repositoryTypeDefs,
   researchDomainTypeDefs,

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -15,8 +15,6 @@ extend type Mutation {
     updateQuestion(input: UpdateQuestionInput!): Question!
     "Delete a Question"
     removeQuestion(questionId: Int!): Question
-    "Separate Question update specifically for options"
-    updateQuestionOptions(questionId: Int!, required:Boolean = false ): Question
   }
 
 "Question always belongs to a Section, which always belongs to a Template"
@@ -84,6 +82,8 @@ input AddQuestionInput {
     sampleText: String
     "To indicate whether the question is required to be completed"
     required: Boolean
+    "Add options for a question type, like radio buttons"
+    questionOptions: [QuestionOptionInput]
 }
 
 input UpdateQuestionInput {
@@ -101,6 +101,8 @@ input UpdateQuestionInput {
     sampleText: String
     "To indicate whether the question is required to be completed"
     required: Boolean
+    "Update options for a question type like radio buttons"
+    questionOptions: [UpdateQuestionOptionInput]
 }
 
 "QuestionOption always belongs to a Question"
@@ -128,4 +130,14 @@ type QuestionOption {
     isDefault: Boolean
 
 }
+
+  "Input for Question options operations"
+  input QuestionOptionInput {
+    "The text for the question option"
+    text: String
+    "The order of the question option"
+    orderNumber: Int
+    "Whether the question option is the default selected one"
+    isDefault: Boolean
+  }
 `

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -104,40 +104,4 @@ input UpdateQuestionInput {
     "Update options for a question type like radio buttons"
     questionOptions: [UpdateQuestionOptionInput]
 }
-
-"QuestionOption always belongs to a Question"
-type QuestionOption {
-    "The unique identifer for the Object"
-    id: Int
-    "The user who created the Object"
-    createdById: Int
-    "The timestamp when the Object was created"
-    created: String
-    "The user who last modified the Object"
-    modifiedById: Int
-    "The timestamp when the Object was last modifed"
-    modified: String
-    "Errors associated with the Object"
-    errors: [String!]
-
-    "The question id that the QuestionOption belongs to"
-    questionId: Int!
-    "The option text"
-    text: String!
-    "The option order number"
-    orderNumber: Int!
-    "Whether the option is the default selected one"
-    isDefault: Boolean
-
-}
-
-  "Input for Question options operations"
-  input QuestionOptionInput {
-    "The text for the question option"
-    text: String
-    "The order of the question option"
-    orderNumber: Int
-    "Whether the question option is the default selected one"
-    isDefault: Boolean
-  }
 `

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -59,6 +59,8 @@ type Question {
 
     "The conditional logic triggered by this question"
     questionConditions: [QuestionCondition!]
+    "The question options associated with this question"
+    questionOptions: [QuestionOption!]
 }
 
 input AddQuestionInput {
@@ -99,5 +101,31 @@ input UpdateQuestionInput {
     sampleText: String
     "To indicate whether the question is required to be completed"
     required: Boolean
+}
+
+"QuestionOption always belongs to a Question"
+type QuestionOption {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: [String!]
+
+    "The question id that the QuestionOption belongs to"
+    questionId: Int!
+    "The option text"
+    text: String!
+    "The option order number"
+    orderNumber: Int!
+    "Whether the option is the default selected one"
+    isDefault: Boolean
+
 }
 `

--- a/src/schemas/questionOption.ts
+++ b/src/schemas/questionOption.ts
@@ -56,7 +56,7 @@ input AddQuestionOptionInput {
 
 input UpdateQuestionOptionInput {
     "The id of the QuestionOption"
-    questionOptionId: Int!
+    questionOptionId: Int
     "The option text"
     text: String!
     "The option order number"

--- a/src/schemas/questionOption.ts
+++ b/src/schemas/questionOption.ts
@@ -1,0 +1,67 @@
+import gql from "graphql-tag";
+
+export const typeDefs = gql`
+  extend type Query {
+    "Get the Question Options that belong to the associated questionId"
+    questionOptions(questionId: Int!): [QuestionOption]
+    "Get the specific Question Option based on questionOptionId"
+    questionOption(questionOptionId: Int!): QuestionOption
+  }
+
+extend type Mutation {
+    "Create a new QuestionOption"
+    addQuestionOption(input: AddQuestionOptionInput!): QuestionOption!
+    "Update a QuestionOption"
+    updateQuestionOption(input: UpdateQuestionOptionInput!): QuestionOption!
+    "Delete a QuestionOption"
+    removeQuestionOption(questionOptionId: Int!): QuestionOption
+  }
+
+"QuestionOption always belongs to a Question"
+type QuestionOption {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: [String!]
+
+    "The question id that the QuestionOption belongs to"
+    questionId: Int!
+    "The option text"
+    text: String!
+    "The option order number"
+    orderNumber: Int!
+    "Whether the option is the default selected one"
+    isDefault: Boolean
+
+}
+
+input AddQuestionOptionInput {
+    "The question id that the QuestionOption belongs to"
+    questionId: Int!
+    "The option text"
+    text: String!
+    "The option order number"
+    orderNumber: Int!
+    "Whether the option is the default selected one"
+    isDefault: Boolean
+}
+
+input UpdateQuestionOptionInput {
+    "The id of the QuestionOption"
+    questionOptionId: Int!
+    "The option text"
+    text: String!
+    "The option order number"
+    orderNumber: Int!
+    "Whether the option is the default selected one"
+    isDefault: Boolean
+}
+`

--- a/src/schemas/questionOption.ts
+++ b/src/schemas/questionOption.ts
@@ -43,6 +43,16 @@ type QuestionOption {
 
 }
 
+"Input for Question options operations"
+input QuestionOptionInput {
+  "The text for the question option"
+  text: String
+  "The order of the question option"
+  orderNumber: Int
+  "Whether the question option is the default selected one"
+  isDefault: Boolean
+}
+
 input AddQuestionOptionInput {
     "The question id that the QuestionOption belongs to"
     questionId: Int!

--- a/src/services/__tests__/questionService.spec.ts
+++ b/src/services/__tests__/questionService.spec.ts
@@ -3,12 +3,11 @@ import { Template } from "../../models/Template";
 import { buildContext, mockToken } from "../../__mocks__/context";
 import { logger } from "../../__mocks__/logger";
 import { MySQLDataSource } from "../../datasources/mySQLDataSource";
-import { cloneQuestion, generateQuestionConditionVersion, generateQuestionVersion, getExistingQuestionOptions, hasPermissionOnQuestion } from "../questionService";
+import { cloneQuestion, generateQuestionConditionVersion, generateQuestionVersion, hasPermissionOnQuestion } from "../questionService";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { hasPermissionOnTemplate } from "../templateService";
 import { NotFoundError } from "../../utils/graphQLErrors";
 import { Question } from "../../models/Question";
-import { QuestionOption } from "../../models/QuestionOption";
 import { VersionedQuestion } from "../../models/VersionedQuestion";
 import { QuestionType } from "../../models/QuestionType";
 import { QuestionCondition, QuestionConditionActionType, QuestionConditionCondition } from "../../models/QuestionCondition";
@@ -515,64 +514,5 @@ describe('generateQuestionConditionVersion', () => {
     expect(newVersion.conditionType).toEqual(questionCondition.conditionType);
     expect(newVersion.conditionMatch).toEqual(questionCondition.conditionMatch);
     expect(newVersion.target).toEqual(questionCondition.target);
-  });
-});
-
-describe('getExistingQuestionOptions', () => {
-  let mockQuery;
-
-  const expectedResponse = [
-    expect.objectContaining({
-      questionId: 50,
-      text: 'Yes',
-      orderNumber: 1,
-      isDefault: true,
-    }),
-    expect.objectContaining({
-      questionId: 50,
-      text: 'No',
-      orderNumber: 2,
-      isDefault: false,
-    }),
-    expect.objectContaining({
-      questionId: 50,
-      text: 'Maybe',
-      orderNumber: 3,
-      isDefault: false,
-    }),
-  ];
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-
-    // Cast getInstance to a jest.Mock type to use mockReturnValue
-    (MySQLDataSource.getInstance as jest.Mock).mockReturnValue({
-      query: jest.fn(), // Initialize the query mock function here
-    });
-
-    const instance = MySQLDataSource.getInstance();
-    mockQuery = instance.query as jest.MockedFunction<typeof instance.query>;
-    context = { logger, dataSources: { sqlDataSource: { query: mockQuery } } };
-
-    const existingOption1 = new QuestionOption({ questionId: 50, text: "Yes", orderNumber: 1, isDefault: true });
-    const existingOption2 = new QuestionOption({ questionId: 50, text: "No", orderNumber: 2, isDefault: false });
-    const existingOption3 = new QuestionOption({ questionId: 50, text: "Maybe", orderNumber: 3, isDefault: false });
-    const existingOptions: QuestionOption[] = [existingOption1, existingOption2, existingOption3];
-
-    const mockGetSectionTagsBySectionId = jest.fn();
-    (QuestionOption.findByQuestionId as jest.Mock) = mockGetSectionTagsBySectionId;
-    mockGetSectionTagsBySectionId.mockResolvedValueOnce(existingOptions);
-  });
-
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('Should return an array of question options', async () => {
-    const questionId = 50;
-    const result = await getExistingQuestionOptions(context, questionId);
-
-    expect(result).toEqual(expect.arrayContaining(expectedResponse));
   });
 });

--- a/src/services/__tests__/questionService.spec.ts
+++ b/src/services/__tests__/questionService.spec.ts
@@ -3,11 +3,12 @@ import { Template } from "../../models/Template";
 import { buildContext, mockToken } from "../../__mocks__/context";
 import { logger } from "../../__mocks__/logger";
 import { MySQLDataSource } from "../../datasources/mySQLDataSource";
-import { cloneQuestion, generateQuestionConditionVersion, generateQuestionVersion, hasPermissionOnQuestion } from "../questionService";
+import { cloneQuestion, generateQuestionConditionVersion, generateQuestionVersion, getExistingQuestionOptions, hasPermissionOnQuestion } from "../questionService";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { hasPermissionOnTemplate } from "../templateService";
 import { NotFoundError } from "../../utils/graphQLErrors";
 import { Question } from "../../models/Question";
+import { QuestionOption } from "../../models/QuestionOption";
 import { VersionedQuestion } from "../../models/VersionedQuestion";
 import { QuestionType } from "../../models/QuestionType";
 import { QuestionCondition, QuestionConditionActionType, QuestionConditionCondition } from "../../models/QuestionCondition";
@@ -243,7 +244,7 @@ describe('generateQuestionVersion', () => {
       obj.modifed = tstamp;
       obj.modifiedById = userId;
 
-      switch(table) {
+      switch (table) {
         case 'questions': {
           questionStore.push(obj);
           break;
@@ -266,7 +267,7 @@ describe('generateQuestionVersion', () => {
         obj.modifiedById = userId;
       }
 
-      switch(table) {
+      switch (table) {
         case 'questions': {
           const existing = questionStore.find((entry) => { return entry.id === obj.id });
           if (!existing) {
@@ -419,7 +420,7 @@ describe('generateQuestionConditionVersion', () => {
       obj.modifed = tstamp;
       obj.modifiedById = userId;
 
-      switch(table) {
+      switch (table) {
         case 'questionConditions': {
           questionConditionStore.push(obj);
           break;
@@ -442,7 +443,7 @@ describe('generateQuestionConditionVersion', () => {
         obj.modifiedById = userId;
       }
 
-      switch(table) {
+      switch (table) {
         case 'questionConditions': {
           const existing = questionConditionStore.find((entry) => { return entry.id === obj.id });
           if (!existing) {
@@ -514,5 +515,64 @@ describe('generateQuestionConditionVersion', () => {
     expect(newVersion.conditionType).toEqual(questionCondition.conditionType);
     expect(newVersion.conditionMatch).toEqual(questionCondition.conditionMatch);
     expect(newVersion.target).toEqual(questionCondition.target);
+  });
+});
+
+describe('getExistingQuestionOptions', () => {
+  let mockQuery;
+
+  const expectedResponse = [
+    expect.objectContaining({
+      questionId: 50,
+      text: 'Yes',
+      orderNumber: 1,
+      isDefault: true,
+    }),
+    expect.objectContaining({
+      questionId: 50,
+      text: 'No',
+      orderNumber: 2,
+      isDefault: false,
+    }),
+    expect.objectContaining({
+      questionId: 50,
+      text: 'Maybe',
+      orderNumber: 3,
+      isDefault: false,
+    }),
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    // Cast getInstance to a jest.Mock type to use mockReturnValue
+    (MySQLDataSource.getInstance as jest.Mock).mockReturnValue({
+      query: jest.fn(), // Initialize the query mock function here
+    });
+
+    const instance = MySQLDataSource.getInstance();
+    mockQuery = instance.query as jest.MockedFunction<typeof instance.query>;
+    context = { logger, dataSources: { sqlDataSource: { query: mockQuery } } };
+
+    const existingOption1 = new QuestionOption({ questionId: 50, text: "Yes", orderNumber: 1, isDefault: true });
+    const existingOption2 = new QuestionOption({ questionId: 50, text: "No", orderNumber: 2, isDefault: false });
+    const existingOption3 = new QuestionOption({ questionId: 50, text: "Maybe", orderNumber: 3, isDefault: false });
+    const existingOptions: QuestionOption[] = [existingOption1, existingOption2, existingOption3];
+
+    const mockGetSectionTagsBySectionId = jest.fn();
+    (QuestionOption.findByQuestionId as jest.Mock) = mockGetSectionTagsBySectionId;
+    mockGetSectionTagsBySectionId.mockResolvedValueOnce(existingOptions);
+  });
+
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should return an array of question options', async () => {
+    const questionId = 50;
+    const result = await getExistingQuestionOptions(context, questionId);
+
+    expect(result).toEqual(expect.arrayContaining(expectedResponse));
   });
 });

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -5,7 +5,6 @@ import { Question } from "../models/Question";
 import { VersionedQuestion } from "../models/VersionedQuestion";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { QuestionCondition } from "../models/QuestionCondition";
-import { QuestionOption } from "../models/QuestionOption";
 import { VersionedQuestionCondition } from "../models/VersionedQuestionCondition";
 import { formatLogMessage, logger } from "../logger";
 
@@ -168,11 +167,5 @@ export const generateQuestionConditionVersion = async (
     formatLogMessage(logger).error(null, `${msg}, errs: ${created.errors}`);
     throw new Error(msg);
   }
-}
-
-export const getExistingQuestionOptions = async (context: MyContext, questionId: number): Promise<QuestionOption[]> => {
-
-  //Get all the existing question options already associated with this question
-  return await QuestionOption.findByQuestionId('questionService', context, questionId);
 }
 

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -5,6 +5,7 @@ import { Question } from "../models/Question";
 import { VersionedQuestion } from "../models/VersionedQuestion";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { QuestionCondition } from "../models/QuestionCondition";
+import { QuestionOption } from "../models/QuestionOption";
 import { VersionedQuestionCondition } from "../models/VersionedQuestionCondition";
 import { formatLogMessage, logger } from "../logger";
 
@@ -168,3 +169,10 @@ export const generateQuestionConditionVersion = async (
     throw new Error(msg);
   }
 }
+
+export const getExistingQuestionOptions = async (context: MyContext, questionId: number): Promise<QuestionOption[]> => {
+
+  //Get all the existing question options already associated with this question
+  return await QuestionOption.findByQuestionId('questionService', context, questionId);
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,17 @@ export type AddQuestionInput = {
   templateId: Scalars['Int']['input'];
 };
 
+export type AddQuestionOptionInput = {
+  /** Whether the option is the default selected one */
+  isDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The option order number */
+  orderNumber: Scalars['Int']['input'];
+  /** The question id that the QuestionOption belongs to */
+  questionId: Scalars['Int']['input'];
+  /** The option text */
+  text: Scalars['String']['input'];
+};
+
 export type AddRepositoryInput = {
   /** A description of the repository */
   description?: InputMaybe<Scalars['String']['input']>;
@@ -551,6 +562,8 @@ export type Mutation = {
   addQuestion: Question;
   /** Create a new QuestionCondition associated with a question */
   addQuestionCondition: QuestionCondition;
+  /** Create a new QuestionOption */
+  addQuestionOption: QuestionOption;
   /** Add a new Repository */
   addRepository?: Maybe<Repository>;
   /** Create a new Section. Leave the 'copyFromVersionedSectionId' blank to create a new section from scratch */
@@ -617,6 +630,8 @@ export type Mutation = {
   removeQuestion?: Maybe<Question>;
   /** Remove a QuestionCondition using a specific QuestionCondition id */
   removeQuestionCondition?: Maybe<QuestionCondition>;
+  /** Delete a QuestionOption */
+  removeQuestionOption?: Maybe<QuestionOption>;
   /** Delete a Repository */
   removeRepository?: Maybe<Repository>;
   /** Delete a section */
@@ -667,6 +682,8 @@ export type Mutation = {
   updateQuestion: Question;
   /** Update a QuestionCondition for a specific QuestionCondition id */
   updateQuestionCondition?: Maybe<QuestionCondition>;
+  /** Update a QuestionOption */
+  updateQuestionOption: QuestionOption;
   /** Separate Question update specifically for options */
   updateQuestionOptions?: Maybe<Question>;
   /** Update a Repository record */
@@ -779,6 +796,11 @@ export type MutationAddQuestionArgs = {
 
 export type MutationAddQuestionConditionArgs = {
   input: AddQuestionConditionInput;
+};
+
+
+export type MutationAddQuestionOptionArgs = {
+  input: AddQuestionOptionInput;
 };
 
 
@@ -963,6 +985,11 @@ export type MutationRemoveQuestionConditionArgs = {
 };
 
 
+export type MutationRemoveQuestionOptionArgs = {
+  questionOptionId: Scalars['Int']['input'];
+};
+
+
 export type MutationRemoveRepositoryArgs = {
   repositoryId: Scalars['Int']['input'];
 };
@@ -1094,6 +1121,11 @@ export type MutationUpdateQuestionArgs = {
 
 export type MutationUpdateQuestionConditionArgs = {
   input: UpdateQuestionConditionInput;
+};
+
+
+export type MutationUpdateQuestionOptionArgs = {
+  input: UpdateQuestionOptionInput;
 };
 
 
@@ -1564,6 +1596,10 @@ export type Query = {
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
   questionConditions?: Maybe<Array<Maybe<QuestionCondition>>>;
+  /** Get the specific Question Option based on questionOptionId */
+  questionOption?: Maybe<QuestionOption>;
+  /** Get the Question Options that belong to the associated questionId */
+  questionOptions?: Maybe<Array<Maybe<QuestionOption>>>;
   /** Get all the QuestionTypes */
   questionTypes?: Maybe<Array<Maybe<QuestionType>>>;
   /** Get the Questions that belong to the associated sectionId */
@@ -1769,6 +1805,16 @@ export type QueryQuestionConditionsArgs = {
 };
 
 
+export type QueryQuestionOptionArgs = {
+  questionOptionId: Scalars['Int']['input'];
+};
+
+
+export type QueryQuestionOptionsArgs = {
+  questionId: Scalars['Int']['input'];
+};
+
+
 export type QueryQuestionsArgs = {
   sectionId: Scalars['Int']['input'];
 };
@@ -1851,6 +1897,8 @@ export type Question = {
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The conditional logic triggered by this question */
   questionConditions?: Maybe<Array<QuestionCondition>>;
+  /** The question options associated with this question */
+  questionOptions?: Maybe<Array<QuestionOption>>;
   /** This will be used as a sort of title for the Question */
   questionText?: Maybe<Scalars['String']['output']>;
   /** The type of question, such as text field, select box, radio buttons, etc */
@@ -1918,6 +1966,31 @@ export type QuestionConditionCondition =
   | 'HAS_ANSWER'
   /** When a question includes a specific value */
   | 'INCLUDES';
+
+/** QuestionOption always belongs to a Question */
+export type QuestionOption = {
+  __typename?: 'QuestionOption';
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<Array<Scalars['String']['output']>>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** Whether the option is the default selected one */
+  isDefault?: Maybe<Scalars['Boolean']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The option order number */
+  orderNumber: Scalars['Int']['output'];
+  /** The question id that the QuestionOption belongs to */
+  questionId: Scalars['Int']['output'];
+  /** The option text */
+  text: Scalars['String']['output'];
+};
 
 /** The type of Question, such as text field, radio buttons, etc */
 export type QuestionType = {
@@ -2256,6 +2329,17 @@ export type UpdateQuestionInput = {
   requirementText?: InputMaybe<Scalars['String']['input']>;
   /** Sample text to possibly provide a starting point or example to answer question */
   sampleText?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateQuestionOptionInput = {
+  /** Whether the option is the default selected one */
+  isDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The option order number */
+  orderNumber: Scalars['Int']['input'];
+  /** The id of the QuestionOption */
+  questionOptionId: Scalars['Int']['input'];
+  /** The option text */
+  text: Scalars['String']['input'];
 };
 
 export type UpdateRepositoryInput = {
@@ -2679,6 +2763,7 @@ export type ResolversTypes = {
   AddProjectOutputInput: AddProjectOutputInput;
   AddQuestionConditionInput: AddQuestionConditionInput;
   AddQuestionInput: AddQuestionInput;
+  AddQuestionOptionInput: AddQuestionOptionInput;
   AddRepositoryInput: AddRepositoryInput;
   AddSectionInput: AddSectionInput;
   Affiliation: ResolverTypeWrapper<Affiliation>;
@@ -2727,6 +2812,7 @@ export type ResolversTypes = {
   QuestionCondition: ResolverTypeWrapper<QuestionCondition>;
   QuestionConditionActionType: QuestionConditionActionType;
   QuestionConditionCondition: QuestionConditionCondition;
+  QuestionOption: ResolverTypeWrapper<QuestionOption>;
   QuestionType: ResolverTypeWrapper<QuestionType>;
   Repository: ResolverTypeWrapper<Repository>;
   RepositorySearchInput: RepositorySearchInput;
@@ -2748,6 +2834,7 @@ export type ResolversTypes = {
   UpdateProjectOutputInput: UpdateProjectOutputInput;
   UpdateQuestionConditionInput: UpdateQuestionConditionInput;
   UpdateQuestionInput: UpdateQuestionInput;
+  UpdateQuestionOptionInput: UpdateQuestionOptionInput;
   UpdateRepositoryInput: UpdateRepositoryInput;
   UpdateSectionInput: UpdateSectionInput;
   User: ResolverTypeWrapper<User>;
@@ -2773,6 +2860,7 @@ export type ResolversParentTypes = {
   AddProjectOutputInput: AddProjectOutputInput;
   AddQuestionConditionInput: AddQuestionConditionInput;
   AddQuestionInput: AddQuestionInput;
+  AddQuestionOptionInput: AddQuestionOptionInput;
   AddRepositoryInput: AddRepositoryInput;
   AddSectionInput: AddSectionInput;
   Affiliation: Affiliation;
@@ -2811,6 +2899,7 @@ export type ResolversParentTypes = {
   Query: {};
   Question: Question;
   QuestionCondition: QuestionCondition;
+  QuestionOption: QuestionOption;
   QuestionType: QuestionType;
   Repository: Repository;
   RepositorySearchInput: RepositorySearchInput;
@@ -2828,6 +2917,7 @@ export type ResolversParentTypes = {
   UpdateProjectOutputInput: UpdateProjectOutputInput;
   UpdateQuestionConditionInput: UpdateQuestionConditionInput;
   UpdateQuestionInput: UpdateQuestionInput;
+  UpdateQuestionOptionInput: UpdateQuestionOptionInput;
   UpdateRepositoryInput: UpdateRepositoryInput;
   UpdateSectionInput: UpdateSectionInput;
   User: User;
@@ -3016,6 +3106,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addProjectOutput?: Resolver<Maybe<ResolversTypes['ProjectOutput']>, ParentType, ContextType, RequireFields<MutationAddProjectOutputArgs, 'input'>>;
   addQuestion?: Resolver<ResolversTypes['Question'], ParentType, ContextType, RequireFields<MutationAddQuestionArgs, 'input'>>;
   addQuestionCondition?: Resolver<ResolversTypes['QuestionCondition'], ParentType, ContextType, RequireFields<MutationAddQuestionConditionArgs, 'input'>>;
+  addQuestionOption?: Resolver<ResolversTypes['QuestionOption'], ParentType, ContextType, RequireFields<MutationAddQuestionOptionArgs, 'input'>>;
   addRepository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, Partial<MutationAddRepositoryArgs>>;
   addSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationAddSectionArgs, 'input'>>;
   addTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationAddTagArgs, 'name'>>;
@@ -3049,6 +3140,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   removeProjectOutputFromPlan?: Resolver<Maybe<ResolversTypes['ProjectOutput']>, ParentType, ContextType, RequireFields<MutationRemoveProjectOutputFromPlanArgs, 'planId' | 'projectOutputId'>>;
   removeQuestion?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<MutationRemoveQuestionArgs, 'questionId'>>;
   removeQuestionCondition?: Resolver<Maybe<ResolversTypes['QuestionCondition']>, ParentType, ContextType, RequireFields<MutationRemoveQuestionConditionArgs, 'questionConditionId'>>;
+  removeQuestionOption?: Resolver<Maybe<ResolversTypes['QuestionOption']>, ParentType, ContextType, RequireFields<MutationRemoveQuestionOptionArgs, 'questionOptionId'>>;
   removeRepository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, RequireFields<MutationRemoveRepositoryArgs, 'repositoryId'>>;
   removeSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationRemoveSectionArgs, 'sectionId'>>;
   removeTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationRemoveTagArgs, 'tagId'>>;
@@ -3074,6 +3166,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateProjectOutput?: Resolver<Maybe<ResolversTypes['ProjectOutput']>, ParentType, ContextType, RequireFields<MutationUpdateProjectOutputArgs, 'input'>>;
   updateQuestion?: Resolver<ResolversTypes['Question'], ParentType, ContextType, RequireFields<MutationUpdateQuestionArgs, 'input'>>;
   updateQuestionCondition?: Resolver<Maybe<ResolversTypes['QuestionCondition']>, ParentType, ContextType, RequireFields<MutationUpdateQuestionConditionArgs, 'input'>>;
+  updateQuestionOption?: Resolver<ResolversTypes['QuestionOption'], ParentType, ContextType, RequireFields<MutationUpdateQuestionOptionArgs, 'input'>>;
   updateQuestionOptions?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<MutationUpdateQuestionOptionsArgs, 'questionId' | 'required'>>;
   updateRepository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, Partial<MutationUpdateRepositoryArgs>>;
   updateSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationUpdateSectionArgs, 'input'>>;
@@ -3294,6 +3387,8 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
   question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
   questionConditions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryQuestionConditionsArgs, 'questionId'>>;
+  questionOption?: Resolver<Maybe<ResolversTypes['QuestionOption']>, ParentType, ContextType, RequireFields<QueryQuestionOptionArgs, 'questionOptionId'>>;
+  questionOptions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionOption']>>>, ParentType, ContextType, RequireFields<QueryQuestionOptionsArgs, 'questionId'>>;
   questionTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionType']>>>, ParentType, ContextType>;
   questions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Question']>>>, ParentType, ContextType, RequireFields<QueryQuestionsArgs, 'sectionId'>>;
   recommendedLicenses?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType, RequireFields<QueryRecommendedLicensesArgs, 'recommended'>>;
@@ -3324,6 +3419,7 @@ export type QuestionResolvers<ContextType = MyContext, ParentType extends Resolv
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   questionConditions?: Resolver<Maybe<Array<ResolversTypes['QuestionCondition']>>, ParentType, ContextType>;
+  questionOptions?: Resolver<Maybe<Array<ResolversTypes['QuestionOption']>>, ParentType, ContextType>;
   questionText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   questionTypeId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
@@ -3347,6 +3443,20 @@ export type QuestionConditionResolvers<ContextType = MyContext, ParentType exten
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   questionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   target?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QuestionOptionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['QuestionOption'] = ResolversParentTypes['QuestionOption']> = {
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  orderNumber?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  questionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  text?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -3624,6 +3734,7 @@ export type Resolvers<ContextType = MyContext> = {
   Query?: QueryResolvers<ContextType>;
   Question?: QuestionResolvers<ContextType>;
   QuestionCondition?: QuestionConditionResolvers<ContextType>;
+  QuestionOption?: QuestionOptionResolvers<ContextType>;
   QuestionType?: QuestionTypeResolvers<ContextType>;
   Repository?: RepositoryResolvers<ContextType>;
   ResearchDomain?: ResearchDomainResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,8 @@ export type AddQuestionInput = {
   guidanceText?: InputMaybe<Scalars['String']['input']>;
   /** Whether or not the Question has had any changes since it was last published */
   isDirty?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Add options for a question type, like radio buttons */
+  questionOptions?: InputMaybe<Array<InputMaybe<QuestionOptionInput>>>;
   /** This will be used as a sort of title for the Question */
   questionText?: InputMaybe<Scalars['String']['input']>;
   /** The type of question, such as text field, select box, radio buttons, etc */
@@ -684,8 +686,6 @@ export type Mutation = {
   updateQuestionCondition?: Maybe<QuestionCondition>;
   /** Update a QuestionOption */
   updateQuestionOption: QuestionOption;
-  /** Separate Question update specifically for options */
-  updateQuestionOptions?: Maybe<Question>;
   /** Update a Repository record */
   updateRepository?: Maybe<Repository>;
   /** Update a Section */
@@ -1126,12 +1126,6 @@ export type MutationUpdateQuestionConditionArgs = {
 
 export type MutationUpdateQuestionOptionArgs = {
   input: UpdateQuestionOptionInput;
-};
-
-
-export type MutationUpdateQuestionOptionsArgs = {
-  questionId: Scalars['Int']['input'];
-  required?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -1992,6 +1986,16 @@ export type QuestionOption = {
   text: Scalars['String']['output'];
 };
 
+/** Input for Question options operations */
+export type QuestionOptionInput = {
+  /** Whether the question option is the default selected one */
+  isDefault?: InputMaybe<Scalars['Boolean']['input']>;
+  /** The order of the question option */
+  orderNumber?: InputMaybe<Scalars['Int']['input']>;
+  /** The text for the question option */
+  text?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** The type of Question, such as text field, radio buttons, etc */
 export type QuestionType = {
   __typename?: 'QuestionType';
@@ -2321,6 +2325,8 @@ export type UpdateQuestionInput = {
   guidanceText?: InputMaybe<Scalars['String']['input']>;
   /** The unique identifier for the Question */
   questionId: Scalars['Int']['input'];
+  /** Update options for a question type like radio buttons */
+  questionOptions?: InputMaybe<Array<InputMaybe<UpdateQuestionOptionInput>>>;
   /** This will be used as a sort of title for the Question */
   questionText?: InputMaybe<Scalars['String']['input']>;
   /** To indicate whether the question is required to be completed */
@@ -2337,7 +2343,7 @@ export type UpdateQuestionOptionInput = {
   /** The option order number */
   orderNumber: Scalars['Int']['input'];
   /** The id of the QuestionOption */
-  questionOptionId: Scalars['Int']['input'];
+  questionOptionId?: InputMaybe<Scalars['Int']['input']>;
   /** The option text */
   text: Scalars['String']['input'];
 };
@@ -2813,6 +2819,7 @@ export type ResolversTypes = {
   QuestionConditionActionType: QuestionConditionActionType;
   QuestionConditionCondition: QuestionConditionCondition;
   QuestionOption: ResolverTypeWrapper<QuestionOption>;
+  QuestionOptionInput: QuestionOptionInput;
   QuestionType: ResolverTypeWrapper<QuestionType>;
   Repository: ResolverTypeWrapper<Repository>;
   RepositorySearchInput: RepositorySearchInput;
@@ -2900,6 +2907,7 @@ export type ResolversParentTypes = {
   Question: Question;
   QuestionCondition: QuestionCondition;
   QuestionOption: QuestionOption;
+  QuestionOptionInput: QuestionOptionInput;
   QuestionType: QuestionType;
   Repository: Repository;
   RepositorySearchInput: RepositorySearchInput;
@@ -3167,7 +3175,6 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateQuestion?: Resolver<ResolversTypes['Question'], ParentType, ContextType, RequireFields<MutationUpdateQuestionArgs, 'input'>>;
   updateQuestionCondition?: Resolver<Maybe<ResolversTypes['QuestionCondition']>, ParentType, ContextType, RequireFields<MutationUpdateQuestionConditionArgs, 'input'>>;
   updateQuestionOption?: Resolver<ResolversTypes['QuestionOption'], ParentType, ContextType, RequireFields<MutationUpdateQuestionOptionArgs, 'input'>>;
-  updateQuestionOptions?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<MutationUpdateQuestionOptionsArgs, 'questionId' | 'required'>>;
   updateRepository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, Partial<MutationUpdateRepositoryArgs>>;
   updateSection?: Resolver<ResolversTypes['Section'], ParentType, ContextType, RequireFields<MutationUpdateSectionArgs, 'input'>>;
   updateTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationUpdateTagArgs, 'name' | 'tagId'>>;


### PR DESCRIPTION
## Description

Needed to make updated to accommodate question options for question types like radio buttons, checkboxes, and select drop-down

- Added data-migration scripts to add `questionOptions` table and seed data
- Added `questionOptions` schema, resolver and `QuestionOption` model, which will be used for `option` question types
- Updated `questions` resolver to add or update `questionOptions` when passed in the mutation
- Added `questionOptions` to schema and updated `question` query and mutations to include `questionOptions`

Fixes # ([172](https://github.com/CDLUC3/dmsp_backend_prototype/issues/172))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
This has been manually tested and tested with unit tests.


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules