### PR TITLE
Fix for missing data from PlanSearchResult

### DIFF
--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from "graphql";
 import { MyContext } from "../context";
-import { Plan, PlanSearchResult } from "../models/Plan";
+import { Plan, PlanSearchResult, PlanSectionProgress } from "../models/Plan";
 import { formatLogMessage } from "../logger";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
@@ -85,6 +85,15 @@ export const resolvers: Resolvers = {
     funders: async (parent: Plan, _, context: MyContext): Promise<PlanFunder[]> => {
       if (parent?.id) {
         return await PlanFunder.findByPlanId('plan funders resolver', context, parent.id);
+      }
+      return [];
+    }
+  },
+
+  PlanSearchResult: {
+    sections: async (parent: PlanSearchResult, _, context: MyContext): Promise<PlanSectionProgress[]> => {
+      if (parent?.id) {
+        return await PlanSectionProgress.findByPlanId('plan sections resolver', context, parent.id);
       }
       return [];
     }

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -36,9 +36,6 @@ export const typeDefs = gql`
     "The timestamp when the Object was last modifed"
     modified: String
 
-    "The template the plan is based on"
-    versionedTemplateId: Int!
-
     "The title of the plan"
     title: String
     "The current status of the plan"
@@ -54,7 +51,25 @@ export const typeDefs = gql`
     "The name of the funder"
     funder: String
     "The names of the contributors"
-    contributors: String!
+    contributors: String
+    "The name of the template the plan is based on"
+    templateTtitle: String
+    "The section search results"
+    sections: [PlanSectionProgress!]
+  }
+
+  "The progress the user has made within a section of the plan"
+  type PlanSectionProgress {
+    "The id of the Section"
+    sectionId: Int!
+    "The title of the section"
+    sectionTitle: String!
+    "The display order of the section"
+    displayOrder: Int!
+    "The number of questions in the section"
+    totalQuestions: Int!
+    "The number of questions the user has answered"
+    answeredQuestions: Int!
   }
 
   enum PlanDownloadFormat {

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -53,7 +53,7 @@ export const typeDefs = gql`
     "The names of the contributors"
     contributors: String
     "The name of the template the plan is based on"
-    templateTtitle: String
+    templateTitle: String
     "The section search results"
     sections: [PlanSectionProgress!]
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1535,7 +1535,7 @@ export type PlanSearchResult = {
   /** The current status of the plan */
   status?: Maybe<PlanStatus>;
   /** The name of the template the plan is based on */
-  templateTtitle?: Maybe<Scalars['String']['output']>;
+  templateTitle?: Maybe<Scalars['String']['output']>;
   /** The title of the plan */
   title?: Maybe<Scalars['String']['output']>;
   /** The visibility/permission setting */
@@ -4190,7 +4190,7 @@ export type PlanSearchResultResolvers<ContextType = MyContext, ParentType extend
   registeredBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sections?: Resolver<Maybe<Array<ResolversTypes['PlanSectionProgress']>>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;
-  templateTtitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  templateTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   visibility?: Resolver<Maybe<ResolversTypes['PlanVisibility']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1511,7 +1511,7 @@ export type PlanOutputErrors = {
 export type PlanSearchResult = {
   __typename?: 'PlanSearchResult';
   /** The names of the contributors */
-  contributors: Scalars['String']['output'];
+  contributors?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
@@ -1530,14 +1530,31 @@ export type PlanSearchResult = {
   registered?: Maybe<Scalars['String']['output']>;
   /** The person who published/registered the plan */
   registeredBy?: Maybe<Scalars['String']['output']>;
+  /** The section search results */
+  sections?: Maybe<Array<PlanSectionProgress>>;
   /** The current status of the plan */
   status?: Maybe<PlanStatus>;
+  /** The name of the template the plan is based on */
+  templateTtitle?: Maybe<Scalars['String']['output']>;
   /** The title of the plan */
   title?: Maybe<Scalars['String']['output']>;
-  /** The template the plan is based on */
-  versionedTemplateId: Scalars['Int']['output'];
   /** The visibility/permission setting */
   visibility?: Maybe<PlanVisibility>;
+};
+
+/** The progress the user has made within a section of the plan */
+export type PlanSectionProgress = {
+  __typename?: 'PlanSectionProgress';
+  /** The number of questions the user has answered */
+  answeredQuestions: Scalars['Int']['output'];
+  /** The display order of the section */
+  displayOrder: Scalars['Int']['output'];
+  /** The id of the Section */
+  sectionId: Scalars['Int']['output'];
+  /** The title of the section */
+  sectionTitle: Scalars['String']['output'];
+  /** The number of questions in the section */
+  totalQuestions: Scalars['Int']['output'];
 };
 
 /** The status/state of the plan */
@@ -3488,6 +3505,7 @@ export type ResolversTypes = {
   PlanOutput: ResolverTypeWrapper<PlanOutput>;
   PlanOutputErrors: ResolverTypeWrapper<PlanOutputErrors>;
   PlanSearchResult: ResolverTypeWrapper<PlanSearchResult>;
+  PlanSectionProgress: ResolverTypeWrapper<PlanSectionProgress>;
   PlanStatus: PlanStatus;
   PlanVersion: ResolverTypeWrapper<PlanVersion>;
   PlanVisibility: PlanVisibility;
@@ -3621,6 +3639,7 @@ export type ResolversParentTypes = {
   PlanOutput: PlanOutput;
   PlanOutputErrors: PlanOutputErrors;
   PlanSearchResult: PlanSearchResult;
+  PlanSectionProgress: PlanSectionProgress;
   PlanVersion: PlanVersion;
   Project: Project;
   ProjectCollaborator: ProjectCollaborator;
@@ -4159,7 +4178,7 @@ export type PlanOutputErrorsResolvers<ContextType = MyContext, ParentType extend
 };
 
 export type PlanSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanSearchResult'] = ResolversParentTypes['PlanSearchResult']> = {
-  contributors?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  contributors?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   dmpId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -4169,10 +4188,20 @@ export type PlanSearchResultResolvers<ContextType = MyContext, ParentType extend
   modifiedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sections?: Resolver<Maybe<Array<ResolversTypes['PlanSectionProgress']>>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;
+  templateTtitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  versionedTemplateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   visibility?: Resolver<Maybe<ResolversTypes['PlanVisibility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PlanSectionProgressResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanSectionProgress'] = ResolversParentTypes['PlanSectionProgress']> = {
+  answeredQuestions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  displayOrder?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sectionTitle?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  totalQuestions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -4939,6 +4968,7 @@ export type Resolvers<ContextType = MyContext> = {
   PlanOutput?: PlanOutputResolvers<ContextType>;
   PlanOutputErrors?: PlanOutputErrorsResolvers<ContextType>;
   PlanSearchResult?: PlanSearchResultResolvers<ContextType>;
+  PlanSectionProgress?: PlanSectionProgressResolvers<ContextType>;
   PlanVersion?: PlanVersionResolvers<ContextType>;
   Project?: ProjectResolvers<ContextType>;
   ProjectCollaborator?: ProjectCollaboratorResolvers<ContextType>;


### PR DESCRIPTION
## Description

additional PR for #187

- Added `PlanSectionProgress` to schema as a child of `PlanSearchResult`
- Added `templateTtitle` to `PlanSearchResult`

It can be queryied like this:
```
query Plans($projectId: Int!) {
  plans(projectId: $projectId) {
    id
    templateTitle
    sections {
      sectionId
      sectionTitle
      displayOrder
      totalQuestions
      answeredQuestions
    }
  }
}
```
With results that look like:
```
{
  "plans": [
      {
        "id": 2,
        "templateTtitle": null,
        "sections": [
          {
            "sectionId": 383,
            "sectionTitle": "UCOP template phase 1, section 1",
            "displayOrder": 1,
            "totalQuestions": 3,
            "answeredQuestions": 0
          },
        }
      ]
    }
  ]
}
``

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in Apollo explorer and updated unit tests

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules