### PR TITLE
Add the requestId to the Apollo context and include it in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `requestId` to the Apollo context
 - Added `questionOptions` schema, resolver and `QuestionOption` model, which will be used for `option` question types
 - Added a new query to get all versionedTemplates, called `myVersionedTemplates`, under user's affiliation, and added a new method in the model called `findByAffiliationId`
 - Updated `templates` resolver to handle updates to `sections` and `questions` when copying a `template`
@@ -43,6 +44,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Updated `formatLogMessage` to accept the Apollo context instead of the logger so that it can being to record the `requestId`, `jti` and `userId` (when available)
 - Updated `questionTypes` table to remove 'Rich Text Editor' and to add `usageDescription`. Also, updated Question model's `create` method to allow for entries with duplicate `questionText`
 - Updated User update method to prevent password manipulation
 - Updated User registration so that the terms and conditions must have been accepted

--- a/src/__mocks__/context.ts
+++ b/src/__mocks__/context.ts
@@ -36,6 +36,33 @@ jest.spyOn(MySQLDataSource, 'getInstance').mockImplementation(function () {
 
 const mockedMysqlInstance = MySQLDataSource.getInstance();
 
+// Mock Cache for testing, just has a local storage hash
+let mockCacheStore = {};
+// eslint-disable-next-line  @typescript-eslint/no-extraneous-class
+export class MockCache {
+  public static getInstance() {
+    return {
+      adapter: {
+        set(key: string, val: string): void {
+          mockCacheStore[key] = val;
+        },
+        get(key: string): string {
+          return mockCacheStore[key];
+        },
+        delete(key: string): void {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete mockCacheStore[key];
+        },
+      },
+      getStore() {
+        return mockCacheStore
+      },
+      resetStore(): void {
+        mockCacheStore = {};
+      },
+    }
+  }
+}
 export class MockDMPHubAPI extends DMPHubAPI {
   getData = jest.fn();
   getDMSPs = jest.fn();
@@ -92,10 +119,12 @@ export const mockDataSources = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-export function buildContext(logger: Logger, token: JWTAccessToken = null, _cache: any = null): MyContext {
+export function buildContext(logger: Logger, token: JWTAccessToken = null, cache: any = null): MyContext {
   return {
+    cache: cache,
     token: token,
     logger: logger,
+    requestId: casual.rgb_hex,
     dataSources: mockDataSources,
   }
 }

--- a/src/__mocks__/logger.ts
+++ b/src/__mocks__/logger.ts
@@ -1,7 +1,7 @@
 import pino, { Logger } from 'pino';
+import { MyContext } from '../context';
 
-// Mock a Pino Logger
-const mockLogger = {
+const baseMockLogger = {
   level: jest.fn(),
   fatal: jest.fn(),
   error: jest.fn(),
@@ -9,12 +9,19 @@ const mockLogger = {
   info: jest.fn(),
   debug: jest.fn(),
   trace: jest.fn(),
-  child: jest.fn().mockReturnThis(),
+}
+
+// Mock a Pino Logger
+const mockLogger = {
+  ...baseMockLogger,
+  child() {
+    return baseMockLogger;
+  },
 } as unknown as pino.Logger;
 
 export const logger = mockLogger;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-invalid-void-type
-export function formatLogMessage(logger: Logger, _args: object | void): Logger {
-  return logger;
+export function formatLogMessage(context: MyContext): Logger {
+  return context.logger;
 }

--- a/src/controllers/__tests__/signinController.spec.ts
+++ b/src/controllers/__tests__/signinController.spec.ts
@@ -8,6 +8,10 @@ import * as UserModel from '../../models/User';
 import { defaultLanguageId } from '../../models/Language';
 import { getRandomEnumValue } from '../../__tests__/helpers';
 import { getCurrentDate } from '../../utils/helpers';
+import { logger } from '../../__mocks__/logger';
+import { buildContext, mockToken } from "../../__mocks__/context";
+
+jest.mock('../../context.ts');
 
 // Mocking external dependencies
 jest.mock('../../datasources/cache');
@@ -59,9 +63,13 @@ describe('signinController', () => {
   let mockResponse: Partial<Response>;
   let mockCache: jest.Mocked<Cache>;
   let mockUser;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let context;
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    context = buildContext(logger, mockToken(), null);
 
     mockRequest = {
       body: {
@@ -92,7 +100,7 @@ describe('signinController', () => {
     });
 
     await signinController(mockRequest as Request, mockResponse as Response);
-    expect(generateAuthTokens).toHaveBeenCalledWith(mockCache, mockedUser);
+    expect(generateAuthTokens).toHaveBeenCalled();
     expect(setTokenCookie).toHaveBeenCalledWith(mockResponse, 'dmspt', 'new-access-token', generalConfig.jwtTTL);
     expect(setTokenCookie).toHaveBeenCalledWith(mockResponse, 'dmspr', 'new-refresh-token', generalConfig.jwtRefreshTTL);
     expect(mockResponse.status).toHaveBeenCalledWith(200);

--- a/src/controllers/__tests__/signoutController.spec.ts
+++ b/src/controllers/__tests__/signoutController.spec.ts
@@ -4,6 +4,11 @@ import { Cache } from "../../datasources/cache";
 import { revokeAccessToken, revokeRefreshToken, verifyAccessToken } from '../../services/tokenService';
 import casual from 'casual';
 import { signoutController } from '../signoutController';
+import { logger } from '../../__mocks__/logger';
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { MyContext } from '../../context';
+
+jest.mock('../../context.ts');
 
 // Mocking external dependencies
 jest.mock('../../datasources/cache');
@@ -13,9 +18,13 @@ describe('signoutController', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let mockCache: jest.Mocked<Cache>;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let context: MyContext;
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    context = buildContext(logger, mockToken(), null);
 
     mockRequest = {
       auth: { jti: casual.integer(1, 99999).toString() },
@@ -42,8 +51,8 @@ describe('signoutController', () => {
 
     await signoutController(mockRequest as Request, mockResponse as Response);
 
-    expect(revokeRefreshToken).toHaveBeenCalledWith(mockCache, mockRequest.auth.jti);
-    expect(revokeAccessToken).toHaveBeenCalledWith(mockCache, mockRequest.auth.jti);
+    expect(revokeRefreshToken).toHaveBeenCalled();
+    expect(revokeAccessToken).toHaveBeenCalled();
     expect(mockResponse.clearCookie).toHaveBeenCalledWith('dmspt');
     expect(mockResponse.clearCookie).toHaveBeenCalledWith('dmspr');
     expect(mockResponse.status).toHaveBeenCalledWith(200);

--- a/src/controllers/__tests__/signupController.spec.ts
+++ b/src/controllers/__tests__/signupController.spec.ts
@@ -8,6 +8,13 @@ import { signupController } from '../signupController';
 import { defaultLanguageId } from '../../models/Language';
 import { getCurrentDate } from '../../utils/helpers';
 import { getRandomEnumValue } from '../../__tests__/helpers';
+import { logger } from '../../__mocks__/logger';
+import { buildContext, mockToken } from "../../__mocks__/context";
+
+jest.mock('../../context.ts');
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+let context;
 
 // Mocking external dependencies
 jest.mock('../../datasources/cache');
@@ -63,6 +70,8 @@ describe('signupController', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    context = buildContext(logger, mockToken(), null);
+
     mockRequest = {
       body: {
         email: casual.email,
@@ -97,7 +106,7 @@ describe('signupController', () => {
 
     await signupController(mockRequest as Request, mockResponse as Response);
 
-    expect(generateAuthTokens).toHaveBeenCalledWith(mockCache, mockedUser);
+    expect(generateAuthTokens).toHaveBeenCalled();
     expect(setTokenCookie).toHaveBeenCalledWith(mockResponse, 'dmspt', 'new-access-token', generalConfig.jwtTTL);
     expect(setTokenCookie).toHaveBeenCalledWith(mockResponse, 'dmspr', 'new-refresh-token', generalConfig.jwtRefreshTTL);
     expect(mockResponse.status).toHaveBeenCalledWith(201);

--- a/src/controllers/refreshTokenController.ts
+++ b/src/controllers/refreshTokenController.ts
@@ -9,10 +9,11 @@ export const refreshTokenController = async (req: Request, res: Response) => {
   const refreshToken = req.cookies?.dmspr?.toString();
 
   if (refreshToken) {
+    const cache = Cache.getInstance();
+    const context = buildContext(logger, cache);
+
     try {
-      const cache = Cache.getInstance();
-      const context = buildContext(logger, cache);
-      const newAccessToken = await refreshAccessToken(cache, context, refreshToken);
+      const newAccessToken = await refreshAccessToken(context, refreshToken);
 
       if (newAccessToken) {
         // Set the new access token
@@ -25,7 +26,7 @@ export const refreshTokenController = async (req: Request, res: Response) => {
         res.status(401).json({ success: false, message: 'Refresh token has expired' });
       }
     } catch (err) {
-      formatLogMessage(logger).error(err, 'refreshTokenController error');
+      formatLogMessage(context)?.error(err, 'refreshTokenController error');
       res.status(401).json({ success: false, message: 'Server error: unable to refresh tokens at this time' });
     }
   } else {

--- a/src/controllers/signinController.ts
+++ b/src/controllers/signinController.ts
@@ -8,13 +8,14 @@ import { buildContext } from '../context';
 
 export const signinController = async (req: Request, res: Response) => {
   const userIn = new User(req.body);
+  const cache = Cache.getInstance();
+  const context = buildContext(logger, cache);
+
   try {
-    const cache = Cache.getInstance();
-    const context = buildContext(logger, cache);
     const user = await userIn.login(context) || null;
 
     if (user) {
-      const { accessToken, refreshToken } = await generateAuthTokens(cache, user);
+      const { accessToken, refreshToken } = await generateAuthTokens(context, user);
       // Record the login and generate the tokens
       if (accessToken && refreshToken) {
         // Set the tokens as HTTP only cookies
@@ -29,7 +30,7 @@ export const signinController = async (req: Request, res: Response) => {
       res.status(401).json({ success: false, message: 'Invalid credentials' });
     }
   } catch (err) {
-    formatLogMessage(logger).error(err, 'Signin error')
+    formatLogMessage(context)?.error(err, 'Signin error');
     res.status(500).json({ success: false, message: 'Internal server error' });
   }
 };

--- a/src/controllers/signoutController.ts
+++ b/src/controllers/signoutController.ts
@@ -3,26 +3,29 @@ import { Response } from 'express';
 import { Cache } from "../datasources/cache";
 import { revokeAccessToken, revokeRefreshToken, verifyAccessToken } from '../services/tokenService';
 import { formatLogMessage, logger } from '../logger';
+import { buildContext } from '../context';
 
 export const signoutController = async (req: Request, res: Response) => {
+  const cache = Cache.getInstance();
+  const context = buildContext(logger, cache);
+
   try {
     // For some reason req.auth is `undefined` here even though authMiddleware is called.
     // It's in req.cookies though :/
     const accessToken = req.cookies?.dmspt;
 
     if (accessToken) {
-      const token = verifyAccessToken(accessToken);
+      const token = verifyAccessToken(context, accessToken);
 
       // Clear the old cookies from the response
       res.clearCookie('dmspt');
       res.clearCookie('dmspr');
 
       if (token && token.jti) {
-        const cache = Cache.getInstance();
         // Delete the refresh token from the cache
-        if (await revokeRefreshToken(cache, token.jti)) {
+        if (await revokeRefreshToken(context, token.jti)) {
           // Add the access token to the black list so that token is immediately invalidated
-          await revokeAccessToken(cache, token.jti);
+          await revokeAccessToken(context, token.jti);
           res.status(200).json({});
         } else {
           res.status(500).json({ success: true, message: 'Unable to sign out at this time' });
@@ -34,7 +37,7 @@ export const signoutController = async (req: Request, res: Response) => {
       res.status(200).json({});
     }
   } catch (err) {
-    formatLogMessage(logger).error(err, 'Signout error!');
+    formatLogMessage(context)?.error(err, 'Signout error!');
     res.status(500).json({ error: 'An unexpected error occurred' });
   }
 }

--- a/src/controllers/signupController.ts
+++ b/src/controllers/signupController.ts
@@ -45,8 +45,7 @@ export const signupController = async (req: Request, res: Response) => {
         }
 
         // Generate the tokens
-        const { accessToken, refreshToken } = await generateAuthTokens(cache, user);
-
+        const { accessToken, refreshToken } = await generateAuthTokens(context, user);
         if (accessToken && refreshToken) {
           // Set the tokens as HTTP only cookies
           setTokenCookie(res, 'dmspt', accessToken, generalConfig.jwtTTL);
@@ -61,7 +60,7 @@ export const signupController = async (req: Request, res: Response) => {
       res.status(500).json({ success: false, message: 'Unable to register the account.' });
     }
   } catch (err) {
-    formatLogMessage(logger, { msg: `Signup error. userId: ${user.id}, error: ${err?.message}` });
+    formatLogMessage(context)?.error({ err, user }, 'Signup error');
     res.status(500).json({ success: false, message: 'Internal server error' });
   }
 };

--- a/src/datasources/cache.ts
+++ b/src/datasources/cache.ts
@@ -3,7 +3,7 @@ import KeyvRedis from "@keyv/redis";
 import Redis from "ioredis";
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
 import { autoFailoverEnabled, cacheConfig, connectTimeout } from "../config/cacheConfig";
-import { logger, formatLogMessage } from '../logger';
+import { logger } from '../logger';
 
 // Note that Redis cache clusters require you to wrap keys in `{}` to ensure that they are stored
 // near one another and are able to be set and fetched.
@@ -16,7 +16,7 @@ export class Cache {
     let cache;
 
     // Setup the Redis Cluster
-    formatLogMessage(logger).info(cacheConfig, 'Attempting to connect to Redis');
+    logger.info(cacheConfig, 'Attempting to connect to Redis');
 
     if (['development', 'test'].includes(process.env.NODE_ENV)) {
       // We are running locally, so use we are dealing with a single Redis node
@@ -54,15 +54,15 @@ export class Cache {
     const keyV = new Keyv(new KeyvRedis(cache)) as any;
 
     keyV.on('connect', () => {
-      formatLogMessage(logger).info(null, `Redis connection established`);
+      logger.info(null, `Redis connection established`);
     });
 
     keyV.on('error', (err) => {
-      formatLogMessage(logger).error(err, `Redis connection error - ${err.message}`);
+      logger.error(err, `Redis connection error - ${err.message}`);
     });
 
     keyV.on('close', () => {
-      formatLogMessage(logger).info( null, `Redis connection closed`);
+      logger.info( null, `Redis connection closed`);
     });
 
     // Set the Adapter which will be used to interact with the cache

--- a/src/datasources/dmphubAPI.ts
+++ b/src/datasources/dmphubAPI.ts
@@ -1,12 +1,13 @@
 import { RESTDataSource } from "@apollo/datasource-rest";
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
-import { logger, formatLogMessage } from '../logger';
+import { logger } from '../logger';
 import { DmspModel as Dmsp } from "../models/Dmsp"
 import { JWTAccessToken } from '../services/tokenService';
 
 export class DMPHubAPI extends RESTDataSource {
   override baseURL = process.env.DMPHUB_API_BASE_URL;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private token: JWTAccessToken;
 
   constructor(options: { cache: KeyValueCache, token: JWTAccessToken }) {
@@ -51,13 +52,13 @@ export class DMPHubAPI extends RESTDataSource {
 
   // Fetch a specific DMSP by its DMP ID
   async getDMSP(dmspID: string) {
-    formatLogMessage(logger).info(`Calling DMPHub: ${this.baseURL}/dmps/${dmspID}`)
+    logger.info({ dmphubUrl: this.baseURL, dmspID }, 'Calling DMPHub');
     try {
       const id = this.dmspIdWithoutProtocol(dmspID);
       const response = await this.get<Dmsp>(`dmps/${encodeURI(id)}`);
       return this.handleResponse(response);
     } catch(err) {
-      formatLogMessage(logger, { err }).error('Error calling DMPHub API getDMSP.')
+      logger.error({ err, dmspID, dmphubURL: this.baseURL }, 'Error calling the DMPHub API');
       throw(err);
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 import pino, { Logger } from 'pino';
 import { ecsFormat } from '@elastic/ecs-pino-format';
+import { MyContext } from './context';
 
 const logLevel = process.env.LOG_LEVEL || 'info';
 
@@ -10,14 +11,28 @@ const logLevel = process.env.LOG_LEVEL || 'info';
  */
 export const logger: Logger = pino({ level: logLevel, ...ecsFormat })
 
-// Add the additional args to the ECS logger so that they are queryable fields.
-// At least you should send the sessionId if available and the error (if applicable)
+// Format a log message with information from the Apollo server context.
+// Attaches the unique Request Id, and the user's JTI and UserId from the token.
+//
+// The message and any payload information can be included in the normal logger function.
+//    For example:  `formatLogMessage(context).debug({ foo: bar }, 'My log message');
+//
+// The log messages will include a numeric `level` that corresponds to the log level.
+//    For example: 10 = trace, 20 = debug, 30 = info, 40 = debug, 50 = error, 60 = fatal
+//
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-export function formatLogMessage(logger: Logger, args: object | void): Logger {
-  if (args) {
-    // Add the args to the ECS logger
-    return logger.child({ ...args });
+export function formatLogMessage(context: MyContext): Logger {
+  const args = {
+    requestId: context?.requestId,
+    jti: context?.token?.jti,
+    userId: context?.token?.id,
   }
+
+  // Append the Apollo context args
+  if (args.requestId || args.userId || args.jti) {
+    return context.logger.child({ ...args });
+  }
+
   // Otherwise there were no additional arfs, so return the logger as-is
-  return logger;
+  return context.logger;
 }

--- a/src/middleware/express.ts
+++ b/src/middleware/express.ts
@@ -6,7 +6,8 @@ import { Request } from 'express-jwt';
 import { formatLogMessage } from '../logger';
 
 export async function attachApolloServer(apolloServer: ApolloServer, cache, logger) {
-  formatLogMessage(logger).info(null, 'Attaching Apollo server');
+  const context = buildContext(logger, cache);
+  formatLogMessage(context).info(null, 'Attaching Apollo server');
 
   // expressMiddleware accepts the same arguments:
   //   an Apollo Server instance and optional configuration options

--- a/src/models/ContributorRole.ts
+++ b/src/models/ContributorRole.ts
@@ -47,7 +47,7 @@ export class ContributorRole extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, projectContributorId };
       const msg = 'Unable to add the contributor role to the project contributor';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -63,7 +63,7 @@ export class ContributorRole extends MySqlModel {
     if (!results) {
       const payload = { contributorRoleId: this.id, projectContributorId };
       const msg = 'Unable to remove the contributor role from the project contributor';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;

--- a/src/models/MetadataStandard.ts
+++ b/src/models/MetadataStandard.ts
@@ -147,7 +147,7 @@ export class MetadataStandard extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, projectOutputId };
       const msg = 'Unable to add the standard to the project output';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -163,7 +163,7 @@ export class MetadataStandard extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, projectOutputId };
       const msg = 'Unable to remove the standard from the project output';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -139,18 +139,18 @@ export class MySqlModel {
       const vals = values.map((entry) => this.prepareValue(entry, typeof (entry)));
 
       try {
-        formatLogMessage(logger).debug(logMessage);
-        const resp = await dataSources.sqlDataSource.query(sql, vals);
+        formatLogMessage(apolloContext).debug(logMessage);
+        const resp = await dataSources.sqlDataSource.query(apolloContext, sql, vals);
         return Array.isArray(resp) ? resp : [resp];
       } catch (err) {
         const msg = `${reference}, ERROR: ${err.message}`;
-        formatLogMessage(logger).error(msg);
+        formatLogMessage(apolloContext).error(err, msg);
         return [];
       }
     }
     const errMsg = `${reference}, ERROR: apolloContext and sqlStatement are required.`;
     if (logger) {
-      formatLogMessage(logger).error(errMsg);
+      formatLogMessage(apolloContext).error(errMsg);
     } else {
       // In the event that there was no logger!
       console.log(errMsg);

--- a/src/models/Repository.ts
+++ b/src/models/Repository.ts
@@ -159,7 +159,7 @@ export class Repository extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, projectOutputId };
       const msg = 'Unable to add the repository to the project output';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -175,7 +175,7 @@ export class Repository extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, projectOutputId };
       const msg = 'Unable to remove the repository from the project output';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;

--- a/src/models/ResearchDomain.ts
+++ b/src/models/ResearchDomain.ts
@@ -128,7 +128,7 @@ export class ResearchDomain extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, metadataStandardId };
       const msg = 'Unable to add the research domain to the metadata standard';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -146,7 +146,7 @@ export class ResearchDomain extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, repositoryId };
       const msg = 'Unable to add the research domain to the repository';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -162,7 +162,7 @@ export class ResearchDomain extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, metadataStandardId };
       const msg = 'Unable to remove the research domain from the metadata standard';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;
@@ -178,7 +178,7 @@ export class ResearchDomain extends MySqlModel {
     if (!results) {
       const payload = { researchDomainId: this.id, repositoryId };
       const msg = 'Unable to remove the research domain from the repository';
-      formatLogMessage(context.logger).error(payload, `${reference} - ${msg}`);
+      formatLogMessage(context).error(payload, `${reference} - ${msg}`);
       return false;
     }
     return true;

--- a/src/models/UserEmail.ts
+++ b/src/models/UserEmail.ts
@@ -132,7 +132,7 @@ export class UserEmail extends MySqlModel {
 
         if (created) {
           // Send out an email confirmation notification. No async, can happen in background
-          sendEmailConfirmationNotification(created.email);
+          sendEmailConfirmationNotification(context, created.email);
         }
         return created;
       }

--- a/src/models/__tests__/UserEmail.spec.ts
+++ b/src/models/__tests__/UserEmail.spec.ts
@@ -205,6 +205,8 @@ describe('confirmEmail', () => {
   let mockDelete;
 
   beforeEach(() => {
+    context = buildContext(logger);
+
     mockUserEmail = new UserEmail({ id: casual.integer(1, 99), email: mockUser.email, userId: mockUser.id });
 
     mockOtherEmails = [

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -35,7 +35,7 @@ export const resolvers: Resolvers = {
         const affiliation = new Affiliation(input);
         return await affiliation.create(context);
       } catch (err) {
-        formatLogMessage(context.logger).error(err, 'Failure in addAffiliation rsolver');
+        formatLogMessage(context).error(err, 'Failure in addAffiliation rsolver');
         throw InternalServerError();
       }
     },
@@ -61,7 +61,7 @@ export const resolvers: Resolvers = {
         }
         throw ForbiddenError();
       } catch (err) {
-        formatLogMessage(context.logger).error(err, 'Failure in updateAffiliation resolver');
+        formatLogMessage(context).error(err, 'Failure in updateAffiliation resolver');
         throw InternalServerError();
       }
     },
@@ -78,7 +78,7 @@ export const resolvers: Resolvers = {
         }
         throw ForbiddenError();
       } catch (err) {
-        formatLogMessage(context.logger).error(err, 'Failure in removeAffiliation rsolver');
+        formatLogMessage(context).error(err, 'Failure in removeAffiliation rsolver');
         throw InternalServerError();
       }
     },

--- a/src/resolvers/contributor.ts
+++ b/src/resolvers/contributor.ts
@@ -68,7 +68,7 @@ export const resolvers: Resolvers = {
           }
           return created
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -132,7 +132,7 @@ export const resolvers: Resolvers = {
           // Otherwise there were errors so return the object with errors
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -168,7 +168,7 @@ export const resolvers: Resolvers = {
           }
           return deleted
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/funder.ts
+++ b/src/resolvers/funder.ts
@@ -53,7 +53,7 @@ export const resolvers: Resolvers = {
           const created = await newFunder.create(context, project.id);
           return created
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -83,7 +83,7 @@ export const resolvers: Resolvers = {
           const updated = await toUpdate.update(context);
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -109,7 +109,7 @@ export const resolvers: Resolvers = {
           const deleted = await funder.delete(context);
           return deleted
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/license.ts
+++ b/src/resolvers/license.ts
@@ -28,7 +28,7 @@ export const resolvers: Resolvers = {
           const newLicense = new License({ name, uri, description, recommended});
           return await newLicense.create(context);
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in addLicense resolver');
+          formatLogMessage(context).error(err, 'Failure in addLicense resolver');
           throw InternalServerError();
         }
       } else {
@@ -47,7 +47,7 @@ export const resolvers: Resolvers = {
           const toUpdate = new License({ id: license.id, uri: license.uri, name, description, recommended });
           return await toUpdate.update(context);
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in updateLicense resolver');
+          formatLogMessage(context).error(err, 'Failure in updateLicense resolver');
           throw InternalServerError();
         }
       } else {
@@ -67,7 +67,7 @@ export const resolvers: Resolvers = {
           //       or notify that it is being done and to what DMPs
           return await license.delete(context);
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeLicense resolver');
+          formatLogMessage(context).error(err, 'Failure in removeLicense resolver');
           throw InternalServerError();
         }
       } else {
@@ -108,7 +108,7 @@ export const resolvers: Resolvers = {
           await toRemove.delete(context);
           return toKeep;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeLicense resolver');
+          formatLogMessage(context).error(err, 'Failure in removeLicense resolver');
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/metadataStandard.ts
+++ b/src/resolvers/metadataStandard.ts
@@ -41,7 +41,7 @@ export const resolvers: Resolvers = {
           }
           return created
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in addMetadataStandard resolver');
+          formatLogMessage(context).error(err, 'Failure in addMetadataStandard resolver');
           throw InternalServerError();
         }
       } else {
@@ -97,7 +97,7 @@ export const resolvers: Resolvers = {
           // Otherwise there were errors so return the object with errors
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -121,7 +121,7 @@ export const resolvers: Resolvers = {
           // No need to remove the related research domain associations the DB will cascade the deletion
           return deleted
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeMetadataStandard resolver');
+          formatLogMessage(context).error(err, 'Failure in removeMetadataStandard resolver');
           throw InternalServerError();
         }
       } else {
@@ -167,7 +167,7 @@ export const resolvers: Resolvers = {
           await toRemove.delete(context);
           return toKeep;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeMetadataStandard resolver');
+          formatLogMessage(context).error(err, 'Failure in removeMetadataStandard resolver');
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/output.ts
+++ b/src/resolvers/output.ts
@@ -151,7 +151,7 @@ export const resolvers: Resolvers = {
 
           return created;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -194,7 +194,7 @@ export const resolvers: Resolvers = {
           // Otherwise there were errors so return the object with errors
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -222,7 +222,7 @@ export const resolvers: Resolvers = {
           // the DB will cascade the deletion.
           return deleted
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -41,7 +41,7 @@ export const resolvers: Resolvers = {
           const created = await newProject.create(context);
           return created
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in addProject resolver');
+          formatLogMessage(context).error(err, 'Failure in addProject resolver');
           throw InternalServerError();
         }
       } else {
@@ -64,7 +64,7 @@ export const resolvers: Resolvers = {
           const updated = await toUpdate.update(context);
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in updateProject resolver');
+          formatLogMessage(context).error(err, 'Failure in updateProject resolver');
           throw InternalServerError();
         }
       } else {
@@ -90,7 +90,7 @@ export const resolvers: Resolvers = {
           const deleted = await project.delete(context);
           return deleted
         } catch(err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeProject resolver');
+          formatLogMessage(context).error(err, 'Failure in removeProject resolver');
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/repository.ts
+++ b/src/resolvers/repository.ts
@@ -49,7 +49,7 @@ export const resolvers: Resolvers = {
           }
           return created
         } catch (err) {
-          formatLogMessage(context.logger).error(err, 'Failure in addRepository resolver');
+          formatLogMessage(context).error(err, 'Failure in addRepository resolver');
           throw InternalServerError();
         }
       } else {
@@ -105,7 +105,7 @@ export const resolvers: Resolvers = {
           // Otherwise there were errors so return the object with errors
           return updated;
         } catch(err) {
-          formatLogMessage(context.logger).error(err, `Failure in ${reference}`);
+          formatLogMessage(context).error(err, `Failure in ${reference}`);
           throw InternalServerError();
         }
       } else {
@@ -127,7 +127,7 @@ export const resolvers: Resolvers = {
           // No need to remove the related research domain associations the DB will cascade the deletion
           return deleted
         } catch (err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeRepository resolver');
+          formatLogMessage(context).error(err, 'Failure in removeRepository resolver');
           throw InternalServerError();
         }
       } else {
@@ -182,7 +182,7 @@ export const resolvers: Resolvers = {
           await toRemove.delete(context);
           return toKeep;
         } catch (err) {
-          formatLogMessage(context.logger).error(err, 'Failure in removeRepository resolver');
+          formatLogMessage(context).error(err, 'Failure in removeRepository resolver');
           throw InternalServerError();
         }
       } else {

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -8,17 +8,11 @@ import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError
 import { defaultLanguageId } from "../models/Language";
 import { anonymizeUser, mergeUsers } from "../services/userService";
 import { processOtherAffiliationName } from "../services/affiliationService";
-import { formatLogMessage } from "../logger";
 
 export const resolvers: Resolvers = {
   Query: {
     // returns the current User
     me: async (_, __, context: MyContext): Promise<User> => {
-
-formatLogMessage(context).info(null, 'Example A');
-formatLogMessage(context).info('Example B');
-
-
       if (isAuthorized(context?.token)) {
         return await User.findById('me resolver', context, context.token.id);
       }

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -8,11 +8,17 @@ import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError
 import { defaultLanguageId } from "../models/Language";
 import { anonymizeUser, mergeUsers } from "../services/userService";
 import { processOtherAffiliationName } from "../services/affiliationService";
+import { formatLogMessage } from "../logger";
 
 export const resolvers: Resolvers = {
   Query: {
     // returns the current User
     me: async (_, __, context: MyContext): Promise<User> => {
+
+formatLogMessage(context).info(null, 'Example A');
+formatLogMessage(context).info('Example B');
+
+
       if (isAuthorized(context?.token)) {
         return await User.findById('me resolver', context, context.token.id);
       }

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -40,7 +40,7 @@ describe('sendEmail', () => {
   it('sends the confirmation email', async () => {
     jest.spyOn(logger, 'info');
     const email = casual.email;
-    const sent = await sendEmailConfirmationNotification(email);
+    const sent = await sendEmailConfirmationNotification(context, email);
 
     const expectedSubject = `${subjectPrefix} - ${emailSubjects.emailConfirmation}`
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -30,6 +30,6 @@ export const hasPermissionOnProject = async (context: MyContext, project: Projec
   }
 
   const payload = { projectId: project.id, userId: context.token.id };
-  formatLogMessage(context.logger).error(payload, `AUTH failure: ${reference}`)
+  formatLogMessage(context).error(payload, `AUTH failure: ${reference}`)
   return false;
 }

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -6,7 +6,7 @@ import { VersionedQuestion } from "../models/VersionedQuestion";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { QuestionCondition } from "../models/QuestionCondition";
 import { VersionedQuestionCondition } from "../models/VersionedQuestionCondition";
-import { formatLogMessage, logger } from "../logger";
+import { formatLogMessage } from "../logger";
 
 // Determine whether the specified user has permission to access the Section
 export const hasPermissionOnQuestion = async (context: MyContext, templateId: number): Promise<boolean> => {
@@ -87,18 +87,18 @@ export const generateQuestionVersion = async (
         } else {
           // There were errors on the object so report them
           const msg = `Unable to generateQuestionVersion for question: ${question.id}, errs: ${updated.errors}`;
-          formatLogMessage(logger).error(null, msg);
+          formatLogMessage(context).error(null, msg);
           throw new Error(msg);
         }
       }
     } else {
       // There were errors on the object so report them
       const msg = `Unable to generateQuestionVersion for versionedQuestion errs: ${saved.errors}`;
-      formatLogMessage(logger).error(null, msg);
+      formatLogMessage(context).error(null, msg);
       throw new Error(msg);
     }
   } catch (err) {
-    formatLogMessage(logger).error(err, `Unable to generateQuestionVersion for question: ${question.id}`);
+    formatLogMessage(context).error(err, `Unable to generateQuestionVersion for question: ${question.id}`);
     throw err
   }
 
@@ -164,8 +164,7 @@ export const generateQuestionConditionVersion = async (
   } else {
     // There were errors on the object so report them
     const msg = `Unable to generateQuestionConditionVersion for questionCondition errs: ${created.errors}`
-    formatLogMessage(logger).error(null, `${msg}, errs: ${created.errors}`);
+    formatLogMessage(context).error(null, `${msg}, errs: ${created.errors}`);
     throw new Error(msg);
   }
 }
-

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -8,7 +8,7 @@ import { VersionedSection } from "../models/VersionedSection";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { Question } from "../models/Question";
 import { generateQuestionVersion } from "./questionService";
-import { formatLogMessage, logger } from "../logger";
+import { formatLogMessage } from "../logger";
 
 // Creates a new Version/Snapshot the specified Section (as a point in time snapshot)
 //    - Creates a new VersionedSection including all of the related Questions
@@ -69,17 +69,17 @@ export const generateSectionVersion = async (
           return true;
         } else {
           const msg = `Unable to generateSectionVersion for section: ${section.id}, errs: ${updated.errors}`;
-          formatLogMessage(logger).error(null, msg);
+          formatLogMessage(context).error(null, msg);
           throw new Error(msg);
         }
       }
     } else {
       const msg = `Unable to generateSectionVersion for versionedSection errs: ${created.errors}`;
-      formatLogMessage(logger).error(null, msg);
+      formatLogMessage(context).error(null, msg);
       throw new Error(msg);
     }
   } catch (err) {
-    formatLogMessage(logger).error(err, `Unable to generateSectionVersion for section: ${section.id}`);
+    formatLogMessage(context).error(err, `Unable to generateSectionVersion for section: ${section.id}`);
     throw err;
   }
 

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -6,7 +6,7 @@ import { isSuperAdmin } from "./authService";
 import { TemplateCollaborator } from "../models/Collaborator";
 import { Section } from "../models/Section";
 import { generateSectionVersion } from "./sectionService";
-import { formatLogMessage, logger } from "../logger";
+import { formatLogMessage } from "../logger";
 
 
 // Determine whether the specified user has permission to access the Template
@@ -28,7 +28,7 @@ export const hasPermissionOnTemplate = async (context: MyContext, template: Temp
   }
 
   const payload = { templateId: template.id, userId: context.token.id };
-  formatLogMessage(context.logger).error(payload, 'AUTH failure: hasPermissionOnTemplate')
+  formatLogMessage(context).error(payload, 'AUTH failure: hasPermissionOnTemplate')
   return false;
 }
 
@@ -114,17 +114,17 @@ export const generateTemplateVersion = async (
           return created;
         } else {
           const msg = `Unable to generateTemplateVersion for template: ${template.id}, errs: ${updated.errors}`;
-          formatLogMessage(logger).error(null, msg);
+          formatLogMessage(context).error(null, msg);
           throw new Error(msg);
         }
       }
     } catch (err) {
-      formatLogMessage(logger).error(err, `Unable to generateTemplateVersion for id: ${template.id}`);
+      formatLogMessage(context).error(err, `Unable to generateTemplateVersion for id: ${template.id}`);
       throw new Error(err.message);
     }
   } else {
     const msg = `Unable to generateTemplateVersion for versionedTemplate errs: ${created.errors}`;
-    formatLogMessage(logger).error(null, msg);
+    formatLogMessage(context).error(null, msg);
     throw new Error(msg);
   }
   // Something went wrong, so return a null instead

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -6,7 +6,12 @@ import { logger, formatLogMessage } from '../logger';
 import { User } from '../models/User';
 import { generalConfig } from '../config/generalConfig';
 import { UserRole } from '../models/User';
-import { AuthenticationError, DEFAULT_INTERNAL_SERVER_MESSAGE, DEFAULT_UNAUTHORIZED_MESSAGE, InternalServerError } from '../utils/graphQLErrors';
+import {
+  AuthenticationError,
+  DEFAULT_INTERNAL_SERVER_MESSAGE,
+  DEFAULT_UNAUTHORIZED_MESSAGE,
+  InternalServerError
+} from '../utils/graphQLErrors';
 import { Cache } from '../datasources/cache';
 import { MyContext } from '../context';
 import { defaultLanguageId } from '../models/Language';
@@ -54,13 +59,13 @@ export const generateCSRFToken = async (cache: Cache): Promise<string> => {
     await cache.adapter.set(`{csrf}:${csrfToken}`, hashedToken, { ttl: generalConfig.csrfTTL });
     return csrfToken;
   } catch(err) {
-    formatLogMessage(logger).error(err, 'generateCSRFToken error!');
+    logger.error(err, 'generateCSRFToken error!');
     return null;
   }
 }
 
 // Generate an access token for the User
-const generateAccessToken = (jti: string, user: User): string => {
+const generateAccessToken = (context: MyContext, jti: string, user: User): string => {
   try {
     const payload: JWTAccessToken = {
       id: user.id,
@@ -73,18 +78,17 @@ const generateAccessToken = (jti: string, user: User): string => {
       jti,
       expiresIn: generalConfig.jwtTTL,
     };
-
     return jwt.sign(payload, generalConfig.jwtSecret as string, { expiresIn: generalConfig.jwtTTL });
   } catch(err) {
-    if (logger) {
-      formatLogMessage(logger).error(err, `generateAccessToken error - ${err.message}`);
+    if (context?.logger) {
+      formatLogMessage(context).error(err, `generateAccessToken error - ${err.message}`);
     }
     throw AuthenticationError(`${DEFAULT_UNAUTHORIZED_MESSAGE} - ${err.message}`);
   }
 }
 
 // Generate a refresh token for the User and add it to the Cache.
-const generateRefreshToken = async (cache: Cache, jti: string, userId: number): Promise<string> => {
+const generateRefreshToken = async (context: MyContext, jti: string, userId: number): Promise<string> => {
   try {
     const payload: JWTRefreshToken = {
       jti,
@@ -94,31 +98,33 @@ const generateRefreshToken = async (cache: Cache, jti: string, userId: number): 
 
     const token = jwt.sign(payload, generalConfig.jwtRefreshSecret, { expiresIn: generalConfig.jwtRefreshTTL });
     const hashedToken = hashToken(token);
+
     // Add the refresh token to the Cache
-    await cache.adapter.set(`{dmspr}:${jti}`, hashedToken, { ttl: generalConfig.jwtRefreshTTL })
+    await context.cache.adapter.set(`{dmspr}:${jti}`, hashedToken, { ttl: generalConfig.jwtRefreshTTL })
     return token;
   } catch(err) {
-    if (logger) {
-      formatLogMessage(logger).error(err, `generateRefreshToken error - ${err.message}`);
+    if (context?.logger) {
+      formatLogMessage(context).error(err, `generateRefreshToken error - ${err.message}`);
     }
     throw AuthenticationError(`${DEFAULT_UNAUTHORIZED_MESSAGE} - ${err.message}`);
   }
 }
 
 // Generate an Access Token and a Refresh Token
-export const generateAuthTokens = async (cache: Cache, user: User): Promise<{ accessToken: string; refreshToken: string }> => {
+export const generateAuthTokens = async (context: MyContext, user: User): Promise<{ accessToken: string; refreshToken: string }> => {
   if (generalConfig.jwtSecret && generalConfig.jwtRefreshSecret && user && user.id && user.email) {
     try {
       // Generate a unique id for the JWT
       const jti = `${user.id}-${new Date().getTime()}`;
       // Generate an Access Token
-      const accessToken = generateAccessToken(jti, user);
+      const accessToken = generateAccessToken(context, jti, user);
+
       // Generate a Refresh Token
-      const refreshToken = await generateRefreshToken(cache, jti, user.id);
+      const refreshToken = await generateRefreshToken(context, jti, user.id);
 
       return { accessToken, refreshToken };
     } catch(err) {
-      formatLogMessage(logger).error(err, 'generateAuthTokens - unable to generate tokens');
+      formatLogMessage(context).error(err, 'generateAuthTokens - unable to generate tokens');
     }
   }
   return { accessToken: null, refreshToken: null };
@@ -133,13 +139,13 @@ export const verifyCSRFToken = async (cache: Cache, csrfToken: string): Promise<
     const calculatedHash = hashToken(csrfToken);
     return timingSafeEqual(Buffer.from(storedHash), Buffer.from(calculatedHash));
   } catch(err) {
-    formatLogMessage(logger).error(err, 'verifyCSRFToken failure');
+    logger.error(err, 'verifyCSRFToken failure');
     return false;
   }
 }
 
 // Verify the Incoming Access Token. The express-jwt middleware handles this in most circumstances
-export const verifyAccessToken = (accessToken: string): JwtPayload => {
+export const verifyAccessToken = (context: MyContext, accessToken: string): JwtPayload => {
   try {
     const now = new Date().getTime();
     const token = jwt.verify(accessToken, generalConfig.jwtSecret) as JwtPayload;
@@ -149,26 +155,26 @@ export const verifyAccessToken = (accessToken: string): JwtPayload => {
       return token;
     }
   } catch(err) {
-    formatLogMessage(logger).error(err, `verifyAccessToken error`);
+    formatLogMessage(context).error(err, `verifyAccessToken error`);
   }
   return null;
 }
 
 // Verify a Refresh Token
-const verifyRefreshToken = async (cache: Cache, refreshToken: string): Promise<JWTRefreshToken> => {
+const verifyRefreshToken = async (context: MyContext, refreshToken: string): Promise<JWTRefreshToken> => {
   try {
     const token = jwt.verify(refreshToken, generalConfig.jwtRefreshSecret) as JWTRefreshToken;
 
     if (token) {
       // Make sure the token hasn't been tampered with
-      const storedHash = await cache.adapter.get(`{dmspr}:${token.jti}`);
+      const storedHash = await context.cache.adapter.get(`{dmspr}:${token.jti}`);
       const calculatedHash = hashToken(refreshToken);
       return timingSafeEqual(Buffer.from(storedHash), Buffer.from(calculatedHash)) ? token : null;
     }
     return null;
   } catch(err) {
     if (logger) {
-      formatLogMessage(logger).error(err, `verifyRefreshToken error - ${err.message}`);
+      formatLogMessage(context).error(err, 'verifyRefreshToken error');
     }
     throw AuthenticationError(`${DEFAULT_UNAUTHORIZED_MESSAGE} - Invalid refresh token`);
   }
@@ -185,11 +191,12 @@ export const isRevokedCallback = async (req: Express.Request, token?: jwt.Jwt): 
       try {
         // See if the JTI is in the black list
         if (await cache.adapter.get(`{dmspbl}:${jti}`)) {
-          formatLogMessage(logger).warn(`Attempt to access revoked access token! jti: ${jti}`);
+          // We don't have access to the Apollo context here so log normally
+          logger.warn(`Attempt to access revoked access token! jti: ${jti}`);
           return true;
         }
       } catch(err) {
-        formatLogMessage(logger).error(err, 'isRevokedCallback - unable to fetch token from cache');
+        logger.error(err, 'isRevokedCallback - unable to fetch token from cache');
       }
     }
   }
@@ -198,46 +205,45 @@ export const isRevokedCallback = async (req: Express.Request, token?: jwt.Jwt): 
 
 // Refresh the Access and Refresh Tokens
 export const refreshAccessToken = async (
-  cache: Cache,
   context: MyContext,
   refreshToken: string,
 ): Promise<string> => {
   try {
-    const verifiedRefreshToken = await verifyRefreshToken(cache, refreshToken);
+    const verifiedRefreshToken = await verifyRefreshToken(context, refreshToken);
     if (verifiedRefreshToken) {
       // TODO: We can eventually add some checks here to see if the account if locked or deactivated
       const user = await User.findById('refreshAccessToken', context, verifiedRefreshToken.id);
       if (user) {
-        return generateAccessToken(verifiedRefreshToken.jti, user);
+        return generateAccessToken(context, verifiedRefreshToken.jti, user);
       }
     }
     // Otherwise the refresh token was invalid or something else went wrong!
     throw AuthenticationError();
   } catch (err) {
     if (logger) {
-      formatLogMessage(logger).error(err, `refreshAccessToken error - ${err.message}`);
+      formatLogMessage(context).error(err, 'refreshAccessToken error');
     }
     throw AuthenticationError(err.message);
   }
 };
 
 // Invalidate the Refresh Token (e.g., on logout or token rotation)
-export const revokeRefreshToken = async (cache: Cache, jti: string): Promise<boolean> => {
+export const revokeRefreshToken = async (context: MyContext, jti: string): Promise<boolean> => {
   try {
-    await cache.adapter.delete(`{dmspr}:${jti}`);
+    await context.cache.adapter.delete(`{dmspr}:${jti}`);
     return true;
   } catch(err) {
-    formatLogMessage(logger).error(err, `revokeRefreshToken unable to delete token from cache - ${err.message}`);
+    formatLogMessage(context).error(err, `revokeRefreshToken unable to delete token from cache - ${err.message}`);
     throw InternalServerError(`${DEFAULT_INTERNAL_SERVER_MESSAGE} - ${err.message}`);
   }
 };
 
-export const revokeAccessToken = async (cache: Cache, jti: string): Promise<boolean> => {
+export const revokeAccessToken = async (context: MyContext, jti: string): Promise<boolean> => {
   try {
-    await cache.adapter.set(`{dmspbl}:${jti}`, new Date().toISOString(), { ttl: generalConfig.jwtTTL });
+    await context.cache.adapter.set(`{dmspbl}:${jti}`, new Date().toISOString(), { ttl: generalConfig.jwtTTL });
     return true;
   } catch(err) {
-    formatLogMessage(logger).error(err, `revokeAccessToken unable to add token to black list - ${err.message}`);
+    formatLogMessage(context).error(err, `revokeAccessToken unable to add token to black list - ${err.message}`);
     throw InternalServerError(`${DEFAULT_INTERNAL_SERVER_MESSAGE} - ${err.message}`);
   }
 }


### PR DESCRIPTION
## Description

Fixes #190 

- Added `requestId` to the Apollo context
- Updated the `formatLogMessage` function so that it includes the following fields (when available) on each request: `requestId`, `jti` and `userId`

@jupiter007 the core changes are in `src/context.ts` and `src/logger.ts` the majority of the other changes are updated to accommodate the fact that `formatLogMessage` now take the Apollo context as its argument instead of logger

## Type of change
Please delete options that are not relevant

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

All unit tests are passing, the Apollo server loads and I can run queries in the explorer

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules