### PR TITLE
Optimized template, versionedTemplate and Project queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `TemplateSearchResult`, `VersionedTemplateSearchResult` and `ProjectSearchResult` to optimize querying
 - Added `sections` to `Plan` schema and to plan resolver
 - Added the `relatedWorks` data migration
 - Added model and resolvers for `RelatedWork`
@@ -66,6 +67,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Fixed projectCollaborators table which had an FKey on the plans table instead of the projects table
 - Updated the `dmpHubAPI` datasource to support CRUD operations
 - Updated the `Plan` resolver and model to support mutations
 - Updated the `Affiliation` schema and model to include the new `apiTarget` property.

--- a/data-migrations/2025-03-18-0449-change-fkey-projectCollaborators.sql
+++ b/data-migrations/2025-03-18-0449-change-fkey-projectCollaborators.sql
@@ -1,0 +1,11 @@
+
+ALTER TABLE `projectCollaborators`
+  ADD COLUMN `projectId` INT NOT NULL,
+  ADD CONSTRAINT `unique_project_collaborator` UNIQUE (`projectId`, `email`),
+  ADD FOREIGN KEY (projectId) REFERENCES projects(id) ON DELETE CASCADE;
+
+ALTER TABLE `projectCollaborators`
+  DROP COLUMN `planId`,
+  DROP CONSTRAINT `unique_template_collaborator`,
+  DROP FOREIGN KEY `projectCollaborators_ibfk_1`,
+  DROP FOREIGN KEY `projectCollaborators_ibfk_2`;

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -1,6 +1,124 @@
 import { MyContext } from "../context";
 import { validateDate } from "../utils/helpers";
 import { MySqlModel } from "./MySqlModel";
