### PR TITLE
[Bug] - updatePlanContributor was not properly setting isPrimaryContact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- When calling `updatePlanContributors`, the resolver should set isPrimaryContact to `false` for all contributors other than the one marked as isPrimary.
 - Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.
 - Fixed bugs related to addPlanContributor and updatePlanContributor since these were not working without missing contributorRoles
 - Converted DateTimeISO to String in schemas so that dates could be inserted into mariaDB database, and updated MySqlModel and associated unit test


### PR DESCRIPTION


## Description

While working on frontend changes to Plan Members page ([389](https://github.com/CDLUC3/dmsp_frontend_prototype/pull/389)), I noticed that the `upatePlanContributors` resolver was not successfully setting `isPrimaryContact` to false for all of the plan's contributors that were not just set as isPrimaryContact.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested and ran all existing unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules