### PR TITLE
[Bug] - Update researchDomain because parentResearchDomain is always returning null

### DIFF
--- a/src/controllers/signinController.ts
+++ b/src/controllers/signinController.ts
@@ -17,10 +17,6 @@ export const signinController = async (req: Request, res: Response) => {
     if (user) {
       const { accessToken, refreshToken } = await generateAuthTokens(context, user);
 
-console.log('User:', user);
-console.log('Access Token:');
-console.log(accessToken);
-
       // Record the login and generate the tokens
       if (accessToken && refreshToken) {
         // Set the tokens as HTTP only cookies

--- a/src/models/ResearchDomain.ts
+++ b/src/models/ResearchDomain.ts
@@ -9,6 +9,7 @@ export class ResearchDomain extends MySqlModel {
   public name: string;
   public uri: string;
   public description?: string;
+  public parentResearchDomainId?: number;
   public parentResearchDomain: ResearchDomain;
 
   private tableName = 'researchDomains';
@@ -20,6 +21,7 @@ export class ResearchDomain extends MySqlModel {
     this.name = options.name;
     this.uri = options.uri;
     this.description = options.description;
+    this.parentResearchDomainId = options.parentResearchDomainId;
     this.parentResearchDomain = options.parentResearchDomain;
   }
 
@@ -226,7 +228,7 @@ export class ResearchDomain extends MySqlModel {
   }
 
   // Fetch a ResearchDomain by it's id
-  static async findById(reference: string, context: MyContext, researchDomainId: number): Promise<ResearchDomain> {
+  static async findById(reference: string, context: MyContext, researchDomainId: number): Promise<ResearchDomain | null> {
     const sql = `SELECT * FROM researchDomains WHERE id = ?`;
     const results = await ResearchDomain.query(context, sql, [researchDomainId?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new ResearchDomain(results[0]) : null;
@@ -245,3 +247,4 @@ export class ResearchDomain extends MySqlModel {
     return Array.isArray(results) && results.length > 0 ? new ResearchDomain(results[0]) : null;
   }
 };
+

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -182,13 +182,5 @@ export const resolvers: Resolvers = {
       );
     },
   },
-  ResearchDomain: {
-    parentResearchDomain: async (parent: ResearchDomain, _, context: MyContext): Promise<ResearchDomain | null> => {
-      if (parent.parentResearchDomainId) {
-        return await ResearchDomain.findById('ResearchDomain.parentResearchDomain', context, parent.parentResearchDomainId);
-      }
-      return null;
-    },
-  },
 };
 

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -68,7 +68,7 @@ export const resolvers: Resolvers = {
               newProject.addError('general', 'Unable to create Project');
             }
             return newProject;
-          } catch(err) {
+          } catch (err) {
             formatLogMessage(context).error(err, `Failure in ${reference}`);
             throw InternalServerError();
           }
@@ -100,7 +100,7 @@ export const resolvers: Resolvers = {
             const toUpdate = new Project(input);
             const updated = await toUpdate.update(context);
             return updated;
-          } catch(err) {
+          } catch (err) {
             formatLogMessage(context).error(err, `Failure in ${reference}`);
             throw InternalServerError();
           }
@@ -134,7 +134,7 @@ export const resolvers: Resolvers = {
             //       been published
             const deleted = await project.delete(context);
             return deleted
-          } catch(err) {
+          } catch (err) {
             formatLogMessage(context).error(err, `Failure in ${reference}`);
             throw InternalServerError();
           }
@@ -150,12 +150,15 @@ export const resolvers: Resolvers = {
   },
 
   Project: {
-    researchDomain: async (parent: Project, _, context: MyContext): Promise<ResearchDomain> => {
-      return await ResearchDomain.findById(
-        'Chained Project.researchDomain',
-        context,
-        parent.researchDomainId
-      );
+    researchDomain: async (parent: Project, _, context: MyContext): Promise<ResearchDomain | null> => {
+      if (parent.researchDomainId) {
+        return await ResearchDomain.findById(
+          'Chained Project.researchDomain',
+          context,
+          parent.researchDomainId
+        );
+      }
+      return null;
     },
     contributors: async (parent: Project, _, context: MyContext): Promise<ProjectContributor[]> => {
       return await ProjectContributor.findByProjectId(
@@ -179,4 +182,13 @@ export const resolvers: Resolvers = {
       );
     },
   },
+  ResearchDomain: {
+    parentResearchDomain: async (parent: ResearchDomain, _, context: MyContext): Promise<ResearchDomain | null> => {
+      if (parent.parentResearchDomainId) {
+        return await ResearchDomain.findById('ResearchDomain.parentResearchDomain', context, parent.parentResearchDomainId);
+      }
+      return null;
+    },
+  },
 };
+

--- a/src/resolvers/researchDomain.ts
+++ b/src/resolvers/researchDomain.ts
@@ -40,4 +40,13 @@ export const resolvers: Resolvers = {
       }
     },
   },
+  ResearchDomain: {
+    parentResearchDomain: async (parent: ResearchDomain, _, context: MyContext): Promise<ResearchDomain | null> => {
+      if (parent.parentResearchDomainId) {
+        return await ResearchDomain.findById('ResearchDomain.parentResearchDomain', context, parent.parentResearchDomainId);
+      }
+      return null;
+    },
+  },
 };
+

--- a/src/schemas/researchDomain.ts
+++ b/src/schemas/researchDomain.ts
@@ -31,6 +31,8 @@ export const typeDefs = gql`
     description: String
     "The parent research domain (if applicable). If this is blank then it is a top level domain."
     parentResearchDomain: ResearchDomain
+    "The ID of the parent research domain (if applicable)"
+    parentResearchDomainId: Int
     "The child research domains (if applicable)"
     childResearchDomains: [ResearchDomain!]
   }
@@ -47,3 +49,4 @@ export const typeDefs = gql`
     childResearchDomainIds: String
   }
 `;
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -2373,6 +2373,8 @@ export type ResearchDomain = {
   name: Scalars['String']['output'];
   /** The parent research domain (if applicable). If this is blank then it is a top level domain. */
   parentResearchDomain?: Maybe<ResearchDomain>;
+  /** The ID of the parent research domain (if applicable) */
+  parentResearchDomainId?: Maybe<Scalars['Int']['output']>;
   /** The taxonomy URL of the research domain */
   uri: Scalars['String']['output'];
 };
@@ -4239,6 +4241,7 @@ export type ResearchDomainResolvers<ContextType = MyContext, ParentType extends 
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   parentResearchDomain?: Resolver<Maybe<ResolversTypes['ResearchDomain']>, ParentType, ContextType>;
+  parentResearchDomainId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };


### PR DESCRIPTION

## Description

While I was working on [#351](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/351), I noticed that I wasn't able to get any data returned for parentResearchDomain. It was always null, even though a parentResearchDomainId existed.

Fixes # ([215](https://github.com/CDLUC3/dmsp_backend_prototype/issues/215))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules