### PR TITLE
Added useSampleTextAsDefault to question table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `useSampleTextAsDefault` column to questions table
 - Added `requestId` to the Apollo context
 - Added `questionOptions` schema, resolver and `QuestionOption` model, which will be used for `option` question types
 - Added a new query to get all versionedTemplates, called `myVersionedTemplates`, under user's affiliation, and added a new method in the model called `findByAffiliationId`

--- a/data-migrations/2025-02-07-0310-add-column-to-questions.sql
+++ b/data-migrations/2025-02-07-0310-add-column-to-questions.sql
@@ -1,0 +1,3 @@
+# This is a boolean to use the content from `sampleText` as the default answer
+ALTER TABLE `questions`
+ADD COLUMN `useSampleTextAsDefault` TINYINT(1) NOT NULL DEFAULT 0 AFTER `sampleText`;

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -11,6 +11,7 @@ export class Question extends MySqlModel {
   public requirementText?: string;
   public guidanceText?: string;
   public sampleText?: string;
+  public useSampleTextAsDefault?: boolean;
   public required: boolean;
   public displayOrder: number;
   public isDirty: boolean;
@@ -29,6 +30,7 @@ export class Question extends MySqlModel {
     this.requirementText = options.requirementText;
     this.guidanceText = options.guidanceText;
     this.sampleText = options.sampleText;
+    this.useSampleTextAsDefault = options.useSampleTextAsDefault;
     this.required = options.required || false;
     this.displayOrder = options.displayOrder;
     this.isDirty = options.isDirty || false;

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -30,7 +30,7 @@ export class Question extends MySqlModel {
     this.requirementText = options.requirementText;
     this.guidanceText = options.guidanceText;
     this.sampleText = options.sampleText;
-    this.useSampleTextAsDefault = options.useSampleTextAsDefault;
+    this.useSampleTextAsDefault = options.useSampleTextAsDefault || false;
     this.required = options.required || false;
     this.displayOrder = options.displayOrder;
     this.isDirty = options.isDirty || false;

--- a/src/models/__tests__/Question.spec.ts
+++ b/src/models/__tests__/Question.spec.ts
@@ -33,8 +33,6 @@ describe('Question', () => {
   }
   beforeEach(() => {
     question = new Question(questionData);
-
-    console.log("***QUESTION", question);
   });
 
   it('should initialize options as expected', () => {

--- a/src/models/__tests__/Question.spec.ts
+++ b/src/models/__tests__/Question.spec.ts
@@ -28,10 +28,13 @@ describe('Question', () => {
     requirementText: casual.sentences(3),
     guidanceText: casual.sentences(10),
     sampleText: casual.sentences(10),
+    useSampleTextAsDefault: true,
     displayOrder: casual.integer(1, 20),
   }
   beforeEach(() => {
     question = new Question(questionData);
+
+    console.log("***QUESTION", question);
   });
 
   it('should initialize options as expected', () => {
@@ -40,6 +43,7 @@ describe('Question', () => {
     expect(question.requirementText).toEqual(questionData.requirementText);
     expect(question.guidanceText).toEqual(questionData.guidanceText);
     expect(question.sampleText).toEqual(questionData.sampleText);
+    expect(question.useSampleTextAsDefault).toEqual(questionData.useSampleTextAsDefault);
     expect(question.displayOrder).toEqual(questionData.displayOrder);
     expect(question.required).toEqual(false);
   });

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -39,6 +39,7 @@ export const resolvers: Resolvers = {
       requirementText,
       guidanceText,
       sampleText,
+      useSampleTextAsDefault,
       required,
       questionOptions } }, context: MyContext): Promise<Question> => {
 
@@ -54,6 +55,7 @@ export const resolvers: Resolvers = {
           requirementText,
           guidanceText,
           sampleText,
+          useSampleTextAsDefault,
           required
         });
 
@@ -96,6 +98,7 @@ export const resolvers: Resolvers = {
       requirementText,
       guidanceText,
       sampleText,
+      useSampleTextAsDefault,
       required,
       questionOptions } }, context: MyContext): Promise<Question> => {
 
@@ -120,6 +123,7 @@ export const resolvers: Resolvers = {
           requirementText: requirementText,
           guidanceText: guidanceText,
           sampleText: sampleText,
+          useSampleTextAsDefault: useSampleTextAsDefault,
           required: required,
           isDirty: questionData.isDirty
         });

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -93,6 +93,7 @@ export const resolvers: Resolvers = {
     },
     updateQuestion: async (_, { input: {
       questionId,
+      questionTypeId,
       displayOrder,
       questionText,
       requirementText,
@@ -118,7 +119,7 @@ export const resolvers: Resolvers = {
           templateId: questionData.templateId,
           createdById: questionData.createdById,
           displayOrder: displayOrder,
-          questionTypeId: questionData.questionTypeId,
+          questionTypeId: questionTypeId || questionData.questionTypeId,
           questionText: questionText,
           requirementText: requirementText,
           guidanceText: guidanceText,

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -93,6 +93,8 @@ input AddQuestionInput {
 input UpdateQuestionInput {
     "The unique identifier for the Question"
     questionId: Int!
+    "The type of question, such as text field, select box, radio buttons, etc"
+    questionTypeId: Int
     "The display order of the Question"
     displayOrder: Int
     "This will be used as a sort of title for the Question"

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -52,6 +52,8 @@ type Question {
     guidanceText: String
     "Sample text to possibly provide a starting point or example to answer question"
     sampleText: String
+    "Boolean indicating whether we should use content from sampleText as the default answer"
+    useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
 
@@ -80,6 +82,8 @@ input AddQuestionInput {
     guidanceText: String
     "Sample text to possibly provide a starting point or example to answer question"
     sampleText: String
+    "Boolean indicating whether we should use content from sampleText as the default answer"
+    useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
     "Add options for a question type, like radio buttons"
@@ -99,6 +103,8 @@ input UpdateQuestionInput {
     guidanceText: String
     "Sample text to possibly provide a starting point or example to answer question"
     sampleText: String
+    "Boolean indicating whether we should use content from sampleText as the default answer"
+    useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
     "Update options for a question type like radio buttons"

--- a/src/types.ts
+++ b/src/types.ts
@@ -2351,6 +2351,8 @@ export type UpdateQuestionInput = {
   questionOptions?: InputMaybe<Array<InputMaybe<UpdateQuestionOptionInput>>>;
   /** This will be used as a sort of title for the Question */
   questionText?: InputMaybe<Scalars['String']['input']>;
+  /** The type of question, such as text field, select box, radio buttons, etc */
+  questionTypeId?: InputMaybe<Scalars['Int']['input']>;
   /** To indicate whether the question is required to be completed */
   required?: InputMaybe<Scalars['Boolean']['input']>;
   /** Requirements associated with the Question */

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,8 @@ export type AddQuestionInput = {
   sectionId: Scalars['Int']['input'];
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['input'];
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AddQuestionOptionInput = {
@@ -1925,6 +1927,8 @@ export type Question = {
   sourceQestionId?: Maybe<Scalars['Int']['output']>;
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['output'];
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /**
@@ -2353,6 +2357,8 @@ export type UpdateQuestionInput = {
   requirementText?: InputMaybe<Scalars['String']['input']>;
   /** Sample text to possibly provide a starting point or example to answer question */
   sampleText?: InputMaybe<Scalars['String']['input']>;
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type UpdateQuestionOptionInput = {
@@ -3458,6 +3464,7 @@ export type QuestionResolvers<ContextType = MyContext, ParentType extends Resolv
   sectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sourceQestionId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   templateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  useSampleTextAsDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 


### PR DESCRIPTION
## Description

Added `useSampleTextAsDefault` boolean to questions table. This will allow users to set the `sampleText` field from the Edit/Add Question form as the `default` answer.

Fixes # ([192](https://github.com/CDLUC3/dmsp_backend_prototype/issues/192))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Tested this in Apollo Explorer, and with the frontend changes in this PR: https://github.com/CDLUC3/dmsp_frontend_prototype/pull/304

##To Test
- Grab the frontend branch `feature/JS-hook-up-edit-question-and-add-change-type-function`
- Log in and navigate to something like `template/15/q/new?section_id=67` if you logged in with `super@example.com`
- Select `Text Area` as your question type and fill out the Question form and check the `useSampleTextAsDefault` and click `Save`. You should see the new question appear in the `questions` db table with the `useSampleTextAsDefault` set to 1.

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules