### PR TITLE
minor tweak to migration file because mysql doesn't allow JSON fields…

### DIFF
--- a/data-migrations/2024-12-17-1309-create-plans.sql
+++ b/data-migrations/2024-12-17-1309-create-plans.sql
@@ -23,7 +23,7 @@ CREATE TABLE `planContributors` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
   `planId` INT NOT NULL,
   `projectContributorId` INT NOT NULL,
-  `roles` JSON NOT NULL DEFAULT '[]',
+  `roles` JSON NOT NULL,
   `createdById` INT NOT NULL,
   `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modifiedById` INT NOT NULL,


### PR DESCRIPTION
Discovered a bug when trying to rebuild the database from scratch in the AWS dev environment.

MySQL doesn't allow JSON columns to have a default value.