### PR TITLE
Fix Jest Tests on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.
 - Fixed bugs related to addPlanContributor and updatePlanContributor since these were not working without missing contributorRoles
 - Converted DateTimeISO to String in schemas so that dates could be inserted into mariaDB database, and updated MySqlModel and associated unit test
 

--- a/src/__mocks__/context.ts
+++ b/src/__mocks__/context.ts
@@ -18,7 +18,7 @@ jest.mock('../datasources/mySQLDataSource', () => {
   };
 });
 
-jest.mock('../datasources/DMPHubAPI', () => {
+jest.mock('../datasources/dmphubAPI', () => {
   return {
     __esModule: true,
     Authorizer: jest.fn().mockImplementation(() => ({

--- a/src/__tests__/context.spec.ts
+++ b/src/__tests__/context.spec.ts
@@ -7,7 +7,7 @@ import { MockCache } from '../__mocks__/context';
 import { randomHex } from '../utils/helpers';
 
 // Mock dependencies
-jest.mock('../datasources/DMPHubAPI');
+jest.mock('../datasources/dmphubAPI');
 jest.mock('../datasources/mySQLDataSource');
 jest.mock('../logger');
 

--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -4,7 +4,7 @@ import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from '../../__mocks__/context';
 import { getCurrentDate } from '../../utils/helpers';
 
-jest.mock('../../dataSources/mySQLDataSource', () => {
+jest.mock('../../datasources/mySQLDataSource', () => {
   return {
     __esModule: true,
     MySQLDataSource: {


### PR DESCRIPTION
## Description

This PR fixes an issue where Jest tests were failing on Linux due to case-sensitive file paths, causing a few mocks to not import. The tests were passing on macOS because its file system is case-insensitive by default.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the tests locally on Ubuntu 24.04.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules