### PR TITLE
Updated addProjectCollaborator so that we pass accessLevel instead of userId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `accessLevel` to projectCollaborator and removed `userId`
 - Added new resolvers related to `projectCollaborators`. Also, when project is created, automatically add user as `projectCollaborator` with `access level`= `OWN`
 - Added dynamoDb to the docker-compose file and setup dev to use the local instance
 - Added tests for `plan` resolver and added tests for `contributor` resolver's queries

--- a/src/resolvers/collaborator.ts
+++ b/src/resolvers/collaborator.ts
@@ -125,7 +125,7 @@ export const resolvers: Resolvers = {
       }
     },
     // Add a collaborator to a Project
-    addProjectCollaborator: async (_, { projectId, email, userId }, context: MyContext): Promise<ProjectCollaborator> => {
+    addProjectCollaborator: async (_, { projectId, email, accessLevel }, context: MyContext): Promise<ProjectCollaborator> => {
       const reference = 'addProjectCollaborator resolver';
       try {
 
@@ -139,7 +139,7 @@ export const resolvers: Resolvers = {
         // If the user has permission on the Project
         if (await hasPermissionOnProject(context, project)) {
           const invitedById = context.token?.id;
-          const projectCollaborator = new ProjectCollaborator({ projectId, email, userId, invitedById });
+          const projectCollaborator = new ProjectCollaborator({ projectId, email, accessLevel, invitedById });
           const created = await projectCollaborator.create(context);
 
           if (created?.id) {

--- a/src/schemas/collaborator.ts
+++ b/src/schemas/collaborator.ts
@@ -19,7 +19,7 @@ export const typeDefs = gql`
     removeTemplateCollaborator(templateId: Int!, email: String!): TemplateCollaborator
 
     "Add a collaborator to a Plan"
-    addProjectCollaborator(projectId: Int!, email: String!, userId: Int!): ProjectCollaborator
+    addProjectCollaborator(projectId: Int!, email: String!, accessLevel: ProjectCollaboratorAccessLevel): ProjectCollaborator
     "Change a collaborator's accessLevel on a Plan"
     updateProjectCollaborator(projectCollaboratorId: Int!, accessLevel: ProjectCollaboratorAccessLevel!): ProjectCollaborator
     "Remove a ProjectCollaborator from a Plan"

--- a/src/types.ts
+++ b/src/types.ts
@@ -922,9 +922,9 @@ export type MutationAddProjectArgs = {
 
 
 export type MutationAddProjectCollaboratorArgs = {
+  accessLevel?: InputMaybe<ProjectCollaboratorAccessLevel>;
   email: Scalars['String']['input'];
   projectId: Scalars['Int']['input'];
-  userId: Scalars['Int']['input'];
 };
 
 
@@ -4284,7 +4284,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addPlanContributor?: Resolver<Maybe<ResolversTypes['PlanContributor']>, ParentType, ContextType, RequireFields<MutationAddPlanContributorArgs, 'planId' | 'projectContributorId'>>;
   addPlanFunder?: Resolver<Maybe<ResolversTypes['PlanFunder']>, ParentType, ContextType, RequireFields<MutationAddPlanFunderArgs, 'planId' | 'projectFunderId'>>;
   addProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<MutationAddProjectArgs, 'title'>>;
-  addProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationAddProjectCollaboratorArgs, 'email' | 'projectId' | 'userId'>>;
+  addProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationAddProjectCollaboratorArgs, 'email' | 'projectId'>>;
   addProjectContributor?: Resolver<Maybe<ResolversTypes['ProjectContributor']>, ParentType, ContextType, RequireFields<MutationAddProjectContributorArgs, 'input'>>;
   addProjectFunder?: Resolver<Maybe<ResolversTypes['ProjectFunder']>, ParentType, ContextType, RequireFields<MutationAddProjectFunderArgs, 'input'>>;
   addProjectOutput?: Resolver<Maybe<ResolversTypes['ProjectOutput']>, ParentType, ContextType, RequireFields<MutationAddProjectOutputArgs, 'input'>>;


### PR DESCRIPTION
## Description

Currently, the `projects/1/dmp/1/feedback/invite` page creates a new projectCollaborator by passing an `email` address and `access` level. We don't have any `userid` at that point (see screenshot of page below)

So I updated the resolver, as part of the work being done on this ticket: https://github.com/CDLUC3/dmsp_frontend_prototype/issues/381

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested with frontend page, and unit tests.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot
<img width="721" alt="image" src="https://github.com/user-attachments/assets/06f0fae4-860c-48d6-9802-60234ebe24bf" />