+export class ProjectSearchResult {
+  public id: number;
+  public title: string;
+  public abstractText?: string;
+  public startDate?: string;
+  public endDate?: string;
+  public researchDomain?: string;
+  public isTestProject: boolean;
+  public created: string;
+  public createdById: number;
+  public createdByName: string;
+  public modified: string;
+  public modifiedById: number;
+  public modifiedByName: string;
+  public collaborators: { name: string, accessLevel: string, orcid: string }[];
+  public contributors: { name: string, role: string, orcid: string }[];
+  public funders: { name: string, grantId: string }[];
+
+  constructor(options) {
+    this.id = options.id;
+    this.title = options.title;
+    this.abstractText = options.abstractText;
+    this.startDate = options.startDate;
+    this.endDate = options.endDate;
+    this.researchDomain = options.researchDomain;
+    this.isTestProject = options.isTestProject;
+    this.created = options.created;
+    this.createdById = options.createdById;
+    this.createdByName = options.createdByName;
+    this.modified = options.modified;
+    this.modifiedById = options.modifiedById;
+    this.modifiedByName = options.modifiedByName;
+    this.collaborators = options.collaborators;
+    this.contributors = options.contributors;
+    this.funders = options.funders;
+  }
+
+  // Return all of the projects for the User
+  static async findByUserId(reference: string, context: MyContext, userId: number): Promise<ProjectSearchResult[]> {
+    const sql = 'SELECT p.id, p.title, p.abstractText, p.startDate, p.endDate, p.isTestProject, ' +
+                  'researchDomains.description as researchDomain, ' +
+	                'p.createdById, p.created, TRIM(CONCAT(cu.givenName, CONCAT(\' \', cu.surName))) as createdByName, ' +
+                  'p.modifiedById, p.modified, TRIM(CONCAT(mu.givenName, CONCAT(\' \', mu.surName))) as modifiedByName, ' +
+				  	      'GROUP_CONCAT(DISTINCT CONCAT_WS(\'|\', ' +
+                    'CASE ' +
+                      'WHEN pc.surName IS NOT NULL THEN TRIM(CONCAT(collab.givenName, CONCAT(\' \', collab.surName))) ' +
+                      'ELSE collab.email ' +
+                    'END, ' +
+				  	 	      'CONCAT(UPPER(SUBSTRING(pcol.accessLevel, 1, 1)), LOWER(SUBSTRING(pcol.accessLevel FROM 2))), ' +
+                    'collab.orcid ' +
+                  ') ORDER BY collab.created) collaboratorsData, ' +
+                  'GROUP_CONCAT(DISTINCT ' +
+               	  	'CONCAT_WS(\'|\', ' +
+               	  		'CASE ' +
+                        'WHEN pc.surName IS NOT NULL THEN TRIM(CONCAT(pc.givenName, CONCAT(\' \', pc.surName))) ' +
+                        'ELSE pc.email ' +
+                      'END, ' +
+               	  		'r.label, ' +
+               	  	 	'pc.orcid ' +
+               	  ') ORDER BY pc.created) as contributorsData, ' +
+                  'GROUP_CONCAT(DISTINCT CONCAT_WS(\'|\', funders.name, pf.grantId) ' +
+                    'ORDER BY funders.name SEPARATOR \',\') fundersData ' +
+                'FROM projects p ' +
+                  'LEFT JOIN researchDomains ON p.researchDomainId = researchDomains.id ' +
+                  'LEFT JOIN users cu ON cu.id = p.createdById ' +
+                  'LEFT JOIN users mu ON mu.id = p.modifiedById ' +
+                  'LEFT JOIN projectCollaborators pcol ON pcol.projectId = p.id ' +
+                    'LEFT JOIN users collab ON pcol.userId = collab.id ' +
+                  'LEFT JOIN projectContributors pc ON pc.projectId = p.id ' +
+                    'LEFT JOIN projectContributorRoles pcr ON pc.id = pcr.projectContributorId ' +
+                    'LEFT JOIN contributorRoles r ON pcr.contributorRoleId = r.id ' +
+                  'LEFT JOIN projectFunders pf ON pf.projectId = p.id ' +
+                    'LEFT JOIN affiliations funders ON pf.affiliationId = funders.uri ' +
+                'WHERE p.createdById = ? ' +
+                  'OR p.id IN (SELECT projectId FROM projectCollaborators WHERE userId = ?) ' +
+				        'GROUP BY p.id, p.title, p.abstractText, p.startDate, p.endDate, p.isTestProject, ' +
+                  'p.createdById, p.created, p.modifiedById, p.modified, researchDomains.description ' +
+                'ORDER BY p.created DESC;';
+    const results = await Project.query(context, sql, [userId?.toString(), userId?.toString()], reference);
+    if (!Array.isArray(results)) return [];
+
+    // Loop through each result and marshal the collaborators, contributors, and funders objects
+    return results.map((item) => {
+      const collabs = item.collaboratorsData?.split(',') ?? [];
+      const contribs = item.contributorsData?.split(',') ?? [];
+      const funds = item.fundersData?.split(',') ?? [];
+
+      // Translate the string data into collaborator objects
+      item.collaborators = collabs.map((collab) => {
+        const [name, accessLevel, orcid] = collab.split('|');
+        return { name, accessLevel, orcid };
+      });
+      // Translate the string data into contributor objects.
+      item.contributors = contribs.map((contrib) => {
+        const [name, role, orcid] = contrib.split('|');
+        return { name, role, orcid };
+      });
+      // There can be multiple contributor entries (one per role) so we want to deduplicate them
+      // and have a single entry with all the roles listed
+      item.contributors = item.contributors.reduce((acc, curr) => {
+        const existing = acc.find((entry) => entry.name === curr.name);
+        if (existing) {
+          existing.role += `, ${curr.role}`;
+        } else {
+          acc.push(curr);
+        }
+        return acc;
+      }, []);
+
+      // Translate the string data into funder objects
+      item.funders = funds.map((funder) => {
+        const [name, grantId] = funder.split('|');
+        return { name, grantId };
+      });
+      return new ProjectSearchResult(item)
+    });
+  }
+}
 
 export class Project extends MySqlModel {
   public title: string;

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -7,6 +7,65 @@ export enum TemplateVisibility {
   PUBLIC = 'PUBLIC', // Template is available to everyone creating a DMP
 }
 
+// A paired down version of template information for search results
+export class TemplateSearchResult {
+  public id: number;
+  public name: string;
+  public description?: string;
+  public visibility: TemplateVisibility;
+  public bestPractice: boolean;
+  public latestPublishVersion?: string;
+  public latestPublishDate?: string;
+  public isDirty: boolean;
+  public ownerId: string;
+  public ownerDisplayName: string;
+  public createdById: number;
+  public createdByName: string;
+  public created: string;
+  public modifiedById: number;
+  public modifiedByName: string;
+  public modified: string;
+
+  constructor(options) {
+    this.id = options.id;
+    this.name = options.name;
+    this.description = options.description;
+    this.visibility = options.visibility;
+    this.bestPractice = options.bestPractice;
+    this.latestPublishVersion = options.latestPublishVersion;
+    this.latestPublishDate = options.latestPublishDate;
+    this.isDirty = options.isDirty;
+    this.ownerId = options.ownerId;
+    this.ownerDisplayName = options.ownerDisplayName;
+    this.createdById = options.createdById;
+    this.createdByName = options.createdByName;
+    this.created = options.created;
+    this.modifiedById = options.modifiedById;
+    this.modifiedByName = options.modifiedByName;
+    this.modified = options.modified;
+  }
+
+  // Return the templates associated with the Affiliation
+  static async findByAffiliationId(
+    reference: string,
+    context: MyContext,
+    affiliationId: string
+  ): Promise<TemplateSearchResult[]> {
+    const sql = 'SELECT t.id, t.name, t.description, t.visibility, t.bestPractice, t.isDirty, ' +
+                  't.latestPublishVersion, t.latestPublishDate, t.ownerId, a.displayName, ' +
+                  't.createdById, TRIM(CONCAT(cu.givenName, CONCAT(\' \', cu.surName))) as createdByName, t.created, ' +
+                  't.modifiedById, TRIM(CONCAT(mu.givenName, CONCAT(\' \', mu.surName))) as modifiedByName, t.modified ' +
+                'FROM templates t ' +
+                  'INNER JOIN affiliations a ON a.uri = t.ownerId ' +
+                  'INNER JOIN users cu ON cu.id = t.createdById ' +
+                  'INNER JOIN users mu ON mu.id = t.modifiedById ' +
+                'WHERE ownerId = ? ' +
+                'ORDER BY modified DESC';
+    const results = await Template.query(context, sql, [affiliationId], reference);
+    return Array.isArray(results) ? results.map((item) => new TemplateSearchResult(item)) : [];
+  }
+}
+
 // A Template for creating a DMP
 export class Template extends MySqlModel {
   public sourceTemplateId?: number;

--- a/src/models/__tests__/Project.spec.ts
+++ b/src/models/__tests__/Project.spec.ts
@@ -1,7 +1,7 @@
 import casual from "casual";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from "../../__mocks__/context";
-import { Project } from "../Project";
+import { Project, ProjectSearchResult } from "../Project";
 
 jest.mock('../../context.ts');
 
@@ -15,6 +15,131 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+describe('ProjectSearchResult', () => {
+  let localQuery;
+  let originalQuery;
+  let projectSearchResult;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    localQuery = jest.fn();
+    (Project.query as jest.Mock) = localQuery;
+
+    context = buildContext(logger, mockToken());
+
+    projectSearchResult = new ProjectSearchResult({
+      id: casual.integer(1, 9),
+      title: casual.sentence,
+      abstractText: casual.sentences(5),
+      startDate: casual.date('YYYY-MM-DD'),
+      endDate: casual.date('YYYY-MM-DD'),
+      researchDomain: casual.word,
+      isTestProject: casual.boolean,
+      createdById: casual.integer(1, 99),
+      createdByName: casual.name,
+      created: casual.date('YYYY-MM-DDTHH:mm:ssZ'),
+      modifiedById: casual.integer(1, 99),
+      modifiedByName: casual.name,
+      modified: casual.date('YYYY-MM-DDTHH:mm:ssZ'),
+      collaborators: [
+        { name: 'foo@example.com', accessLevel: 'Comment', orcid: '0000-0000-0000-1234' },
+        { name: 'Jane Doe', accessLevel: 'Own' }
+      ],
+      contributors: [
+        { name: 'John Smith', role: 'Principal Investigator (PI), Other' },
+        { name: 'Elmer Fudd', role: 'Other', orcid: '0000-0000-0000-9876' }
+      ],
+      funders: [
+        { name: 'Test Funder', grantId: '12345' },
+        { name: 'Another Funder', grantId: '67890' },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    Project.query = originalQuery;
+  });
+
+  describe('findByUserId', () => {
+    it('returns the matching ProjectSearchResults', async () => {
+      const queryResult = {
+        id: projectSearchResult.id,
+        title: projectSearchResult.title,
+        abstractText: projectSearchResult.abstractText,
+        startDate: projectSearchResult.startDate,
+        endDate: projectSearchResult.endDate,
+        researchDomain: projectSearchResult.researchDomain,
+        isTestProject: projectSearchResult.isTestProject,
+        createdById: projectSearchResult.createdById,
+        created: projectSearchResult.created,
+        createdByName: projectSearchResult.createdByName,
+        modifiedById: projectSearchResult.modifiedById,
+        modified: projectSearchResult.modified,
+        modifiedByName: projectSearchResult.modifiedByName,
+        collaboratorsData: 'foo@example.com|Comment|0000-0000-0000-1234,Jane Doe|Own',
+        contributorsData: 'John Smith|Principal Investigator (PI),John Smith|Other,Elmer Fudd|Other|0000-0000-0000-9876',
+        fundersData: 'Test Funder|12345,Another Funder|67890',
+      }
+      localQuery.mockResolvedValueOnce([queryResult]);
+
+      const result = await ProjectSearchResult.findByUserId('Test', context, projectSearchResult.createdById);
+      const sql = 'SELECT p.id, p.title, p.abstractText, p.startDate, p.endDate, p.isTestProject, ' +
+                    'researchDomains.description as researchDomain, ' +
+                    'p.createdById, p.created, TRIM(CONCAT(cu.givenName, CONCAT(\' \', cu.surName))) as createdByName, ' +
+                    'p.modifiedById, p.modified, TRIM(CONCAT(mu.givenName, CONCAT(\' \', mu.surName))) as modifiedByName, ' +
+                    'GROUP_CONCAT(DISTINCT CONCAT_WS(\'|\', ' +
+                      'CASE ' +
+                        'WHEN pc.surName IS NOT NULL THEN TRIM(CONCAT(collab.givenName, CONCAT(\' \', collab.surName))) ' +
+                        'ELSE collab.email ' +
+                      'END, ' +
+                      'CONCAT(UPPER(SUBSTRING(pcol.accessLevel, 1, 1)), LOWER(SUBSTRING(pcol.accessLevel FROM 2))), ' +
+                      'collab.orcid ' +
+                    ') ORDER BY collab.created) collaboratorsData, ' +
+                    'GROUP_CONCAT(DISTINCT ' +
+                      'CONCAT_WS(\'|\', ' +
+                        'CASE ' +
+                          'WHEN pc.surName IS NOT NULL THEN TRIM(CONCAT(pc.givenName, CONCAT(\' \', pc.surName))) ' +
+                          'ELSE pc.email ' +
+                        'END, ' +
+                        'r.label, ' +
+                        'pc.orcid ' +
+                    ') ORDER BY pc.created) as contributorsData, ' +
+                    'GROUP_CONCAT(DISTINCT CONCAT_WS(\'|\', funders.name, pf.grantId) ' +
+                      'ORDER BY funders.name SEPARATOR \',\') fundersData ' +
+                  'FROM projects p ' +
+                    'LEFT JOIN researchDomains ON p.researchDomainId = researchDomains.id ' +
+                    'LEFT JOIN users cu ON cu.id = p.createdById ' +
+                    'LEFT JOIN users mu ON mu.id = p.modifiedById ' +
+                    'LEFT JOIN projectCollaborators pcol ON pcol.projectId = p.id ' +
+                      'LEFT JOIN users collab ON pcol.userId = collab.id ' +
+                    'LEFT JOIN projectContributors pc ON pc.projectId = p.id ' +
+                      'LEFT JOIN projectContributorRoles pcr ON pc.id = pcr.projectContributorId ' +
+                      'LEFT JOIN contributorRoles r ON pcr.contributorRoleId = r.id ' +
+                    'LEFT JOIN projectFunders pf ON pf.projectId = p.id ' +
+                      'LEFT JOIN affiliations funders ON pf.affiliationId = funders.uri ' +
+                  'WHERE p.createdById = ? ' +
+                    'OR p.id IN (SELECT projectId FROM projectCollaborators WHERE userId = ?) ' +
+                  'GROUP BY p.id, p.title, p.abstractText, p.startDate, p.endDate, p.isTestProject, ' +
+                    'p.createdById, p.created, p.modifiedById, p.modified, researchDomains.description ' +
+                  'ORDER BY p.created DESC;';
+      const vals = [projectSearchResult.createdById.toString(), projectSearchResult.createdById.toString()];
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, sql, vals, 'Test')
+      expect(result).toEqual([projectSearchResult]);
+    });
+
+    it('returns an empty array if there are no matching ProjectSearchResults', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const result = await ProjectSearchResult.findByUserId('Test', context, projectSearchResult.createdById);
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
+    });
+  });
 });
 
 describe('Project', () => {
@@ -80,268 +205,268 @@ describe('Project', () => {
     expect(Object.keys(project.errors).length).toBe(1);
     expect(project.errors['endDate']).toBeTruthy();
   });
-});
 
-describe('findBy Queries', () => {
-  const originalQuery = Project.query;
+  describe('findBy Queries', () => {
+    const originalQuery = Project.query;
 
-  let localQuery;
-  let context;
-  let project;
+    let localQuery;
+    let context;
+    let project;
 
-  beforeEach(() => {
-    localQuery = jest.fn();
-    (Project.query as jest.Mock) = localQuery;
+    beforeEach(() => {
+      localQuery = jest.fn();
+      (Project.query as jest.Mock) = localQuery;
 
-    context = buildContext(logger, mockToken());
+      context = buildContext(logger, mockToken());
 
-    project = new Project({
-      id: casual.integer(1, 999),
-      title: casual.sentence,
-      abstractText: casual.sentences(4),
-      startDate: '2024-12-13',
-      endDate: '2026-01-21',
-      researchDomainId: casual.integer(1, 99),
+      project = new Project({
+        id: casual.integer(1, 999),
+        title: casual.sentence,
+        abstractText: casual.sentences(4),
+        startDate: '2024-12-13',
+        endDate: '2026-01-21',
+        researchDomainId: casual.integer(1, 99),
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      Project.query = originalQuery;
+    });
+
+    it('findById should call query with correct params and return the default', async () => {
+      localQuery.mockResolvedValueOnce([project]);
+      const projectId = casual.integer(1, 999);
+      const result = await Project.findById('testing', context, projectId);
+      const expectedSql = 'SELECT * FROM projects WHERE id = ?';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [projectId.toString()], 'testing')
+      expect(result).toEqual(project);
+    });
+
+    it('findById should return null if it finds no default', async () => {
+      localQuery.mockResolvedValueOnce([]);
+      const projectId = casual.integer(1, 999);
+      const result = await Project.findById('testing', context, projectId);
+      expect(result).toEqual(null);
+    });
+
+    it('findByUserId should call query with correct params and return the default', async () => {
+      localQuery.mockResolvedValueOnce([project]);
+      const userId = casual.integer(1, 999);
+      const result = await Project.findByUserId('testing', context, userId);
+      const expectedSql = 'SELECT * FROM projects WHERE createdById = ? ORDER BY created DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [userId.toString()], 'testing')
+      expect(result).toEqual([project]);
+    });
+
+    it('findByUserId should return empty array if it finds no default', async () => {
+      localQuery.mockResolvedValueOnce([]);
+      const userId = casual.integer(1, 999);
+      const result = await Project.findByUserId('testing', context, userId);
+      expect(result).toEqual([]);
+    });
+
+    it('findByAffiliation should call query with correct params and return the default', async () => {
+      localQuery.mockResolvedValueOnce([project]);
+      const affiliationId = casual.url;
+      const result = await Project.findByAffiliation('testing', context, affiliationId);
+      let expectedSql = 'SELECT projects.* FROM projects INNER JOIN users ON projects.createdById = users.id';
+      expectedSql += ' WHERE users.affiliationId = ? ORDER BY created DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'testing')
+      expect(result).toEqual([project]);
+    });
+
+    it('findByAffiliation should return empty array if it finds no default', async () => {
+      localQuery.mockResolvedValueOnce([]);
+      const affiliationId = casual.url;
+      const result = await Project.findByAffiliation('testing', context, affiliationId);
+      expect(result).toEqual([]);
+    });
+
+    it('findByOwnerAndTitle should call query with correct params and return the default', async () => {
+      localQuery.mockResolvedValueOnce([project]);
+      const title = casual.sentence;
+      const result = await Project.findByOwnerAndTitle('testing', context, title, context.token.id);
+      const expectedSql = 'SELECT * FROM projects WHERE createdById = ? AND LOWER(title) LIKE ?';
+      const expectedVals = [context.token.id.toString(), `%${title.toLowerCase().trim()}%`]
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, expectedVals, 'testing')
+      expect(result).toEqual(project);
+    });
+
+    it('findByOwnerAndTitle should return empty array if it finds no default', async () => {
+      localQuery.mockResolvedValueOnce([]);
+      const title = casual.sentence;
+      const result = await Project.findByOwnerAndTitle('testing', context, title, context.token.id);
+      expect(result).toEqual(null);
     });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-    Project.query = originalQuery;
+  describe('update', () => {
+    let updateQuery;
+    let project;
+
+    beforeEach(() => {
+      updateQuery = jest.fn();
+      (Project.update as jest.Mock) = updateQuery;
+
+      project = new Project({
+        id: casual.integer(1, 999),
+        title: casual.sentence,
+        abstractText: casual.sentences(4),
+        startDate: '2024-12-13',
+        endDate: '2026-01-21',
+        researchDomainId: casual.integer(1, 99),
+        isTestProject: casual.boolean,
+      })
+    });
+
+    it('returns the Project with errors if it is not valid', async () => {
+      const localValidator = jest.fn();
+      (project.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(false);
+
+      const result = await project.update(context);
+      expect(result instanceof Project).toBe(true);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an error if the Project has no id', async () => {
+      const localValidator = jest.fn();
+      (project.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      project.id = null;
+      const result = await project.update(context);
+      expect(Object.keys(result.errors).length).toBe(1);
+      expect(result.errors['general']).toBeTruthy();
+    });
+
+    it('returns the updated Project', async () => {
+      const localValidator = jest.fn();
+      (project.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      updateQuery.mockResolvedValueOnce(project);
+
+      const mockFindById = jest.fn();
+      (Project.findById as jest.Mock) = mockFindById;
+      mockFindById.mockResolvedValueOnce(project);
+
+      const result = await project.update(context);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result).toBeInstanceOf(Project);
+    });
   });
 
-  it('findById should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([project]);
-    const projectId = casual.integer(1, 999);
-    const result = await Project.findById('testing', context, projectId);
-    const expectedSql = 'SELECT * FROM projects WHERE id = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [projectId.toString()], 'testing')
-    expect(result).toEqual(project);
+  describe('create', () => {
+    const originalInsert = Project.insert;
+    let insertQuery;
+    let project;
+
+    beforeEach(() => {
+      insertQuery = jest.fn();
+      (Project.insert as jest.Mock) = insertQuery;
+
+      project = new Project({
+        title: casual.sentence,
+        abstractText: casual.sentences(4),
+        startDate: '2024-12-13',
+        endDate: '2026-01-21',
+        researchDomainId: casual.integer(1, 99),
+        isTestProject: casual.boolean,
+      });
+    });
+
+    afterEach(() => {
+      Project.insert = originalInsert;
+    });
+
+    it('returns the Project without errors if it is valid', async () => {
+      const localValidator = jest.fn();
+      (project.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(false);
+
+      const result = await project.create(context);
+      expect(result instanceof Project).toBe(true);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the Project with errors if it is invalid', async () => {
+      project.title = undefined;
+      const response = await project.create(context);
+      expect(response.errors['title']).toBe('Title can\'t be blank');
+    });
+
+    it('returns the Project with an error if the question already exists', async () => {
+      const mockFindBy = jest.fn();
+      (Project.findByOwnerAndTitle as jest.Mock) = mockFindBy;
+      mockFindBy.mockResolvedValueOnce(project);
+
+      const result = await project.create(context);
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(1);
+      expect(result.errors['general']).toBeTruthy();
+    });
+
+    it('returns the newly added Project', async () => {
+      const mockFindBy = jest.fn();
+      (Project.findByOwnerAndTitle as jest.Mock) = mockFindBy;
+      mockFindBy.mockResolvedValueOnce(null);
+
+      const mockFindById = jest.fn();
+      (Project.findById as jest.Mock) = mockFindById;
+      mockFindById.mockResolvedValueOnce(project);
+
+      const result = await project.create(context);
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+      expect(mockFindById).toHaveBeenCalledTimes(1);
+      expect(insertQuery).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result).toBeInstanceOf(Project);
+    });
   });
 
-  it('findById should return null if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const projectId = casual.integer(1, 999);
-    const result = await Project.findById('testing', context, projectId);
-    expect(result).toEqual(null);
-  });
+  describe('delete', () => {
+    let project;
 
-  it('findByUserId should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([project]);
-    const userId = casual.integer(1, 999);
-    const result = await Project.findByUserId('testing', context, userId);
-    const expectedSql = 'SELECT * FROM projects WHERE createdById = ? ORDER BY created DESC';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [userId.toString()], 'testing')
-    expect(result).toEqual([project]);
-  });
-
-  it('findByUserId should return empty array if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const userId = casual.integer(1, 999);
-    const result = await Project.findByUserId('testing', context, userId);
-    expect(result).toEqual([]);
-  });
-
-  it('findByAffiliation should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([project]);
-    const affiliationId = casual.url;
-    const result = await Project.findByAffiliation('testing', context, affiliationId);
-    let expectedSql = 'SELECT projects.* FROM projects INNER JOIN users ON projects.createdById = users.id';
-    expectedSql += ' WHERE users.affiliationId = ? ORDER BY created DESC';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'testing')
-    expect(result).toEqual([project]);
-  });
-
-  it('findByAffiliation should return empty array if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const affiliationId = casual.url;
-    const result = await Project.findByAffiliation('testing', context, affiliationId);
-    expect(result).toEqual([]);
-  });
-
-  it('findByOwnerAndTitle should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([project]);
-    const title = casual.sentence;
-    const result = await Project.findByOwnerAndTitle('testing', context, title, context.token.id);
-    const expectedSql = 'SELECT * FROM projects WHERE createdById = ? AND LOWER(title) LIKE ?';
-    const expectedVals = [context.token.id.toString(), `%${title.toLowerCase().trim()}%`]
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, expectedVals, 'testing')
-    expect(result).toEqual(project);
-  });
-
-  it('findByOwnerAndTitle should return empty array if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const title = casual.sentence;
-    const result = await Project.findByOwnerAndTitle('testing', context, title, context.token.id);
-    expect(result).toEqual(null);
-  });
-});
-
-describe('update', () => {
-  let updateQuery;
-  let project;
-
-  beforeEach(() => {
-    updateQuery = jest.fn();
-    (Project.update as jest.Mock) = updateQuery;
-
-    project = new Project({
-      id: casual.integer(1, 999),
-      title: casual.sentence,
-      abstractText: casual.sentences(4),
-      startDate: '2024-12-13',
-      endDate: '2026-01-21',
-      researchDomainId: casual.integer(1, 99),
-      isTestProject: casual.boolean,
+    beforeEach(() => {
+      project = new Project({
+        id: casual.integer(1, 999),
+        title: casual.sentence,
+      });
     })
-  });
 
-  it('returns the Project with errors if it is not valid', async () => {
-    const localValidator = jest.fn();
-    (project.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(false);
-
-    const result = await project.update(context);
-    expect(result instanceof Project).toBe(true);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns an error if the Project has no id', async () => {
-    const localValidator = jest.fn();
-    (project.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    project.id = null;
-    const result = await project.update(context);
-    expect(Object.keys(result.errors).length).toBe(1);
-    expect(result.errors['general']).toBeTruthy();
-  });
-
-  it('returns the updated Project', async () => {
-    const localValidator = jest.fn();
-    (project.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    updateQuery.mockResolvedValueOnce(project);
-
-    const mockFindById = jest.fn();
-    (Project.findById as jest.Mock) = mockFindById;
-    mockFindById.mockResolvedValueOnce(project);
-
-    const result = await project.update(context);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(updateQuery).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(0);
-    expect(result).toBeInstanceOf(Project);
-  });
-});
-
-describe('create', () => {
-  const originalInsert = Project.insert;
-  let insertQuery;
-  let project;
-
-  beforeEach(() => {
-    insertQuery = jest.fn();
-    (Project.insert as jest.Mock) = insertQuery;
-
-    project = new Project({
-      title: casual.sentence,
-      abstractText: casual.sentences(4),
-      startDate: '2024-12-13',
-      endDate: '2026-01-21',
-      researchDomainId: casual.integer(1, 99),
-      isTestProject: casual.boolean,
+    it('returns null if the Project has no id', async () => {
+      project.id = null;
+      expect(await project.delete(context)).toBe(null);
     });
-  });
 
-  afterEach(() => {
-    Project.insert = originalInsert;
-  });
+    it('returns null if it was not able to delete the record', async () => {
+      const deleteQuery = jest.fn();
+      (Project.delete as jest.Mock) = deleteQuery;
 
-  it('returns the Project without errors if it is valid', async () => {
-    const localValidator = jest.fn();
-    (project.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(false);
-
-    const result = await project.create(context);
-    expect(result instanceof Project).toBe(true);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns the Project with errors if it is invalid', async () => {
-    project.title = undefined;
-    const response = await project.create(context);
-    expect(response.errors['title']).toBe('Title can\'t be blank');
-  });
-
-  it('returns the Project with an error if the question already exists', async () => {
-    const mockFindBy = jest.fn();
-    (Project.findByOwnerAndTitle as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(project);
-
-    const result = await project.create(context);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(1);
-    expect(result.errors['general']).toBeTruthy();
-  });
-
-  it('returns the newly added Project', async () => {
-    const mockFindBy = jest.fn();
-    (Project.findByOwnerAndTitle as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(null);
-
-    const mockFindById = jest.fn();
-    (Project.findById as jest.Mock) = mockFindById;
-    mockFindById.mockResolvedValueOnce(project);
-
-    const result = await project.create(context);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
-    expect(mockFindById).toHaveBeenCalledTimes(1);
-    expect(insertQuery).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(0);
-    expect(result).toBeInstanceOf(Project);
-  });
-});
-
-describe('delete', () => {
-  let project;
-
-  beforeEach(() => {
-    project = new Project({
-      id: casual.integer(1, 999),
-      title: casual.sentence,
+      deleteQuery.mockResolvedValueOnce(null);
+      expect(await project.delete(context)).toBe(null);
     });
-  })
 
-  it('returns null if the Project has no id', async () => {
-    project.id = null;
-    expect(await project.delete(context)).toBe(null);
-  });
+    it('returns the Project if it was able to delete the record', async () => {
+      const deleteQuery = jest.fn();
+      (Project.delete as jest.Mock) = deleteQuery;
+      deleteQuery.mockResolvedValueOnce(project);
 
-  it('returns null if it was not able to delete the record', async () => {
-    const deleteQuery = jest.fn();
-    (Project.delete as jest.Mock) = deleteQuery;
+      const mockFindById = jest.fn();
+      (Project.findById as jest.Mock) = mockFindById;
+      mockFindById.mockResolvedValueOnce(project);
 
-    deleteQuery.mockResolvedValueOnce(null);
-    expect(await project.delete(context)).toBe(null);
-  });
-
-  it('returns the Project if it was able to delete the record', async () => {
-    const deleteQuery = jest.fn();
-    (Project.delete as jest.Mock) = deleteQuery;
-    deleteQuery.mockResolvedValueOnce(project);
-
-    const mockFindById = jest.fn();
-    (Project.findById as jest.Mock) = mockFindById;
-    mockFindById.mockResolvedValueOnce(project);
-
-    const result = await project.delete(context);
-    expect(Object.keys(result.errors).length).toBe(0);
-    expect(result).toBeInstanceOf(Project);
+      const result = await project.delete(context);
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result).toBeInstanceOf(Project);
+    });
   });
 });

--- a/src/models/__tests__/Template.spec.ts
+++ b/src/models/__tests__/Template.spec.ts
@@ -1,9 +1,10 @@
 import casual from 'casual';
-import { Template, TemplateVisibility } from "../Template";
+import { Template, TemplateSearchResult, TemplateVisibility } from "../Template";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from '../../__mocks__/context';
 import { TemplateCollaborator } from '../Collaborator';
 import { defaultLanguageId } from '../Language';
+import { getRandomEnumValue } from '../../__tests__/helpers';
 
 jest.mock('../../context.ts');
 
@@ -17,6 +18,74 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+describe('TemplateSearchResult', () => {
+  let localQuery;
+  let originalQuery;
+  let templateSearchResult;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    localQuery = jest.fn();
+    (Template.query as jest.Mock) = localQuery;
+
+    context = buildContext(logger, mockToken());
+
+    templateSearchResult = new TemplateSearchResult({
+      id: casual.integer(1, 9),
+      name: casual.sentence,
+      description: casual.sentences(5),
+      visibility: getRandomEnumValue(TemplateVisibility),
+      bestPractice: casual.boolean,
+      latestPublishVersion: `v${casual.integer(1, 9)}`,
+      latestPublishDate: casual.date('YYYY-MM-DD'),
+      isDirty: casual.boolean,
+      ownerId: casual.url,
+      ownerDisplayName: casual.name,
+      createdById: casual.integer(1, 99),
+      createdByName: casual.name,
+      created: casual.date('YYYY-MM-DDTHH:mm:ssZ'),
+      modifiedById: casual.integer(1, 99),
+      modifiedByName: casual.name,
+      modified: casual.date('YYYY-MM-DDTHH:mm:ssZ'),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    Template.query = originalQuery;
+  });
+
+  describe('findByUserId', () => {
+    it('returns the matching TemplateSearchResults', async () => {
+      localQuery.mockResolvedValueOnce([templateSearchResult]);
+
+      const result = await TemplateSearchResult.findByAffiliationId('Test', context, templateSearchResult.ownerId);
+      const sql = 'SELECT t.id, t.name, t.description, t.visibility, t.bestPractice, t.isDirty, ' +
+                    't.latestPublishVersion, t.latestPublishDate, t.ownerId, a.displayName, ' +
+                    't.createdById, TRIM(CONCAT(cu.givenName, CONCAT(\' \', cu.surName))) as createdByName, t.created, ' +
+                    't.modifiedById, TRIM(CONCAT(mu.givenName, CONCAT(\' \', mu.surName))) as modifiedByName, t.modified ' +
+                  'FROM templates t ' +
+                    'INNER JOIN affiliations a ON a.uri = t.ownerId ' +
+                    'INNER JOIN users cu ON cu.id = t.createdById ' +
+                    'INNER JOIN users mu ON mu.id = t.modifiedById ' +
+                  'WHERE ownerId = ? ' +
+                  'ORDER BY modified DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, sql, [templateSearchResult.ownerId], 'Test')
+      expect(result).toEqual([templateSearchResult]);
+    });
+
+    it('returns an empty array if there are no matching TemplateSearchResults', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const result = await TemplateSearchResult.findByAffiliationId('Test', context, templateSearchResult.ownerId);
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
+    });
+  });
 });
 
 describe('Template', () => {
@@ -76,336 +145,336 @@ describe('Template', () => {
     expect(Object.keys(template.errors).length).toBe(1);
     expect(template.errors['name'].includes('Name')).toBe(true);
   });
-});
 
-describe('findBy queries', () => {
-  const originalQuery = Template.query;
+  describe('findBy queries', () => {
+    const originalQuery = Template.query;
 
-  let localQuery;
-  let context;
-  let template;
+    let localQuery;
+    let context;
+    let template;
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+    beforeEach(() => {
+      jest.resetAllMocks();
 
-    localQuery = jest.fn();
-    (Template.query as jest.Mock) = localQuery;
+      localQuery = jest.fn();
+      (Template.query as jest.Mock) = localQuery;
 
-    context = buildContext(logger, mockToken());
+      context = buildContext(logger, mockToken());
 
-    template = new Template({
-      id: casual.integer(1, 9),
-      createdById: casual.integer(1, 999),
-      name: casual.sentence,
-      ownerId: casual.url,
-    })
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    Template.query = originalQuery;
-  });
-
-  it('findById returns the Template', async () => {
-    localQuery.mockResolvedValueOnce([template]);
-
-    const id = template.id;
-    const result = await Template.findById('Test', context, id);
-    const expectedSql = 'SELECT * FROM templates WHERE id = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'Test')
-    expect(result).toEqual(template);
-  });
-
-  it('findById returns null if there is no Template', async () => {
-    localQuery.mockResolvedValueOnce([]);
-
-    const id = template.id;
-    const result = await Template.findById('Test', context, id);
-    const expectedSql = 'SELECT * FROM templates WHERE id = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'Test')
-    expect(result).toEqual(null);
-  });
-
-  it('findByNameAndOwnerId returns the matching Template', async () => {
-    localQuery.mockResolvedValueOnce([template]);
-
-    const name = template.name.toLowerCase();
-    const ownerId = context.token?.affiliationId;
-    const result = await Template.findByNameAndOwnerId('Test', context, name);
-    const expectedSql = 'SELECT * FROM templates WHERE LOWER(name) = ? AND ownerId = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [name, ownerId], 'Test')
-    expect(result).toEqual(template);
-  });
-
-  it('findByNameAndOwnerId returns null if there is no matching Template', async () => {
-    localQuery.mockResolvedValueOnce([]);
-
-    const name = template.name.toLowerCase();
-    const ownerId = context.token?.affiliationId;
-    const result = await Template.findByNameAndOwnerId('Test', context, name);
-    const expectedSql = 'SELECT * FROM templates WHERE LOWER(name) = ? AND ownerId = ?';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [name, ownerId], 'Test')
-    expect(result).toEqual(null);
-  });
-
-  it('findByAffiliationId returns the Templates owned by the current user\'s Affiliation', async () => {
-    localQuery.mockResolvedValueOnce([template]);
-
-    const mockFindByEmail = jest.fn();
-    (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
-    mockFindByEmail.mockResolvedValueOnce([]);
-
-    const affiliationId = context.token.affiliationId;
-    const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
-    const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
-    expect(result).toEqual([template]);
-  });
-
-  it('findByAffiliationId returns the Templates shared with the current user', async () => {
-    localQuery.mockResolvedValueOnce([template]);
-
-    const sharedTemplate = new Template({
-      createdById: casual.integer(1, 99),
-      name: casual.sentence,
-      ownerId: casual.url,
+      template = new Template({
+        id: casual.integer(1, 9),
+        createdById: casual.integer(1, 999),
+        name: casual.sentence,
+        ownerId: casual.url,
+      })
     });
 
-    const mockFindByEmail = jest.fn();
-    (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
-    mockFindByEmail.mockResolvedValueOnce([sharedTemplate]);
-
-    const affiliationId = context.token.affiliationId;
-    const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
-    const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
-    expect(result).toEqual([template]);
-  });
-
-  it('findByAffiliationId returns null if there are no Templates for the current user', async () => {
-    localQuery.mockResolvedValueOnce([]);
-
-    const mockFindByEmail = jest.fn();
-    (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
-    mockFindByEmail.mockResolvedValueOnce([]);
-
-    const affiliationId = context.token.affiliationId;
-    const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
-    const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
-    expect(result).toEqual([]);
-  });
-});
-
-describe('create', () => {
-  const originalInsert = Template.insert;
-  let insertQuery;
-  let template;
-
-  beforeEach(() => {
-    // jest.resetAllMocks();
-
-    insertQuery = jest.fn();
-    (Template.insert as jest.Mock) = insertQuery;
-
-    template = new Template({
-      createdById: casual.integer(1, 999),
-      ownerId: casual.url,
-      name: casual.sentence,
-      description: casual.sentences(5),
-    })
-  });
-
-  afterEach(() => {
-    // jest.resetAllMocks();
-    Template.insert = originalInsert;
-  });
-
-  it('returns the Template with errors if it is not valid', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(false);
-
-    const result = await template.create(context);
-    expect(result.errors).toEqual({});
-    expect(localValidator).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns the Template with an error if the template already exists', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    const mockFindBy = jest.fn();
-    (Template.findByNameAndOwnerId as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(template);
-
-    const result = await template.create(context);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(1);
-    expect(result.errors['general']).toBeTruthy();
-  });
-
-  it('returns the newly added Template', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    const mockFindBy = jest.fn();
-    (Template.findByNameAndOwnerId as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(null);
-    mockFindBy.mockResolvedValue(template);
-
-    const mockFindById = jest.fn();
-    (Template.findById as jest.Mock) = mockFindById;
-    mockFindById.mockResolvedValueOnce(template);
-
-    const result = await template.create(context);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
-    expect(mockFindById).toHaveBeenCalledTimes(1);
-    expect(insertQuery).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(0);
-    expect(result).toBeInstanceOf(Template);
-  });
-});
-
-describe('update', () => {
-  let updateQuery;
-  let template;
-
-  beforeEach(() => {
-    updateQuery = jest.fn();
-    (Template.update as jest.Mock) = updateQuery;
-
-    template = new Template({
-      id: casual.integer(1, 99),
-      createdById: casual.integer(1, 999),
-      ownerId: casual.url,
-      name: casual.sentence,
-    })
-  });
-
-  it('returns the Template with errors if it is not valid', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(false);
-
-    const result = await template.update(context);
-    expect(result.errors).toEqual({});
-    expect(localValidator).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns an error if the Template has no id', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    template.id = null;
-    const result = await template.update(context);
-    expect(Object.keys(result.errors).length).toBe(1);
-    expect(result.errors['general']).toBeTruthy();
-  });
-
-  it('returns the updated Template', async () => {
-    const localValidator = jest.fn();
-    (template.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    const mockFindById = jest.fn();
-    (Template.findById as jest.Mock) = mockFindById;
-    mockFindById.mockResolvedValueOnce(template);
-
-    updateQuery.mockResolvedValueOnce(template);
-
-    const result = await template.update(context);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(updateQuery).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(0);
-    expect(result).toBeInstanceOf(Template);
-  });
-});
-
-describe('delete', () => {
-  let template;
-
-  beforeEach(() => {
-    template = new Template({
-      id: casual.integer(1, 99),
-      createdById: casual.integer(1, 999),
-      ownerId: casual.url,
-      name: casual.sentence,
-    });
-  })
-
-  it('returns null if the Template has no id', async () => {
-    template.id = null;
-    expect(await template.delete(context)).toBe(null);
-  });
-
-  it('returns null if it was not able to delete the record', async () => {
-    const deleteQuery = jest.fn();
-    (Template.delete as jest.Mock) = deleteQuery;
-
-    deleteQuery.mockResolvedValueOnce(null);
-    expect(await template.delete(context)).toBe(null);
-  });
-
-  it('returns the Template if it was able to delete the record', async () => {
-    const deleteQuery = jest.fn();
-    (Template.delete as jest.Mock) = deleteQuery;
-    deleteQuery.mockResolvedValueOnce(template);
-    const findById = jest.fn();
-    (Template.findById as jest.Mock) = findById;
-    findById.mockResolvedValueOnce(template);
-
-    const result = await template.delete(context);
-    expect(result).toBeInstanceOf(Template);
-    expect(result.errors).toEqual({});
-  });
-});
-
-describe('markTemplateAsDirty', () => {
-  let template;
-  let context;
-
-  beforeEach(() => {
-    context = buildContext(logger, mockToken());
-
-    template = new Template({
-      id: casual.integer(1, 99),
-      createdById: casual.integer(1, 999),
-      ownerId: casual.url,
-      name: casual.sentence,
-      isDirty: false,
+    afterEach(() => {
+      jest.clearAllMocks();
+      Template.query = originalQuery;
     });
 
-    jest.spyOn(Template, 'findById').mockResolvedValue(template);
-    jest.spyOn(template, 'update').mockResolvedValue(template);
+    it('findById returns the Template', async () => {
+      localQuery.mockResolvedValueOnce([template]);
+
+      const id = template.id;
+      const result = await Template.findById('Test', context, id);
+      const expectedSql = 'SELECT * FROM templates WHERE id = ?';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'Test')
+      expect(result).toEqual(template);
+    });
+
+    it('findById returns null if there is no Template', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const id = template.id;
+      const result = await Template.findById('Test', context, id);
+      const expectedSql = 'SELECT * FROM templates WHERE id = ?';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [id.toString()], 'Test')
+      expect(result).toEqual(null);
+    });
+
+    it('findByNameAndOwnerId returns the matching Template', async () => {
+      localQuery.mockResolvedValueOnce([template]);
+
+      const name = template.name.toLowerCase();
+      const ownerId = context.token?.affiliationId;
+      const result = await Template.findByNameAndOwnerId('Test', context, name);
+      const expectedSql = 'SELECT * FROM templates WHERE LOWER(name) = ? AND ownerId = ?';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [name, ownerId], 'Test')
+      expect(result).toEqual(template);
+    });
+
+    it('findByNameAndOwnerId returns null if there is no matching Template', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const name = template.name.toLowerCase();
+      const ownerId = context.token?.affiliationId;
+      const result = await Template.findByNameAndOwnerId('Test', context, name);
+      const expectedSql = 'SELECT * FROM templates WHERE LOWER(name) = ? AND ownerId = ?';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [name, ownerId], 'Test')
+      expect(result).toEqual(null);
+    });
+
+    it('findByAffiliationId returns the Templates owned by the current user\'s Affiliation', async () => {
+      localQuery.mockResolvedValueOnce([template]);
+
+      const mockFindByEmail = jest.fn();
+      (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
+      mockFindByEmail.mockResolvedValueOnce([]);
+
+      const affiliationId = context.token.affiliationId;
+      const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
+      const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
+      expect(result).toEqual([template]);
+    });
+
+    it('findByAffiliationId returns the Templates shared with the current user', async () => {
+      localQuery.mockResolvedValueOnce([template]);
+
+      const sharedTemplate = new Template({
+        createdById: casual.integer(1, 99),
+        name: casual.sentence,
+        ownerId: casual.url,
+      });
+
+      const mockFindByEmail = jest.fn();
+      (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
+      mockFindByEmail.mockResolvedValueOnce([sharedTemplate]);
+
+      const affiliationId = context.token.affiliationId;
+      const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
+      const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
+      expect(result).toEqual([template]);
+    });
+
+    it('findByAffiliationId returns null if there are no Templates for the current user', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const mockFindByEmail = jest.fn();
+      (TemplateCollaborator.findByEmail as jest.Mock) = mockFindByEmail;
+      mockFindByEmail.mockResolvedValueOnce([]);
+
+      const affiliationId = context.token.affiliationId;
+      const result = await Template.findByAffiliationId('Test', context, context.token.affiliationId);
+      const expectedSql = 'SELECT * FROM templates WHERE ownerId = ? ORDER BY modified DESC';
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [affiliationId], 'Test')
+      expect(result).toEqual([]);
+    });
   });
 
-  it('should mark the template as dirty if it exists', async () => {
-    await Template.markTemplateAsDirty('Test', context, template.id);
+  describe('create', () => {
+    const originalInsert = Template.insert;
+    let insertQuery;
+    let template;
 
-    expect(Template.findById).toHaveBeenCalledWith('Test', context, template.id);
-    expect(template.isDirty).toBe(true);
-    expect(template.update).toHaveBeenCalledWith(context);
+    beforeEach(() => {
+      // jest.resetAllMocks();
+
+      insertQuery = jest.fn();
+      (Template.insert as jest.Mock) = insertQuery;
+
+      template = new Template({
+        createdById: casual.integer(1, 999),
+        ownerId: casual.url,
+        name: casual.sentence,
+        description: casual.sentences(5),
+      })
+    });
+
+    afterEach(() => {
+      // jest.resetAllMocks();
+      Template.insert = originalInsert;
+    });
+
+    it('returns the Template with errors if it is not valid', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(false);
+
+      const result = await template.create(context);
+      expect(result.errors).toEqual({});
+      expect(localValidator).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the Template with an error if the template already exists', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      const mockFindBy = jest.fn();
+      (Template.findByNameAndOwnerId as jest.Mock) = mockFindBy;
+      mockFindBy.mockResolvedValueOnce(template);
+
+      const result = await template.create(context);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(1);
+      expect(result.errors['general']).toBeTruthy();
+    });
+
+    it('returns the newly added Template', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      const mockFindBy = jest.fn();
+      (Template.findByNameAndOwnerId as jest.Mock) = mockFindBy;
+      mockFindBy.mockResolvedValueOnce(null);
+      mockFindBy.mockResolvedValue(template);
+
+      const mockFindById = jest.fn();
+      (Template.findById as jest.Mock) = mockFindById;
+      mockFindById.mockResolvedValueOnce(template);
+
+      const result = await template.create(context);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+      expect(mockFindBy).toHaveBeenCalledTimes(1);
+      expect(mockFindById).toHaveBeenCalledTimes(1);
+      expect(insertQuery).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result).toBeInstanceOf(Template);
+    });
   });
 
-  it('should not call update if the template does not exist', async () => {
-    jest.spyOn(Template, 'findById').mockResolvedValue(null);
+  describe('update', () => {
+    let updateQuery;
+    let template;
 
-    await Template.markTemplateAsDirty('Test', context, template.id);
+    beforeEach(() => {
+      updateQuery = jest.fn();
+      (Template.update as jest.Mock) = updateQuery;
 
-    expect(Template.findById).toHaveBeenCalledWith('Test', context, template.id);
-    expect(template.update).not.toHaveBeenCalled();
+      template = new Template({
+        id: casual.integer(1, 99),
+        createdById: casual.integer(1, 999),
+        ownerId: casual.url,
+        name: casual.sentence,
+      })
+    });
+
+    it('returns the Template with errors if it is not valid', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(false);
+
+      const result = await template.update(context);
+      expect(result.errors).toEqual({});
+      expect(localValidator).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an error if the Template has no id', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      template.id = null;
+      const result = await template.update(context);
+      expect(Object.keys(result.errors).length).toBe(1);
+      expect(result.errors['general']).toBeTruthy();
+    });
+
+    it('returns the updated Template', async () => {
+      const localValidator = jest.fn();
+      (template.isValid as jest.Mock) = localValidator;
+      localValidator.mockResolvedValueOnce(true);
+
+      const mockFindById = jest.fn();
+      (Template.findById as jest.Mock) = mockFindById;
+      mockFindById.mockResolvedValueOnce(template);
+
+      updateQuery.mockResolvedValueOnce(template);
+
+      const result = await template.update(context);
+      expect(localValidator).toHaveBeenCalledTimes(1);
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result).toBeInstanceOf(Template);
+    });
+  });
+
+  describe('delete', () => {
+    let template;
+
+    beforeEach(() => {
+      template = new Template({
+        id: casual.integer(1, 99),
+        createdById: casual.integer(1, 999),
+        ownerId: casual.url,
+        name: casual.sentence,
+      });
+    })
+
+    it('returns null if the Template has no id', async () => {
+      template.id = null;
+      expect(await template.delete(context)).toBe(null);
+    });
+
+    it('returns null if it was not able to delete the record', async () => {
+      const deleteQuery = jest.fn();
+      (Template.delete as jest.Mock) = deleteQuery;
+
+      deleteQuery.mockResolvedValueOnce(null);
+      expect(await template.delete(context)).toBe(null);
+    });
+
+    it('returns the Template if it was able to delete the record', async () => {
+      const deleteQuery = jest.fn();
+      (Template.delete as jest.Mock) = deleteQuery;
+      deleteQuery.mockResolvedValueOnce(template);
+      const findById = jest.fn();
+      (Template.findById as jest.Mock) = findById;
+      findById.mockResolvedValueOnce(template);
+
+      const result = await template.delete(context);
+      expect(result).toBeInstanceOf(Template);
+      expect(result.errors).toEqual({});
+    });
+  });
+
+  describe('markTemplateAsDirty', () => {
+    let template;
+    let context;
+
+    beforeEach(() => {
+      context = buildContext(logger, mockToken());
+
+      template = new Template({
+        id: casual.integer(1, 99),
+        createdById: casual.integer(1, 999),
+        ownerId: casual.url,
+        name: casual.sentence,
+        isDirty: false,
+      });
+
+      jest.spyOn(Template, 'findById').mockResolvedValue(template);
+      jest.spyOn(template, 'update').mockResolvedValue(template);
+    });
+
+    it('should mark the template as dirty if it exists', async () => {
+      await Template.markTemplateAsDirty('Test', context, template.id);
+
+      expect(Template.findById).toHaveBeenCalledWith('Test', context, template.id);
+      expect(template.isDirty).toBe(true);
+      expect(template.update).toHaveBeenCalledWith(context);
+    });
+
+    it('should not call update if the template does not exist', async () => {
+      jest.spyOn(Template, 'findById').mockResolvedValue(null);
+
+      await Template.markTemplateAsDirty('Test', context, template.id);
+
+      expect(Template.findById).toHaveBeenCalledWith('Test', context, template.id);
+      expect(template.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -1,6 +1,6 @@
 import { formatLogMessage } from '../logger';
 import { Resolvers } from "../types";
-import { Project } from "../models/Project";
+import { Project, ProjectSearchResult } from "../models/Project";
 import { MyContext } from '../context';
 import { isAuthorized } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
@@ -15,11 +15,11 @@ import { PlanSearchResult } from '../models/Plan';
 export const resolvers: Resolvers = {
   Query: {
     // return all of the projects that the current user owns or is a collaborator on
-    myProjects: async (_, __, context: MyContext): Promise<Project[]> => {
+    myProjects: async (_, __, context: MyContext): Promise<ProjectSearchResult[]> => {
       const reference = 'myProjects resolver';
       try {
         if (isAuthorized(context.token)) {
-          return await Project.findByUserId(reference, context, context.token?.id);
+          return await ProjectSearchResult.findByUserId(reference, context, context.token?.id);
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -1,5 +1,5 @@
 import { Resolvers } from "../types";
-import { Template, TemplateVisibility } from "../models/Template";
+import { Template, TemplateSearchResult, TemplateVisibility } from "../models/Template";
 import { Affiliation } from "../models/Affiliation";
 import { TemplateCollaborator } from "../models/Collaborator";
 import { Section } from "../models/Section";
@@ -19,11 +19,11 @@ import { GraphQLError } from "graphql";
 export const resolvers: Resolvers = {
   Query: {
     // Get the Templates that belong to the current user's affiliation (user must be an Admin)
-    myTemplates: async (_, __, context: MyContext): Promise<Template[]> => {
+    myTemplates: async (_, __, context: MyContext): Promise<TemplateSearchResult[]> => {
       const reference = 'myTemplates resolver';
       try {
         if (isAdmin(context.token)) {
-          return await Template.findByAffiliationId(reference, context, context.token.affiliationId);
+          return await TemplateSearchResult.findByAffiliationId(reference, context, context.token.affiliationId);
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -1,5 +1,5 @@
 import { Resolvers } from "../types";
-import { VersionedTemplate } from "../models/VersionedTemplate";
+import { VersionedTemplate, VersionedTemplateSearchResult } from "../models/VersionedTemplate";
 import { User } from '../models/User';
 import { MyContext } from "../context";
 import { Template } from "../models/Template";
@@ -32,11 +32,11 @@ export const resolvers: Resolvers = {
 
     // Search for PublishedTemplates whose name or owning Org's name contains the search term
     //    - called by the Template Builder - prior template selection page
-    publishedTemplates: async (_, { term }, context: MyContext): Promise<VersionedTemplate[]> => {
+    publishedTemplates: async (_, { term }, context: MyContext): Promise<VersionedTemplateSearchResult[]> => {
       const reference = 'publishedTemplates resolver';
       try {
         if (isAdmin(context.token)) {
-          return await VersionedTemplate.search(reference, context, term);
+          return await VersionedTemplateSearchResult.search(reference, context, term);
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -49,11 +49,15 @@ export const resolvers: Resolvers = {
     },
 
     // Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin)
-    myVersionedTemplates: async (_, __, context: MyContext): Promise<VersionedTemplate[]> => {
+    myVersionedTemplates: async (_, __, context: MyContext): Promise<VersionedTemplateSearchResult[]> => {
       const reference = 'myVersionedTemplates resolver';
       try {
         if (isAdmin(context.token)) {
-          return await VersionedTemplate.findByAffiliationId(reference, context, context.token?.affiliationId);
+          return await VersionedTemplateSearchResult.findByAffiliationId(
+            reference,
+            context,
+            context.token?.affiliationId
+          );
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -3,7 +3,7 @@ import gql from "graphql-tag";
 export const typeDefs = gql`
   extend type Query {
     "Get all of the user's projects"
-    myProjects: [Project]
+    myProjects: [ProjectSearchResult]
 
     "Get a specific project"
     project(projectId: Int!): Project
@@ -16,6 +16,43 @@ export const typeDefs = gql`
     updateProject(input: UpdateProjectInput): Project
     "Download the plan"
     archiveProject(projectId: Int!): Project
+  }
+
+  type ProjectSearchResult {
+    "The unique identifer for the Object"
+    id: Int
+    "The name/title of the research project"
+    title: String
+    "The research project abstract"
+    abstractText: String
+    "The estimated date the research project will begin (use YYYY-MM-DD format)"
+    startDate: String
+    "The estimated date the research project will end (use YYYY-MM-DD format)"
+    endDate: String
+    "The type of research being done"
+    researchDomain: String
+    "Whether or not this is test/mock research project"
+    isTestProject: Boolean
+    "The id of the person who created the project"
+    createdById: Int
+    "The name of the person who created the project"
+    createdByName: String
+    "The timestamp when the project was created"
+    created: String
+    "The id of the person who last modified the project"
+    modifiedById: Int
+    "The name of the person who last modified the project"
+    modifiedByName: String
+    "The timestamp when the project was last modified"
+    modified: String
+    "The names and access levels of the collaborators"
+    collaborators: [ProjectSearchResultCollaborator!]
+    "The names and roles of the contributors"
+    contributors: [ProjectSearchResultContributor!]
+    "The names of the funders"
+    funders: [ProjectSearchResultFunder!]
+    "Search results errors"
+    errors: ProjectErrors
   }
 
   type Project {
@@ -68,6 +105,31 @@ export const typeDefs = gql`
     contributorIds: String
     funderIds: String
     outputIds: String
+  }
+
+  type ProjectSearchResultCollaborator {
+    "The name of the collaborator"
+    name: String
+    "The access level of the collaborator"
+    accessLevel: String
+    "The ORCiD ID"
+    orcid: String
+  }
+
+  type ProjectSearchResultContributor {
+    "The name of the contributor"
+    name: String
+    "The role of the contributor"
+    role: String
+    "The ORCiD ID"
+    orcid: String
+  }
+
+  type ProjectSearchResultFunder {
+    "The name of the funder"
+    name: String
+    "The grant id/url"
+    grantId: String
   }
 
   input UpdateProjectInput {

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -3,7 +3,7 @@ import gql from "graphql-tag";
 export const typeDefs = gql`
   extend type Query {
     "Get the Templates that belong to the current user's affiliation (user must be an Admin)"
-    myTemplates: [Template]
+    myTemplates: [TemplateSearchResult]
     "Get the specified Template (user must be an Admin)"
     template(templateId: Int!): Template
   }
@@ -26,6 +26,42 @@ export const typeDefs = gql`
     PRIVATE
     "Visible to all users"
     PUBLIC
+  }
+
+  "A search result for templates"
+  type TemplateSearchResult {
+    "The unique identifer for the Object"
+    id: Int
+    "The name/title of the template"
+    name: String
+    "A description of the purpose of the template"
+    description: String
+    "The template's availability setting: Public is available to everyone, Private only your affiliation"
+    visibility: TemplateVisibility
+    "Whether or not this Template is designated as a 'Best Practice' template"
+    bestPractice: Boolean
+    "The last published version"
+    latestPublishVersion: String
+    "The last published date"
+    latestPublishDate: String
+    "Whether or not the Template has had any changes since it was last published"
+    isDirty: Boolean
+    "The id of the affiliation that owns the Template"
+    ownerId: String
+    "The display name of the affiliation that owns the Template"
+    ownerDisplayName: String
+    "The id of the person who created the template"
+    createdById: Int
+    "the name of the person who created the template"
+    createdByName: String
+    "The timestamp when the Template was created"
+    created: String
+    "The id of the person who last modified the template"
+    modifiedById: Int
+    "The name of the person who last modified the template"
+    modifiedByName: String
+    "The timestamp when the Template was last modified"
+    modified: String
   }
 
   "A Template used to create DMPs"

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -5,9 +5,9 @@ export const typeDefs = gql`
     "Get all of the VersionedTemplate for the specified Template (a.k. the Template history)"
     templateVersions(templateId: Int!): [VersionedTemplate]
     "Search for VersionedTemplate whose name or owning Org's name contains the search term"
-    publishedTemplates(term: String): [VersionedTemplate]
+    publishedTemplates(term: String): [VersionedTemplateSearchResult]
     "Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin)"
-    myVersionedTemplates: [VersionedTemplate]
+    myVersionedTemplates: [VersionedTemplateSearchResult]
   }
 
   "Template version type"
@@ -16,6 +16,38 @@ export const typeDefs = gql`
     DRAFT
     "Published - saved state for use when creating DMPs"
     PUBLISHED
+  }
+
+  "An abbreviated view of a Template for pages that allow search/filtering of published Templates"
+  type VersionedTemplateSearchResult {
+    "The unique identifer for the Object"
+    id: Int
+    "The id of the template that this version is based on"
+    templateId: Int
+    "The name/title of the template"
+    name: String
+    "A description of the purpose of the template"
+    description: String
+    "The major.minor semantic version"
+    version: String
+    "The template's availability setting: Public is available to everyone, Private only your affiliation"
+    visibility: TemplateVisibility
+    "Whether or not this Template is designated as a 'Best Practice' template"
+    bestPractice: Boolean
+    "The id of the affiliation that owns the Template"
+    ownerId: Int
+    "The URI of the affiliation that owns the Template"
+    ownerURI: String
+    "The search name of the affiliation that owns the Template"
+    ownerSearchName: String
+    "The display name of the affiliation that owns the Template"
+    ownerDisplayName: String
+    "The name of the last person who modified the Template"
+    modifiedById: Int
+    "The name of the last person who modified the Template"
+    modifiedByName: String
+    "The timestamp when the Template was last modified"
+    modified: String
   }
 
   "A snapshot of a Template when it became published. DMPs are created from published templates"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1880,6 +1880,72 @@ export type ProjectOutputErrors = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
+export type ProjectSearchResult = {
+  __typename?: 'ProjectSearchResult';
+  /** The research project abstract */
+  abstractText?: Maybe<Scalars['String']['output']>;
+  /** The names and access levels of the collaborators */
+  collaborators?: Maybe<Array<ProjectSearchResultCollaborator>>;
+  /** The names and roles of the contributors */
+  contributors?: Maybe<Array<ProjectSearchResultContributor>>;
+  /** The timestamp when the project was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The id of the person who created the project */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** The name of the person who created the project */
+  createdByName?: Maybe<Scalars['String']['output']>;
+  /** The estimated date the research project will end (use YYYY-MM-DD format) */
+  endDate?: Maybe<Scalars['String']['output']>;
+  /** Search results errors */
+  errors?: Maybe<ProjectErrors>;
+  /** The names of the funders */
+  funders?: Maybe<Array<ProjectSearchResultFunder>>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not this is test/mock research project */
+  isTestProject?: Maybe<Scalars['Boolean']['output']>;
+  /** The timestamp when the project was last modified */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The id of the person who last modified the project */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The name of the person who last modified the project */
+  modifiedByName?: Maybe<Scalars['String']['output']>;
+  /** The type of research being done */
+  researchDomain?: Maybe<Scalars['String']['output']>;
+  /** The estimated date the research project will begin (use YYYY-MM-DD format) */
+  startDate?: Maybe<Scalars['String']['output']>;
+  /** The name/title of the research project */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type ProjectSearchResultCollaborator = {
+  __typename?: 'ProjectSearchResultCollaborator';
+  /** The access level of the collaborator */
+  accessLevel?: Maybe<Scalars['String']['output']>;
+  /** The name of the collaborator */
+  name?: Maybe<Scalars['String']['output']>;
+  /** The ORCiD ID */
+  orcid?: Maybe<Scalars['String']['output']>;
+};
+
+export type ProjectSearchResultContributor = {
+  __typename?: 'ProjectSearchResultContributor';
+  /** The name of the contributor */
+  name?: Maybe<Scalars['String']['output']>;
+  /** The ORCiD ID */
+  orcid?: Maybe<Scalars['String']['output']>;
+  /** The role of the contributor */
+  role?: Maybe<Scalars['String']['output']>;
+};
+
+export type ProjectSearchResultFunder = {
+  __typename?: 'ProjectSearchResultFunder';
+  /** The grant id/url */
+  grantId?: Maybe<Scalars['String']['output']>;
+  /** The name of the funder */
+  name?: Maybe<Scalars['String']['output']>;
+};
+
 export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']['output']>;
@@ -1918,11 +1984,11 @@ export type Query = {
   /** Search for a metadata standard */
   metadataStandards?: Maybe<Array<Maybe<MetadataStandard>>>;
   /** Get all of the user's projects */
-  myProjects?: Maybe<Array<Maybe<Project>>>;
+  myProjects?: Maybe<Array<Maybe<ProjectSearchResult>>>;
   /** Get the Templates that belong to the current user's affiliation (user must be an Admin) */
-  myTemplates?: Maybe<Array<Maybe<Template>>>;
+  myTemplates?: Maybe<Array<Maybe<TemplateSearchResult>>>;
   /** Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin) */
-  myVersionedTemplates?: Maybe<Array<Maybe<VersionedTemplate>>>;
+  myVersionedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
   /** Get all the research output types */
   outputTypes?: Maybe<Array<Maybe<OutputType>>>;
   /** Get a specific plan */
@@ -1962,7 +2028,7 @@ export type Query = {
   /** Search for VersionedSection whose name contains the search term */
   publishedSections?: Maybe<Array<Maybe<VersionedSection>>>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
-  publishedTemplates?: Maybe<Array<Maybe<VersionedTemplate>>>;
+  publishedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
   /** Get the specific Question based on questionId */
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
@@ -2875,6 +2941,43 @@ export type TemplateErrors = {
   visibility?: Maybe<Scalars['String']['output']>;
 };
 
+/** A search result for templates */
+export type TemplateSearchResult = {
+  __typename?: 'TemplateSearchResult';
+  /** Whether or not this Template is designated as a 'Best Practice' template */
+  bestPractice?: Maybe<Scalars['Boolean']['output']>;
+  /** The timestamp when the Template was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The id of the person who created the template */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** the name of the person who created the template */
+  createdByName?: Maybe<Scalars['String']['output']>;
+  /** A description of the purpose of the template */
+  description?: Maybe<Scalars['String']['output']>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not the Template has had any changes since it was last published */
+  isDirty?: Maybe<Scalars['Boolean']['output']>;
+  /** The last published date */
+  latestPublishDate?: Maybe<Scalars['String']['output']>;
+  /** The last published version */
+  latestPublishVersion?: Maybe<Scalars['String']['output']>;
+  /** The timestamp when the Template was last modified */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The id of the person who last modified the template */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The name of the person who last modified the template */
+  modifiedByName?: Maybe<Scalars['String']['output']>;
+  /** The name/title of the template */
+  name?: Maybe<Scalars['String']['output']>;
+  /** The display name of the affiliation that owns the Template */
+  ownerDisplayName?: Maybe<Scalars['String']['output']>;
+  /** The id of the affiliation that owns the Template */
+  ownerId?: Maybe<Scalars['String']['output']>;
+  /** The template's availability setting: Public is available to everyone, Private only your affiliation */
+  visibility?: Maybe<TemplateVisibility>;
+};
+
 /** Template version type */
 export type TemplateVersionType =
   /** Draft - saved state for internal review */
@@ -3388,6 +3491,39 @@ export type VersionedTemplateErrors = {
   visibility?: Maybe<Scalars['String']['output']>;
 };
 
+/** An abbreviated view of a Template for pages that allow search/filtering of published Templates */
+export type VersionedTemplateSearchResult = {
+  __typename?: 'VersionedTemplateSearchResult';
+  /** Whether or not this Template is designated as a 'Best Practice' template */
+  bestPractice?: Maybe<Scalars['Boolean']['output']>;
+  /** A description of the purpose of the template */
+  description?: Maybe<Scalars['String']['output']>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The timestamp when the Template was last modified */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The name of the last person who modified the Template */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The name of the last person who modified the Template */
+  modifiedByName?: Maybe<Scalars['String']['output']>;
+  /** The name/title of the template */
+  name?: Maybe<Scalars['String']['output']>;
+  /** The display name of the affiliation that owns the Template */
+  ownerDisplayName?: Maybe<Scalars['String']['output']>;
+  /** The id of the affiliation that owns the Template */
+  ownerId?: Maybe<Scalars['Int']['output']>;
+  /** The search name of the affiliation that owns the Template */
+  ownerSearchName?: Maybe<Scalars['String']['output']>;
+  /** The URI of the affiliation that owns the Template */
+  ownerURI?: Maybe<Scalars['String']['output']>;
+  /** The id of the template that this version is based on */
+  templateId?: Maybe<Scalars['Int']['output']>;
+  /** The major.minor semantic version */
+  version?: Maybe<Scalars['String']['output']>;
+  /** The template's availability setting: Public is available to everyone, Private only your affiliation */
+  visibility?: Maybe<TemplateVisibility>;
+};
+
 export type UpdateProjectContributorInput = {
   /** The contributor's affiliation URI */
   affiliationId?: InputMaybe<Scalars['String']['input']>;
@@ -3587,6 +3723,10 @@ export type ResolversTypes = {
   ProjectFunderStatus: ProjectFunderStatus;
   ProjectOutput: ResolverTypeWrapper<ProjectOutput>;
   ProjectOutputErrors: ResolverTypeWrapper<ProjectOutputErrors>;
+  ProjectSearchResult: ResolverTypeWrapper<ProjectSearchResult>;
+  ProjectSearchResultCollaborator: ResolverTypeWrapper<ProjectSearchResultCollaborator>;
+  ProjectSearchResultContributor: ResolverTypeWrapper<ProjectSearchResultContributor>;
+  ProjectSearchResultFunder: ResolverTypeWrapper<ProjectSearchResultFunder>;
   Query: ResolverTypeWrapper<{}>;
   Question: ResolverTypeWrapper<Question>;
   QuestionCondition: ResolverTypeWrapper<QuestionCondition>;
@@ -3621,6 +3761,7 @@ export type ResolversTypes = {
   TemplateCollaborator: ResolverTypeWrapper<TemplateCollaborator>;
   TemplateCollaboratorErrors: ResolverTypeWrapper<TemplateCollaboratorErrors>;
   TemplateErrors: ResolverTypeWrapper<TemplateErrors>;
+  TemplateSearchResult: ResolverTypeWrapper<TemplateSearchResult>;
   TemplateVersionType: TemplateVersionType;
   TemplateVisibility: TemplateVisibility;
   URL: ResolverTypeWrapper<Scalars['URL']['output']>;
@@ -3648,6 +3789,7 @@ export type ResolversTypes = {
   VersionedSectionErrors: ResolverTypeWrapper<VersionedSectionErrors>;
   VersionedTemplate: ResolverTypeWrapper<VersionedTemplate>;
   VersionedTemplateErrors: ResolverTypeWrapper<VersionedTemplateErrors>;
+  VersionedTemplateSearchResult: ResolverTypeWrapper<VersionedTemplateSearchResult>;
   updateProjectContributorInput: UpdateProjectContributorInput;
   updateProjectFunderInput: UpdateProjectFunderInput;
   updateUserNotificationsInput: UpdateUserNotificationsInput;
@@ -3719,6 +3861,10 @@ export type ResolversParentTypes = {
   ProjectFunderErrors: ProjectFunderErrors;
   ProjectOutput: ProjectOutput;
   ProjectOutputErrors: ProjectOutputErrors;
+  ProjectSearchResult: ProjectSearchResult;
+  ProjectSearchResultCollaborator: ProjectSearchResultCollaborator;
+  ProjectSearchResultContributor: ProjectSearchResultContributor;
+  ProjectSearchResultFunder: ProjectSearchResultFunder;
   Query: {};
   Question: Question;
   QuestionCondition: QuestionCondition;
@@ -3747,6 +3893,7 @@ export type ResolversParentTypes = {
   TemplateCollaborator: TemplateCollaborator;
   TemplateCollaboratorErrors: TemplateCollaboratorErrors;
   TemplateErrors: TemplateErrors;
+  TemplateSearchResult: TemplateSearchResult;
   URL: Scalars['URL']['output'];
   UpdateMetadataStandardInput: UpdateMetadataStandardInput;
   UpdateProjectInput: UpdateProjectInput;
@@ -3769,6 +3916,7 @@ export type ResolversParentTypes = {
   VersionedSectionErrors: VersionedSectionErrors;
   VersionedTemplate: VersionedTemplate;
   VersionedTemplateErrors: VersionedTemplateErrors;
+  VersionedTemplateSearchResult: VersionedTemplateSearchResult;
   updateProjectContributorInput: UpdateProjectContributorInput;
   updateProjectFunderInput: UpdateProjectFunderInput;
   updateUserNotificationsInput: UpdateUserNotificationsInput;
@@ -4447,6 +4595,47 @@ export type ProjectOutputErrorsResolvers<ContextType = MyContext, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ProjectSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResult'] = ResolversParentTypes['ProjectSearchResult']> = {
+  abstractText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  collaborators?: Resolver<Maybe<Array<ResolversTypes['ProjectSearchResultCollaborator']>>, ParentType, ContextType>;
+  contributors?: Resolver<Maybe<Array<ResolversTypes['ProjectSearchResultContributor']>>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  createdByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  endDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<ResolversTypes['ProjectErrors']>, ParentType, ContextType>;
+  funders?: Resolver<Maybe<Array<ResolversTypes['ProjectSearchResultFunder']>>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isTestProject?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modifiedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  researchDomain?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProjectSearchResultCollaboratorResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResultCollaborator'] = ResolversParentTypes['ProjectSearchResultCollaborator']> = {
+  accessLevel?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  orcid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProjectSearchResultContributorResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResultContributor'] = ResolversParentTypes['ProjectSearchResultContributor']> = {
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  orcid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  role?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ProjectSearchResultFunderResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResultFunder'] = ResolversParentTypes['ProjectSearchResultFunder']> = {
+  grantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type QueryResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   affiliationById?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByIdArgs, 'affiliationId'>>;
@@ -4466,9 +4655,9 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   metadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<QueryMetadataStandardArgs, 'uri'>>;
   metadataStandards?: Resolver<Maybe<Array<Maybe<ResolversTypes['MetadataStandard']>>>, ParentType, ContextType, Partial<QueryMetadataStandardsArgs>>;
-  myProjects?: Resolver<Maybe<Array<Maybe<ResolversTypes['Project']>>>, ParentType, ContextType>;
-  myTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['Template']>>>, ParentType, ContextType>;
-  myVersionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType>;
+  myProjects?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectSearchResult']>>>, ParentType, ContextType>;
+  myTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateSearchResult']>>>, ParentType, ContextType>;
+  myVersionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
   outputTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['OutputType']>>>, ParentType, ContextType>;
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanArgs, 'planId'>>;
   planCollaborators?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectCollaborator']>>>, ParentType, ContextType, RequireFields<QueryPlanCollaboratorsArgs, 'planId'>>;
@@ -4488,7 +4677,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
   publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
   publishedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
-  publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
+  publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
   question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
   questionConditions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryQuestionConditionsArgs, 'questionId'>>;
   questionOption?: Resolver<Maybe<ResolversTypes['QuestionOption']>, ParentType, ContextType, RequireFields<QueryQuestionOptionArgs, 'id'>>;
@@ -4815,6 +5004,26 @@ export type TemplateErrorsResolvers<ContextType = MyContext, ParentType extends 
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateSearchResult'] = ResolversParentTypes['TemplateSearchResult']> = {
+  bestPractice?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  createdByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isDirty?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  latestPublishDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  latestPublishVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modifiedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ownerDisplayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ownerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  visibility?: Resolver<Maybe<ResolversTypes['TemplateVisibility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export interface UrlScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['URL'], any> {
   name: 'URL';
 }
@@ -5029,6 +5238,24 @@ export type VersionedTemplateErrorsResolvers<ContextType = MyContext, ParentType
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type VersionedTemplateSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedTemplateSearchResult'] = ResolversParentTypes['VersionedTemplateSearchResult']> = {
+  bestPractice?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modifiedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ownerDisplayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ownerId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  ownerSearchName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  ownerURI?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  visibility?: Resolver<Maybe<ResolversTypes['TemplateVisibility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type Resolvers<ContextType = MyContext> = {
   AddRelatedWorkInput?: AddRelatedWorkInputResolvers<ContextType>;
   Affiliation?: AffiliationResolvers<ContextType>;
@@ -5079,6 +5306,10 @@ export type Resolvers<ContextType = MyContext> = {
   ProjectFunderErrors?: ProjectFunderErrorsResolvers<ContextType>;
   ProjectOutput?: ProjectOutputResolvers<ContextType>;
   ProjectOutputErrors?: ProjectOutputErrorsResolvers<ContextType>;
+  ProjectSearchResult?: ProjectSearchResultResolvers<ContextType>;
+  ProjectSearchResultCollaborator?: ProjectSearchResultCollaboratorResolvers<ContextType>;
+  ProjectSearchResultContributor?: ProjectSearchResultContributorResolvers<ContextType>;
+  ProjectSearchResultFunder?: ProjectSearchResultFunderResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Question?: QuestionResolvers<ContextType>;
   QuestionCondition?: QuestionConditionResolvers<ContextType>;
@@ -5103,6 +5334,7 @@ export type Resolvers<ContextType = MyContext> = {
   TemplateCollaborator?: TemplateCollaboratorResolvers<ContextType>;
   TemplateCollaboratorErrors?: TemplateCollaboratorErrorsResolvers<ContextType>;
   TemplateErrors?: TemplateErrorsResolvers<ContextType>;
+  TemplateSearchResult?: TemplateSearchResultResolvers<ContextType>;
   URL?: GraphQLScalarType;
   UpdateRelatedWorkInput?: UpdateRelatedWorkInputResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
@@ -5117,5 +5349,6 @@ export type Resolvers<ContextType = MyContext> = {
   VersionedSectionErrors?: VersionedSectionErrorsResolvers<ContextType>;
   VersionedTemplate?: VersionedTemplateResolvers<ContextType>;
   VersionedTemplateErrors?: VersionedTemplateErrorsResolvers<ContextType>;
+  VersionedTemplateSearchResult?: VersionedTemplateSearchResultResolvers<ContextType>;
 };
 


### PR DESCRIPTION
## Description

Fixes #218 and #223

- Added `TemplateSearchResult`, `VersionedTemplateSearchResult` and `ProjectSearchResult` classes to their corresponding models.
- Updated `Template`, `VersionedTemplate` and `Project` schemas and resolvers to use the new search result objects
- Fixed a bug with the `projectCollaborators` table definition which had an FKey on the `plans` table instead of `projects`

**Note that data migrations need to be run to apply the DB change**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests for new objects
- Verified the queries were working in the Apollo explorer
- Verified that the UI changes in PR are also still working using these changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules