### PR TITLE
Temporary changes to run by Brian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed bugs related to addPlanContributor and updatePlanContributor since these were not working without missing contributorRoles
 - Converted DateTimeISO to String in schemas so that dates could be inserted into mariaDB database, and updated MySqlModel and associated unit test
 
 ## v0.0.1

--- a/src/models/Contributor.ts
+++ b/src/models/Contributor.ts
@@ -50,10 +50,10 @@ export class ProjectContributor extends MySqlModel {
     if (!this.surName && !this.email && !this.orcid) {
       this.addError('general', 'You must specify at least one name, ORCID or email');
     }
-    if (this.orcid && this.orcid.trim().length > 0){
+    if (this.orcid && this.orcid.trim().length > 0) {
       try {
         validateOrcid(this.orcid);
-      } catch(err) {
+      } catch (err) {
         this.addError('orcid', err.message);
       }
     }
@@ -65,7 +65,7 @@ export class ProjectContributor extends MySqlModel {
   }
 
   //Create a new ProjectContributor
-  async create(context: MyContext, projectId: number ): Promise<ProjectContributor> {
+  async create(context: MyContext, projectId: number): Promise<ProjectContributor> {
     const reference = 'ProjectContributor.create';
 
     // First make sure the record is valid
@@ -255,13 +255,12 @@ export class PlanContributor extends MySqlModel {
   // Validation to be used prior to saving the record
   async isValid(): Promise<boolean> {
     await super.isValid();
-
     if (!this.planId) this.addError('planId', 'Plan can\'t be blank');
     if (!this.projectContributorId) this.addError('projectContributorId', 'Project contributor can\'t be blank');
 
-    if (this.contributorRoleIds.length === 0) {
-      this.addError('contributorRoleIds', 'You must specify at least one role');
-    }
+    // if (this.contributorRoleIds.length === 0) {
+    //   this.addError('contributorRoleIds', 'You must specify at least one role');
+    // }
 
     return Object.keys(this.errors).length === 0;
   }
@@ -374,5 +373,11 @@ export class PlanContributor extends MySqlModel {
     const sql = `SELECT * FROM ${this.tableName} WHERE planId = ? ORDER BY isPrimaryContact DESC`;
     const results = await PlanContributor.query(context, sql, [planId?.toString()], reference);
     return Array.isArray(results) ? results.map((item) => new PlanContributor(item)) : [];
+  }
+
+  static async findPrimaryByPlanId(reference: string, context: MyContext, planId: number): Promise<PlanContributor> {
+    const sql = `SELECT * FROM ${this.tableName} WHERE planId = ? AND isPrimaryContact = 1`;
+    const results = await PlanContributor.query(context, sql, [planId?.toString()], reference);
+    return Array.isArray(results) && results.length > 0 ? new PlanContributor(results[0]) : null;
   }
 }

--- a/src/models/Contributor.ts
+++ b/src/models/Contributor.ts
@@ -258,9 +258,9 @@ export class PlanContributor extends MySqlModel {
     if (!this.planId) this.addError('planId', 'Plan can\'t be blank');
     if (!this.projectContributorId) this.addError('projectContributorId', 'Project contributor can\'t be blank');
 
-    // if (this.contributorRoleIds.length === 0) {
-    //   this.addError('contributorRoleIds', 'You must specify at least one role');
-    // }
+    if (this.contributorRoleIds.length === 0) {
+      this.addError('contributorRoleIds', 'You must specify at least one role');
+    }
 
     return Object.keys(this.errors).length === 0;
   }

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -278,14 +278,14 @@ export class MySqlModel {
   // Return a list of the ids to delete, idsToBeRemoved,  and a list of ids to add idsToBeSaved
   static reconcileAssociationIds(
     idsOnCurrentRecord: number[],
-    idsOnNewRecord: number[]
-  ): { idsToBeRemoved: number[], idsToBeSaved: number[] } {
+    idsOnNewRecord?: number[]
+  ): { idsToBeRemoved: number[], idsToBeSaved: number[] | undefined } {
     const current = new Set<number>(idsOnCurrentRecord);
     const wanted = new Set<number>(idsOnNewRecord);
 
     return {
       idsToBeRemoved: idsOnCurrentRecord.filter((id) => !wanted.has(id)),
-      idsToBeSaved: idsOnNewRecord.filter((id) => !current.has(id))
+      idsToBeSaved: idsOnNewRecord ? idsOnNewRecord.filter((id) => !current.has(id)) : []
     }
   }
 }

--- a/src/resolvers/contributor.ts
+++ b/src/resolvers/contributor.ts
@@ -9,6 +9,7 @@ import { MyContext } from '../context';
 import { isAuthorized } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
 import { hasPermissionOnProject } from '../services/projectService';
+import { updateContributorRoles } from '../services/planService';
 import { GraphQLError } from 'graphql';
 import { Plan } from '../models/Plan';
 
@@ -247,13 +248,17 @@ export const resolvers: Resolvers = {
           const plan = await Plan.findById(reference, context, planId);
           const projectContributor = await ProjectContributor.findById(reference, context, projectContributorId);
 
+          // For now, planContributor roles will match the projectContributor roles
+          const roles = await ContributorRole.findByProjectContributorId(reference, context, projectContributorId);
+          const currentProjectRoleIds = roles ? roles.map((d) => d.id) : [];
+
           if (!plan || !projectContributor) {
             throw NotFoundError();
           }
 
           const project = await Project.findById(reference, context, projectContributor.projectId);
           if (hasPermissionOnProject(context, project)) {
-            const newPlanContributor = new PlanContributor({ planId, projectContributorId });
+            const newPlanContributor = new PlanContributor({ planId, projectContributorId, contributorRoleIds: currentProjectRoleIds });
             const created = await newPlanContributor.create(context);
 
             if (!created?.id) {
@@ -300,7 +305,7 @@ export const resolvers: Resolvers = {
     },
 
     // update an existing PlanContributor
-    updatePlanContributor: async (_, { planId, planContributorId, contributorRoleIds, isPrimaryContact }, context) => {
+    updatePlanContributor: async (_, { planId, planContributorId, projectContributorId, contributorRoleIds, isPrimaryContact }, context) => {
       const reference = 'updatePlanContributor resolver';
       try {
         if (isAuthorized(context.token)) {
@@ -309,80 +314,58 @@ export const resolvers: Resolvers = {
             throw NotFoundError();
           }
 
-          // Fetch the project and run a permission check
-          const projectContributor = await ProjectContributor.findById(
-            reference,
-            context,
-            contributor.projectContributorId
-          );
+          const projectContributor = await ProjectContributor.findById(reference, context, contributor.projectContributorId);
           const project = await Project.findById(reference, context, projectContributor.projectId);
           const hasPermission = await hasPermissionOnProject(context, project);
+
           if (hasPermission) {
-            // Update roles
-            const associationErrors = [];
-            // Fetch all of the current Roles associated with this Contributor
-            const roles = await ContributorRole.findByPlanContributorId(reference, context, contributor.id);
-            const currentRoleids = roles ? roles.map((d) => d.id) : [];
+            // Fetch current roles
+            const roles = await ContributorRole.findByPlanContributorId(reference, context, planContributorId);
+            const currentRoleIds = roles ? roles.map((d) => d.id) : [];
 
-            // Use the helper function to determine which Roles to keep
-            const { idsToBeRemoved, idsToBeSaved } = ContributorRole.reconcileAssociationIds(currentRoleids, contributorRoleIds);
+            // Update roles using the helper function
+            const { updatedRoleIds, errors } = await updateContributorRoles(
+              reference,
+              context,
+              contributor.id,
+              currentRoleIds,
+              contributorRoleIds
+            );
 
-            const removeErrors = [];
-            // Delete any Role associations that were removed
-            for (const id of idsToBeRemoved) {
-              const role = await ContributorRole.findById(reference, context, id);
-              if (role) {
-                const wasRemoved = role.removeFromPlanContributor(context, contributor.id);
-                if (!wasRemoved) {
-                  removeErrors.push(role.label);
+            if (errors.length > 0) {
+              contributor.addError('contributorRoles', `Updated but ${errors.join(', ')}`);
+            }
+
+            // Create a new instance of PlanContributor and set the updated values
+            const toUpdate = new PlanContributor({
+              id: planContributorId,
+              planId: planId,
+              projectContributorId,
+              isPrimaryContact,
+              contributorRoleIds: updatedRoleIds ?? currentRoleIds,
+            });
+
+            //update the PlanContributor with new instance
+            const updatedPlan = await toUpdate.update(context);
+
+            // Make updates for isPrimaryContact
+            if (updatedPlan && !updatedPlan.hasErrors()) {
+              if (isPrimaryContact !== undefined) {
+                // Get the current primary contact and set isPrimaryContact to false if it does not match the passed in planContributorId
+                const currentPrimaryContact = await PlanContributor.findPrimaryByPlanId(reference, context, planId);
+                if (currentPrimaryContact && currentPrimaryContact.id !== planContributorId) {
+                  const roles = await ContributorRole.findByPlanContributorId(reference, context, currentPrimaryContact.id);
+                  const currentRoleIds = roles ? roles.map((d) => d.id) : [];
+                  currentPrimaryContact.isPrimaryContact = false;
+                  currentPrimaryContact.contributorRoleIds = currentRoleIds; //Have to add contributor's contributor roles when updating
+                  await currentPrimaryContact.update(context);
                 }
+                updatedPlan.isPrimaryContact = isPrimaryContact;
+                updatedPlan.contributorRoleIds = updatedRoleIds ?? [];
+                await updatedPlan.update(context);
               }
             }
-            // If any failed to be removed, then add an error to the ProjectContributor
-            if (removeErrors.length > 0) {
-              associationErrors.push(`unable to remove roles: ${removeErrors.join(', ')}`);
-            }
 
-            const addErrors = [];
-            // Add any new Role associations
-            for (const id of idsToBeSaved) {
-              const role = await ContributorRole.findById(reference, context, id);
-              if (role) {
-                const wasAdded = role.addToPlanContributor(context, contributor.id);
-                if (!wasAdded) {
-                  addErrors.push(role.label);
-                }
-              }
-            }
-            // If any failed to be added, then add an error to the ProjectContributor
-            if (addErrors.length > 0) {
-              associationErrors.push(`unable to assign roles: ${addErrors.join(', ')}`);
-            }
-
-            if (associationErrors.length > 0) {
-              contributor.addError('contributorRoles', `Updated but ${associationErrors.join(', ')}`);
-            }
-
-
-            // Update isPrimaryContact if it was provided
-            if (isPrimaryContact !== undefined) {
-              // Check if there is an existing PlanContributor with isPrimaryContact === true
-              const currentPrimaryContact = await PlanContributor.findPrimaryByPlanId(reference, context, planId);
-
-              // If one exists and it's not the same as the current contributor, set it to false
-              if (currentPrimaryContact && currentPrimaryContact.id !== contributor.id) {
-                currentPrimaryContact.isPrimaryContact = false;
-                await currentPrimaryContact.update(context);
-              }
-
-              // Set the new contributor as the primary contact
-              contributor.isPrimaryContact = isPrimaryContact;
-              await contributor.update(context);
-            }
-
-            // TODO: We need to generate the plan version snapshot and sync with DMPHub
-
-            // Reload since the roles have changed
             return await PlanContributor.findById(reference, context, contributor.id);
           }
         }

--- a/src/resolvers/contributor.ts
+++ b/src/resolvers/contributor.ts
@@ -305,7 +305,7 @@ export const resolvers: Resolvers = {
     },
 
     // update an existing PlanContributor
-    updatePlanContributor: async (_, { planId, planContributorId, projectContributorId, contributorRoleIds, isPrimaryContact }, context) => {
+    updatePlanContributor: async (_, { planId, planContributorId, contributorRoleIds, isPrimaryContact }, context) => {
       const reference = 'updatePlanContributor resolver';
       try {
         if (isAuthorized(context.token)) {
@@ -340,7 +340,7 @@ export const resolvers: Resolvers = {
             const toUpdate = new PlanContributor({
               id: planContributorId,
               planId: planId,
-              projectContributorId,
+              projectContributorId: projectContributor.id,
               isPrimaryContact,
               contributorRoleIds: updatedRoleIds ?? currentRoleIds,
             });

--- a/src/schemas/contributor.ts
+++ b/src/schemas/contributor.ts
@@ -23,7 +23,7 @@ export const typeDefs = gql`
     "Add a Contributor to a Plan"
     addPlanContributor(planId: Int!, projectContributorId: Int!, roleIds: [Int!]): PlanContributor
     "Chnage a Contributor's accessLevel on a Plan"
-    updatePlanContributor(planId: Int!, planContributorId: Int!, projectContributorId: Int!, contributorRoleIds: [Int!], isPrimaryContact: Boolean): PlanContributor
+    updatePlanContributor(planId: Int!, planContributorId: Int!, contributorRoleIds: [Int!], isPrimaryContact: Boolean): PlanContributor
     "Remove a PlanContributor from a Plan"
     removePlanContributor(planContributorId: Int!): PlanContributor
   }

--- a/src/schemas/contributor.ts
+++ b/src/schemas/contributor.ts
@@ -23,7 +23,7 @@ export const typeDefs = gql`
     "Add a Contributor to a Plan"
     addPlanContributor(planId: Int!, projectContributorId: Int!, roleIds: [Int!]): PlanContributor
     "Chnage a Contributor's accessLevel on a Plan"
-    updatePlanContributor(planId: Int!, planContributorId: Int!, contributorRoleIds: [Int!], isPrimaryContact: Boolean): PlanContributor
+    updatePlanContributor(planId: Int!, planContributorId: Int!, projectContributorId: Int!, contributorRoleIds: [Int!], isPrimaryContact: Boolean): PlanContributor
     "Remove a PlanContributor from a Plan"
     removePlanContributor(planContributorId: Int!): PlanContributor
   }

--- a/src/schemas/contributor.ts
+++ b/src/schemas/contributor.ts
@@ -23,7 +23,7 @@ export const typeDefs = gql`
     "Add a Contributor to a Plan"
     addPlanContributor(planId: Int!, projectContributorId: Int!, roleIds: [Int!]): PlanContributor
     "Chnage a Contributor's accessLevel on a Plan"
-    updatePlanContributor(planContributorId: Int!, roleIds: [Int!]): PlanContributor
+    updatePlanContributor(planId: Int!, planContributorId: Int!, contributorRoleIds: [Int!], isPrimaryContact: Boolean): PlanContributor
     "Remove a PlanContributor from a Plan"
     removePlanContributor(planContributorId: Int!): PlanContributor
   }

--- a/src/services/planService.ts
+++ b/src/services/planService.ts
@@ -1,6 +1,7 @@
 import { MyContext } from "../context";
 import { PlanVersion } from "../models/PlanVersion";
 import { Plan, PlanStatus } from "../models/Plan";
+import { ContributorRole } from "../models/ContributorRole";
 import { planToDMPCommonStandard } from "./commonStandardService";
 import { formatLogMessage } from "../logger";
 import { DMPCommonStandard } from "../datasources/dmphubAPI";
@@ -59,4 +60,52 @@ export const syncWithDMPHub = async (
   await plan.update(context, true);
 
   return dmp;
+}
+
+export async function updateContributorRoles(
+  reference: string,
+  context: MyContext,
+  contributorId: number,
+  currentRoleIds: number[],
+  newRoleIds: number[]
+): Promise<{ updatedRoleIds: number[], errors: string[] }> {
+
+  const associationErrors = [];
+  const { idsToBeRemoved, idsToBeSaved } = ContributorRole.reconcileAssociationIds(currentRoleIds, newRoleIds);
+
+  // Remove roles
+  const removeErrors = [];
+  for (const id of idsToBeRemoved) {
+    const role = await ContributorRole.findById(reference, context, id);
+    if (role) {
+      const wasRemoved = await role.removeFromPlanContributor(context, contributorId);
+      if (!wasRemoved) {
+        removeErrors.push(role.label);
+      }
+    }
+  }
+  if (removeErrors.length > 0) {
+    associationErrors.push(`unable to remove roles: ${removeErrors.join(', ')}`);
+  }
+
+  // Add roles
+  const addErrors = [];
+  for (const id of idsToBeSaved) {
+    const role = await ContributorRole.findById(reference, context, id);
+    if (role) {
+      const wasAdded = await role.addToPlanContributor(context, contributorId);
+      if (!wasAdded) {
+        addErrors.push(role.label);
+      }
+    }
+  }
+  if (addErrors.length > 0) {
+    associationErrors.push(`unable to assign roles: ${addErrors.join(', ')}`);
+  }
+
+  const updatedRoles = [...currentRoleIds.filter(id => !idsToBeRemoved.includes(id)), ...idsToBeSaved];
+  return {
+    updatedRoleIds: updatedRoles.length > 0 ? updatedRoles : currentRoleIds,
+    errors: associationErrors,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1190,6 +1190,7 @@ export type MutationUpdatePlanContributorArgs = {
   isPrimaryContact?: InputMaybe<Scalars['Boolean']['input']>;
   planContributorId: Scalars['Int']['input'];
   planId: Scalars['Int']['input'];
+  projectContributorId: Scalars['Int']['input'];
 };
 
 
@@ -4075,7 +4076,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateLicense?: Resolver<Maybe<ResolversTypes['License']>, ParentType, ContextType, RequireFields<MutationUpdateLicenseArgs, 'name' | 'uri'>>;
   updateMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationUpdateMetadataStandardArgs, 'input'>>;
   updatePassword?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdatePasswordArgs, 'newPassword' | 'oldPassword'>>;
-  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId' | 'planId'>>;
+  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId' | 'planId' | 'projectContributorId'>>;
   updateProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, Partial<MutationUpdateProjectArgs>>;
   updateProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationUpdateProjectCollaboratorArgs, 'accessLevel' | 'projectCollaboratorId'>>;
   updateProjectContributor?: Resolver<Maybe<ResolversTypes['ProjectContributor']>, ParentType, ContextType, RequireFields<MutationUpdateProjectContributorArgs, 'input'>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1186,8 +1186,10 @@ export type MutationUpdatePasswordArgs = {
 
 
 export type MutationUpdatePlanContributorArgs = {
+  contributorRoleIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  isPrimaryContact?: InputMaybe<Scalars['Boolean']['input']>;
   planContributorId: Scalars['Int']['input'];
-  roleIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -4073,7 +4075,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateLicense?: Resolver<Maybe<ResolversTypes['License']>, ParentType, ContextType, RequireFields<MutationUpdateLicenseArgs, 'name' | 'uri'>>;
   updateMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationUpdateMetadataStandardArgs, 'input'>>;
   updatePassword?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdatePasswordArgs, 'newPassword' | 'oldPassword'>>;
-  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId'>>;
+  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId' | 'planId'>>;
   updateProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, Partial<MutationUpdateProjectArgs>>;
   updateProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationUpdateProjectCollaboratorArgs, 'accessLevel' | 'projectCollaboratorId'>>;
   updateProjectContributor?: Resolver<Maybe<ResolversTypes['ProjectContributor']>, ParentType, ContextType, RequireFields<MutationUpdateProjectContributorArgs, 'input'>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1190,7 +1190,6 @@ export type MutationUpdatePlanContributorArgs = {
   isPrimaryContact?: InputMaybe<Scalars['Boolean']['input']>;
   planContributorId: Scalars['Int']['input'];
   planId: Scalars['Int']['input'];
-  projectContributorId: Scalars['Int']['input'];
 };
 
 
@@ -4076,7 +4075,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateLicense?: Resolver<Maybe<ResolversTypes['License']>, ParentType, ContextType, RequireFields<MutationUpdateLicenseArgs, 'name' | 'uri'>>;
   updateMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationUpdateMetadataStandardArgs, 'input'>>;
   updatePassword?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdatePasswordArgs, 'newPassword' | 'oldPassword'>>;
-  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId' | 'planId' | 'projectContributorId'>>;
+  updatePlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationUpdatePlanContributorArgs, 'planContributorId' | 'planId'>>;
   updateProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, Partial<MutationUpdateProjectArgs>>;
   updateProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationUpdateProjectCollaboratorArgs, 'accessLevel' | 'projectCollaboratorId'>>;
   updateProjectContributor?: Resolver<Maybe<ResolversTypes['ProjectContributor']>, ParentType, ContextType, RequireFields<MutationUpdateProjectContributorArgs, 'input'>>;


### PR DESCRIPTION
## Description

One of the issues is that these resolvers require a new instance of the Plan to be created with contributorRoleIds. That was missing for both addPlanContributor and updatePlanContributor.

Fixes # ([236](https://github.com/CDLUC3/dmsp_backend_prototype/issues/236))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested, and existing tests did not break


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules