### PR TITLE
Pagination

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -7,6 +7,10 @@ AWS_REGION=us-east-1
 # The URL your organization - should equate to an entry in the `affiliations.uri`.
 # Prefer the ROR URL here
 DEFAULT_AFFILIATION_URI=http://localhost:3000/affiliations/123
+# The default number of items that will be returned in paginated queries
+DEFAULT_SEARCH_LIMIT=20
+# The maximum number of items that can be returned in paginated queries
+MAXIMUM_SEARCH_LIMIT=100
 
 # Logging level
 LOG_LEVEL=debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `paginateResults` helper function to `MySQLModel`.
 - Added `accessLevel` to projectCollaborator and removed `userId`
 - Added new resolvers related to `projectCollaborators`. Also, when project is created, automatically add user as `projectCollaborator` with `access level`= `OWN`
 - Added dynamoDb to the docker-compose file and setup dev to use the local instance
@@ -75,6 +76,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Updated `publishedTemplates`, `users`, `myTemplates`, `topLevelResearchDomains`, `repositories`, `myProjects`, `metadataStandards`, `licenses`, `affiliations` queries to use the new `paginationService`
 - Format ORCID identifiers consistently, in the `Contributor` and `User` models, the `projectImport` resolver and `orcid` scalar.
 - Changed a number of GraphQL definitions to PascalCase.
 - Fixed projectCollaborators table which had an FKey on the plans table instead of the projects table

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [Building for Production](#building-for-production)
     - [Managing the databases](#managing-the-database)
 - [Querying the Apollo Server](#querying-apollo-server)
+    - [Pagination](#pagination)
     - [Errors](#errors)
 - [Development](#development)
     - [Data Model](#data-model)
@@ -281,6 +282,51 @@ async function fetchTemplateCollaborators() {
 
 fetchTemplateCollaborators();
 ```
+
+### Pagination
+
+Most queries that return multiple results can handle pagination. This means that the query can accept a `cursor` and a `limit` argument and will also return those values in the resultset.
+
+For example an initial query for the list of published templates:
+```
+query PublishedTemplates($term: String) {
+  publishedTemplates(term: $term) {
+    cursor
+    totalCount
+    versionedTemplates {
+      id
+      name
+    }
+    error {
+      general
+    }
+  }
+}
+```
+
+Might return something like this (assuming the default limit was 2):
+```
+{
+  "cursor": 342,
+  "limit": 2,
+  "totalCount": 5,
+  "versionedTemplates": [
+    { "id": 12, "name": "Template A" },
+    { "id": 286, "name": "Template B" },
+  ],
+  "error": {
+    "general": null
+  }
+}
+```
+
+Then a subsequent request using the cursor would return the next 2 records.
+
+The cursor is specific to the type of record. In most cases it will be the id of the next item, but in other cases it might be a URI or some other string value.
+
+Note that the default limit and the maximum allowed limit are defined in `src/config/generalConfig` and can be overridden with environment variables.
+
+If the cursor specified does not exist the an error is returned (e.g. "Cursor 9999 not found") along with an empty array of results and a null cursor.
 
 ### Errors
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -66,6 +66,8 @@ jest.mock('../config/generalConfig', () => ({
     domain: 'localhost:3000',
     applicationName: 'My test app',
     defaultAffiliatioURI: 'https://ror.org/1234abcd',
+    defaultSearchLimit: 5,
+    maximumSearchLimit: 10,
 
     dmpIdBaseURL: 'http://dmsp.com/',
     dmpIdShoulder: '11.22222/C3',

--- a/src/config/generalConfig.ts
+++ b/src/config/generalConfig.ts
@@ -21,6 +21,8 @@ export const generalConfig = {
   domain: process.env.DOMAIN,
   applicationName: env === 'prd' ? process.env.APP_NAME : `${process.env.APP_NAME} (${env})`,
   defaultAffiliatioURI: process.env.DEFAULT_AFFILIATION_URI,
+  defaultSearchLimit: Number.parseInt(process.env.DEFAULT_SEARCH_LIMIT) || 20,
+  maximumSearchLimit: Number.parseInt(process.env.MAXIMUM_SEARCH_LIMIT) || 100,
 
   dmpIdBaseURL: process.env.DMP_ID_BASE_URL || 'https://doi.org/',
   dmpIdShoulder: process.env.DMP_ID_SHOULDER,

--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -16,6 +16,7 @@ jest.mock('../../dataSources/mysql', () => {
 });
 
 class TestImplementation extends MySqlModel {
+  public name: string;
   public testA: string;
   public testB: number;
   public testC: string[];
@@ -26,6 +27,7 @@ class TestImplementation extends MySqlModel {
   constructor(opts) {
     super(opts.id, opts.created, opts.createdById, opts.modified, opts.modifiedById);
 
+    this.name = opts.name ?? casual.sentence;
     this.testA = opts.testA;
     this.testB = opts.testB;
     this.testC = opts.testC;

--- a/src/resolvers/__tests__/affiliation.spec.ts
+++ b/src/resolvers/__tests__/affiliation.spec.ts
@@ -188,8 +188,8 @@ describe('affiliationById query', () => {
 describe('affiliations query', () => {
   beforeEach(() => {
     query = `
-      query Affiliations($name: String!) {
-        affiliations (name: $name) {
+      query Affiliations($term: String!) {
+        affiliations (term: $term) {
           cursor
           totalCount
           error {
@@ -209,7 +209,7 @@ describe('affiliations query', () => {
   });
 
   it('returns the expected affiliations when successful', async () => {
-    const variables = { name: affiliationStore[0].name };
+    const variables = { term: affiliationStore[0].name };
     const resp = await executeQuery(query, variables, mockToken());
 
     assert(resp.body.kind === 'single');
@@ -227,7 +227,7 @@ describe('affiliations query', () => {
 
   it('returns an empty array when no matches are found', async () => {
     // Use a series of number since it will never match one of the names
-    const variables = { name: '1234567890' };
+    const variables = { term: '1234567890' };
     const resp = await executeQuery(query, variables, mockToken());
 
     assert(resp.body.kind === 'single');
@@ -239,7 +239,7 @@ describe('affiliations query', () => {
   it('returns a 500 when a fatal error occurs', async () => {
     jest.spyOn(AffiliationSearch, 'search').mockImplementation(() => { throw new Error('Error!') });
 
-    const variables = { name: casual.company_name };
+    const variables = { term: casual.company_name };
     const resp = await executeQuery(query, variables, mockToken());
 
     assert(resp.body.kind === 'single');

--- a/src/resolvers/__tests__/affiliation.spec.ts
+++ b/src/resolvers/__tests__/affiliation.spec.ts
@@ -195,7 +195,7 @@ describe('affiliations query', () => {
           error {
             general
           }
-          affiliations {
+          feed {
             id
             uri
             displayName
@@ -216,7 +216,7 @@ describe('affiliations query', () => {
     expect(resp.body.singleResult.errors).toBeUndefined();
     expect(resp.body.singleResult.data?.affiliations).toBeDefined();
     // Since we're not returning everything, verify the fields we are returning
-    const affiliation = resp.body.singleResult.data?.affiliations.affiliations[0];
+    const affiliation = resp.body.singleResult.data?.affiliations.feed[0];
     expect(affiliation?.id).toEqual(affiliationStore[0].id);
     expect(affiliation?.displayName).toEqual(affiliationStore[0].displayName);
     expect(affiliation?.uri).toEqual(affiliationStore[0].uri);

--- a/src/resolvers/__tests__/affiliation.spec.ts
+++ b/src/resolvers/__tests__/affiliation.spec.ts
@@ -190,12 +190,19 @@ describe('affiliations query', () => {
     query = `
       query Affiliations($name: String!) {
         affiliations (name: $name) {
-          id
-          uri
-          displayName
-          funder
-          types
-          apiTarget
+          cursor
+          totalCount
+          error {
+            general
+          }
+          affiliations {
+            id
+            uri
+            displayName
+            funder
+            types
+            apiTarget
+          }
         }
       }
     `;
@@ -209,12 +216,13 @@ describe('affiliations query', () => {
     expect(resp.body.singleResult.errors).toBeUndefined();
     expect(resp.body.singleResult.data?.affiliations).toBeDefined();
     // Since we're not returning everything, verify the fields we are returning
-    expect(resp.body.singleResult.data?.affiliations[0]?.id).toEqual(affiliationStore[0].id);
-    expect(resp.body.singleResult.data?.affiliations[0]?.displayName).toEqual(affiliationStore[0].displayName);
-    expect(resp.body.singleResult.data?.affiliations[0]?.uri).toEqual(affiliationStore[0].uri);
-    expect(resp.body.singleResult.data?.affiliations[0]?.funder).toEqual(affiliationStore[0].funder);
-    expect(resp.body.singleResult.data?.affiliations[0]?.types).toEqual(affiliationStore[0].types);
-    expect(resp.body.singleResult.data?.affiliations[0]?.apiTarget).toEqual(affiliationStore[0].apiTarget);
+    const affiliation = resp.body.singleResult.data?.affiliations.affiliations[0];
+    expect(affiliation?.id).toEqual(affiliationStore[0].id);
+    expect(affiliation?.displayName).toEqual(affiliationStore[0].displayName);
+    expect(affiliation?.uri).toEqual(affiliationStore[0].uri);
+    expect(affiliation?.funder).toEqual(affiliationStore[0].funder);
+    expect(affiliation?.types).toEqual(affiliationStore[0].types);
+    expect(affiliation?.apiTarget).toEqual(affiliationStore[0].apiTarget);
   });
 
   it('returns an empty array when no matches are found', async () => {

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -15,10 +15,10 @@ export const resolvers: Resolvers = {
     },
 
     // returns an array of Affiliations that match the search criteria
-    affiliations: async (_, { name, funderOnly, cursor, limit }, context: MyContext): Promise<AffiliationSearchResults> => {
+    affiliations: async (_, { term, funderOnly, cursor, limit }, context: MyContext): Promise<AffiliationSearchResults> => {
       const reference = 'affiliations resolver';
       try {
-        const results = await AffiliationSearch.search(context, { name, funderOnly });
+        const results = await AffiliationSearch.search(context, { name: term, funderOnly });
 
         if (results) {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -24,7 +24,7 @@ export const resolvers: Resolvers = {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
           return {
-            affiliations: items,
+            feed: items,
             totalCount: results.length,
             cursor: nextCursor as number,
             error: {

--- a/src/resolvers/license.ts
+++ b/src/resolvers/license.ts
@@ -1,19 +1,33 @@
 
 import { formatLogMessage } from '../logger';
-import { Resolvers } from "../types";
+import { LicenseSearchResults, Resolvers } from "../types";
 import { DEFAULT_DMPTOOL_LICENSE_URL, License } from "../models/License";
 import { MyContext } from '../context';
 import { isAdmin, isSuperAdmin } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
 import { GraphQLError } from 'graphql';
+import { paginateResults } from '../services/paginationService';
 
 export const resolvers: Resolvers = {
   Query: {
     // searches the licenses table or returns all licenses if no critieria is specified
-    licenses: async (_, { term }, context: MyContext): Promise<License[]> => {
+    licenses: async (_, { term, cursor, limit }, context: MyContext): Promise<LicenseSearchResults> => {
       const reference = 'licenses resolver';
       try {
-        return await License.search(reference, context, term);
+        const results =  await License.search(reference, context, term);
+
+        if (results) {
+          const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
+
+          return {
+            licenses: items,
+            totalCount: results.length,
+            cursor: nextCursor as number,
+            error: {
+              general: error,
+            }
+          }
+        }
       } catch (err) {
         formatLogMessage(context).error(err, `Failure in ${reference}`);
         throw InternalServerError();

--- a/src/resolvers/license.ts
+++ b/src/resolvers/license.ts
@@ -20,7 +20,7 @@ export const resolvers: Resolvers = {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
           return {
-            licenses: items,
+            feed: items,
             totalCount: results.length,
             cursor: nextCursor as number,
             error: {

--- a/src/resolvers/metadataStandard.ts
+++ b/src/resolvers/metadataStandard.ts
@@ -21,7 +21,7 @@ export const resolvers: Resolvers = {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
           return {
-            metadataStandards: items,
+            feed: items,
             totalCount: results.length,
             cursor: nextCursor as number,
             error: {

--- a/src/resolvers/metadataStandard.ts
+++ b/src/resolvers/metadataStandard.ts
@@ -1,20 +1,34 @@
 
 import { formatLogMessage } from '../logger';
-import { Resolvers } from "../types";
+import { MetadataStandardSearchResults, Resolvers } from "../types";
 import { DEFAULT_DMPTOOL_METADATA_STANDARD_URL, MetadataStandard } from "../models/MetadataStandard";
 import { MyContext } from '../context';
 import { isAdmin, isAuthorized, isSuperAdmin } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
 import { ResearchDomain } from '../models/ResearchDomain';
 import { GraphQLError } from 'graphql';
+import { paginateResults } from '../services/paginationService';
 
 export const resolvers: Resolvers = {
   Query: {
     // searches the metadata standards table or returns all standards if no critieria is specified
-    metadataStandards: async (_, { term, researchDomainId }, context: MyContext): Promise<MetadataStandard[]> => {
+    metadataStandards: async (_, { term, researchDomainId, cursor, limit }, context: MyContext): Promise<MetadataStandardSearchResults> => {
       const reference = 'metadataStandards resolver';
       try {
-        return await MetadataStandard.search(reference, context, term, researchDomainId);
+        const results = await MetadataStandard.search(reference, context, term, researchDomainId);
+
+        if (results) {
+          const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
+
+          return {
+            metadataStandards: items,
+            totalCount: results.length,
+            cursor: nextCursor as number,
+            error: {
+              general: error,
+            }
+          }
+        }
       } catch (err) {
         formatLogMessage(context).error(err, `Failure in ${reference}`);
         throw InternalServerError();

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -32,7 +32,7 @@ export const resolvers: Resolvers = {
             const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
             return {
-              projects: items,
+              feed: items,
               totalCount: results.length,
               cursor: nextCursor as number,
               error: {

--- a/src/resolvers/repository.ts
+++ b/src/resolvers/repository.ts
@@ -1,6 +1,6 @@
 
 import { formatLogMessage } from '../logger';
-import { Resolvers } from "../types";
+import { RepositorySearchResults, Resolvers } from "../types";
 import { DEFAULT_DMPTOOL_REPOSITORY_URL, Repository, RepositoryType } from "../models/Repository";
 import { MyContext } from '../context';
 import { isAdmin, isAuthorized, isSuperAdmin } from '../services/authService';
@@ -8,17 +8,31 @@ import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError
 import { ResearchDomain } from '../models/ResearchDomain';
 import { stringToEnumValue } from '../utils/helpers';
 import { GraphQLError } from 'graphql';
+import { paginateResults } from '../services/paginationService';
 
 export const resolvers: Resolvers = {
   Query: {
     // searches the repositories table or returns all repos if no criteria is specified
-    repositories: async (_, { input }, context: MyContext): Promise<Repository[]> => {
+    repositories: async (_, { input }, context: MyContext): Promise<RepositorySearchResults> => {
       const reference = 'repositories resolver';
       try {
         if (isAuthorized(context.token)) {
-          const { term, researchDomainId, repositoryType } = input
+          const { term, researchDomainId, repositoryType, cursor, limit } = input
           const repoType = stringToEnumValue(RepositoryType, repositoryType);
-          return await Repository.search(reference, context, term, researchDomainId, repoType);
+          const results = await Repository.search(reference, context, term, researchDomainId, repoType);
+
+          if (results) {
+            const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
+
+            return {
+              repositories: items,
+              totalCount: results.length,
+              cursor: nextCursor as number,
+              error: {
+                general: error,
+              }
+            }
+          }
         }
         throw AuthenticationError();
       } catch (err) {

--- a/src/resolvers/repository.ts
+++ b/src/resolvers/repository.ts
@@ -25,7 +25,7 @@ export const resolvers: Resolvers = {
             const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
             return {
-              repositories: items,
+              feed: items,
               totalCount: results.length,
               cursor: nextCursor as number,
               error: {

--- a/src/resolvers/researchDomain.ts
+++ b/src/resolvers/researchDomain.ts
@@ -20,7 +20,7 @@ export const resolvers: Resolvers = {
             const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
             return {
-              researchDomains: items,
+              feed: items,
               totalCount: results.length,
               cursor: nextCursor as number,
               error: {

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -30,7 +30,7 @@ export const resolvers: Resolvers = {
             const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
             return {
-              templateSearchResults: items,
+              feed: items,
               totalCount: results.length,
               cursor: nextCursor as number,
               error: {

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -48,7 +48,7 @@ export const resolvers: Resolvers = {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
           return {
-            users: items,
+            feed: items,
             totalCount: results.length,
             cursor: nextCursor as number,
             error: {

--- a/src/resolvers/versionedSection.ts
+++ b/src/resolvers/versionedSection.ts
@@ -42,7 +42,7 @@ export const resolvers: Resolvers = {
         const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
         return {
-          versionedSections: items,
+          feed: items,
           totalCount: results.length,
           cursor: nextCursor as number,
           error: {

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -42,7 +42,7 @@ export const resolvers: Resolvers = {
           const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
 
           return {
-            versionedTemplates: items,
+            feed: items,
             totalCount: results.length,
             cursor: nextCursor as number,
             error: {

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -1,4 +1,4 @@
-import { Resolvers } from "../types";
+import { PublishedTemplateResults, Resolvers } from "../types";
 import { VersionedTemplate, VersionedTemplateSearchResult } from "../models/VersionedTemplate";
 import { User } from '../models/User';
 import { MyContext } from "../context";
@@ -9,10 +9,11 @@ import { AuthenticationError, ForbiddenError, InternalServerError } from "../uti
 import { isAdmin } from "../services/authService";
 import { formatLogMessage } from "../logger";
 import { GraphQLError } from "graphql";
+import { paginateResults } from "../services/paginationService";
 
 export const resolvers: Resolvers = {
   Query: {
-    // Get all of the PublishedTemplates for the specified Template (a.k. the Template history)
+    // Get all of the versions for the specified VersionedTemplate (a.k. the Template history)
     //    - called from the Template history page
     templateVersions: async (_, { templateId }, context: MyContext): Promise<VersionedTemplate[]> => {
       const reference = 'templateVersions resolver';
@@ -32,11 +33,22 @@ export const resolvers: Resolvers = {
 
     // Search for PublishedTemplates whose name or owning Org's name contains the search term
     //    - called by the Template Builder - prior template selection page
-    publishedTemplates: async (_, { term }, context: MyContext): Promise<VersionedTemplateSearchResult[]> => {
+    publishedTemplates: async (_, { term, cursor, limit }, context: MyContext): Promise<PublishedTemplateResults> => {
       const reference = 'publishedTemplates resolver';
+
       try {
         if (isAdmin(context.token)) {
-          return await VersionedTemplateSearchResult.search(reference, context, term);
+          const results = await VersionedTemplateSearchResult.search(reference, context, term);
+          const { items, nextCursor, error } = paginateResults(results, cursor, 'id', limit);
+
+          return {
+            versionedTemplates: items,
+            totalCount: results.length,
+            cursor: nextCursor as number,
+            error: {
+              general: error,
+            }
+          }
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/schemas/affiliation.ts
+++ b/src/schemas/affiliation.ts
@@ -41,7 +41,7 @@ export const typeDefs = gql`
 
   type AffiliationSearchResults {
     "The list of Affiliation search results"
-    affiliations: [AffiliationSearch]
+    feed: [AffiliationSearch]
     "The id of the last Affiliation in the results"
     cursor: Int
     "The total number of Affiliation search results"

--- a/src/schemas/affiliation.ts
+++ b/src/schemas/affiliation.ts
@@ -9,7 +9,9 @@ export const typeDefs = gql`
     "Retrieve a specific Affiliation by its URI"
     affiliationByURI(uri: String!): Affiliation
     "Perform a search for Affiliations matching the specified name"
-    affiliations(name: String!, funderOnly: Boolean): [AffiliationSearch]
+    affiliations(name: String!, funderOnly: Boolean, cursor: Int, limit: Int): AffiliationSearchResults
+    "Returns a list of the top 20 funders ranked by popularity (nbr of plans) for the past year"
+    popularFunders: [FunderPopularityResult]
   }
 
   extend type Mutation {
@@ -23,9 +25,9 @@ export const typeDefs = gql`
 
   "Search result - An abbreviated version of an Affiliation"
   type AffiliationSearch {
-    "The unique identifer for the affiliation (typically the ROR id)"
+    "The unique identifer for the affiliation"
     id: Int!
-    "The URI of the affiliation"
+    "The URI of the affiliation (typically the ROR id)"
     uri: String!
     "The official display name"
     displayName: String!
@@ -35,6 +37,29 @@ export const typeDefs = gql`
     types: [AffiliationType!]
     "Has an API that be used to search for project/award information"
     apiTarget: String
+  }
+
+  type AffiliationSearchResults {
+    "The list of Affiliation search results"
+    affiliations: [AffiliationSearch]
+    "The id of the last Affiliation in the results"
+    cursor: Int
+    "The total number of Affiliation search results"
+    totalCount: Int
+    "Any errors associated with the search"
+    error: PaginationError
+  }
+
+  "A result of the most popular funders"
+  type FunderPopularityResult {
+    "The unique identifer for the affiliation"
+    id: Int!
+    "The URI of the affiliation (typically the ROR id)"
+    uri: String!
+    "The official display name"
+    displayName: String!
+    "The number of plans associated with this funder in the past year"
+    nbrPlans: Int!
   }
 
   "The provenance of an Affiliation record"

--- a/src/schemas/affiliation.ts
+++ b/src/schemas/affiliation.ts
@@ -9,7 +9,7 @@ export const typeDefs = gql`
     "Retrieve a specific Affiliation by its URI"
     affiliationByURI(uri: String!): Affiliation
     "Perform a search for Affiliations matching the specified name"
-    affiliations(name: String!, funderOnly: Boolean, cursor: Int, limit: Int): AffiliationSearchResults
+    affiliations(term: String!, funderOnly: Boolean, cursor: Int, limit: Int): AffiliationSearchResults
     "Returns a list of the top 20 funders ranked by popularity (nbr of plans) for the past year"
     popularFunders: [FunderPopularityResult]
   }

--- a/src/schemas/answer.ts
+++ b/src/schemas/answer.ts
@@ -2,10 +2,10 @@ import gql from "graphql-tag";
 
 export const typeDefs = gql`
   extend type Query {
-    "Get all rounds of admin feedback for the plan"
+    "Get all answers for the given project and plan and section"
     answers(projectId: Int!, planId: Int!, versionedSectionId: Int!): [Answer]
 
-    "Get all of the comments associated with the round of admin feedback"
+    "Get the sepecific answer"
     answer(projectId: Int!, answerId: Int!): Answer
   }
 

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -20,4 +20,9 @@ export const typeDefs = gql`
   type Mutation {
     _empty: String
   }
+
+  type PaginationError {
+    "The error message"
+    general: String
+  }
 `;

--- a/src/schemas/license.ts
+++ b/src/schemas/license.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 export const typeDefs = gql`
   extend type Query {
     "Search for a license"
-    licenses(term: String): [License]
+    licenses(term: String, cursor: Int, limit: Int): LicenseSearchResults
     "Return the recommended Licenses"
     recommendedLicenses(recommended: Boolean!): [License]
     "Fetch a specific license"
@@ -45,6 +45,17 @@ export const typeDefs = gql`
     description: String
     "Whether or not the license is recommended"
     recommended: Boolean!
+  }
+
+  type LicenseSearchResults {
+    "The list of licenses"
+    licenses: [License]
+    "The id of the last License in the results"
+    cursor: Int
+    "The total number of licenses"
+    totalCount: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "A collection of errors related to the License"

--- a/src/schemas/license.ts
+++ b/src/schemas/license.ts
@@ -49,7 +49,7 @@ export const typeDefs = gql`
 
   type LicenseSearchResults {
     "The list of licenses"
-    licenses: [License]
+    feed: [License]
     "The id of the last License in the results"
     cursor: Int
     "The total number of licenses"

--- a/src/schemas/metadataStandard.ts
+++ b/src/schemas/metadataStandard.ts
@@ -49,7 +49,7 @@ export const typeDefs = gql`
 
   type MetadataStandardSearchResults {
     "The list of metadata standards"
-    metadataStandards: [MetadataStandard]
+    feed: [MetadataStandard]
     "The id of the last MetadataStandard in the results"
     cursor: Int
     "The total number of metadata standards"

--- a/src/schemas/metadataStandard.ts
+++ b/src/schemas/metadataStandard.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 export const typeDefs = gql`
   extend type Query {
     "Search for a metadata standard"
-    metadataStandards(term: String, researchDomainId: Int): [MetadataStandard]
+    metadataStandards(term: String, researchDomainId: Int, cursor: Int, limit: Int): MetadataStandardSearchResults
     "Fetch a specific metadata standard"
     metadataStandard(uri: String!): MetadataStandard
   }
@@ -45,6 +45,17 @@ export const typeDefs = gql`
     researchDomains: [ResearchDomain!]
     "Keywords to assist in finding the metadata standard"
     keywords: [String!]
+  }
+
+  type MetadataStandardSearchResults {
+    "The list of metadata standards"
+    metadataStandards: [MetadataStandard]
+    "The id of the last MetadataStandard in the results"
+    cursor: Int
+    "The total number of metadata standards"
+    totalCount: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "A collection of errors related to the MetadataStandard"

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -65,7 +65,7 @@ export const projectTypeDefs = gql`
 
   type ProjectSearchResults {
     "The list of projects"
-    projects: [ProjectSearchResult]
+    feed: [ProjectSearchResult]
     "The id of the last ProjectSearchResult in the results"
     cursor: Int
     "The total number of projects"

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -6,7 +6,7 @@ import {typeDefs as funderTypeDefs} from "./funder"
 export const projectTypeDefs = gql`
   extend type Query {
     "Get all of the user's projects"
-    myProjects: [ProjectSearchResult]
+    myProjects(cursor: Int, limit: Int): ProjectSearchResults
 
     "Get a specific project"
     project(projectId: Int!): Project
@@ -61,6 +61,17 @@ export const projectTypeDefs = gql`
     funders: [ProjectSearchResultFunder!]
     "Search results errors"
     errors: ProjectErrors
+  }
+
+  type ProjectSearchResults {
+    "The list of projects"
+    projects: [ProjectSearchResult]
+    "The id of the last ProjectSearchResult in the results"
+    cursor: Int
+    "The total number of projects"
+    totalCount: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "DMP Tool Project type"

--- a/src/schemas/repository.ts
+++ b/src/schemas/repository.ts
@@ -62,7 +62,7 @@ export const typeDefs = gql`
 
   type RepositorySearchResults {
     "The list of repositories"
-    repositories: [Repository]
+    feed: [Repository]
     "The total number of results"
     totalCount: Int
     "The id of the last Repository in the results"

--- a/src/schemas/repository.ts
+++ b/src/schemas/repository.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 export const typeDefs = gql`
   extend type Query {
     "Search for a repository"
-    repositories(input: RepositorySearchInput!): [Repository]
+    repositories(input: RepositorySearchInput!): RepositorySearchResults
     "Fetch a specific repository"
     repository(uri: String!): Repository
   }
@@ -60,6 +60,17 @@ export const typeDefs = gql`
     repositoryTypes: [RepositoryType!]
   }
 
+  type RepositorySearchResults {
+    "The list of repositories"
+    repositories: [Repository]
+    "The total number of results"
+    totalCount: Int
+    "The id of the last Repository in the results"
+    cursor: Int
+    "Any errors associated with the search"
+    error: PaginationError
+  }
+
   "A collection of errors related to the Repository"
   type RepositoryErrors {
     "General error messages such as the object already exists"
@@ -81,6 +92,10 @@ export const typeDefs = gql`
     repositoryType: String
     "The research domain associated with the repository"
     researchDomainId: Int
+    "The cursor for pagination"
+    cursor: Int
+    "The number of results to return"
+    limit: Int
   }
 
   input AddRepositoryInput {

--- a/src/schemas/researchDomain.ts
+++ b/src/schemas/researchDomain.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 export const typeDefs = gql`
   extend type Query {
     "Get all of the top level research domains (the most generic ones)"
-    topLevelResearchDomains: [ResearchDomain]
+    topLevelResearchDomains(cursor: Int, limit: Int): ResearchDomainResults
     "Get all of the research domains related to the specified top level domain (more nuanced ones)"
     childResearchDomains(parentResearchDomainId: Int!): [ResearchDomain]
   }
@@ -37,6 +37,17 @@ export const typeDefs = gql`
     childResearchDomains: [ResearchDomain!]
   }
 
+  type ResearchDomainResults {
+    "The list of research domains"
+    researchDomains: [ResearchDomain]
+    "The id of the last ResearchDomain in the results"
+    cursor: Int
+    "The total number of research domains"
+    totalCount: Int
+    "Any errors associated with the search"
+    error: PaginationError
+  }
+
   "A collection of errors related to the ResearchDomain"
   type ResearchDomainErrors {
     "General error messages such as the object already exists"
@@ -49,4 +60,3 @@ export const typeDefs = gql`
     childResearchDomainIds: String
   }
 `;
-

--- a/src/schemas/researchDomain.ts
+++ b/src/schemas/researchDomain.ts
@@ -39,7 +39,7 @@ export const typeDefs = gql`
 
   type ResearchDomainResults {
     "The list of research domains"
-    researchDomains: [ResearchDomain]
+    feed: [ResearchDomain]
     "The id of the last ResearchDomain in the results"
     cursor: Int
     "The total number of research domains"

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -67,7 +67,7 @@ export const typeDefs = gql`
    "Paginated results of a search for templates"
    type TemplateSearchResults {
     "The TemplateSearchResults that match the search criteria"
-    templateSearchResults: [TemplateSearchResult]
+    feed: [TemplateSearchResult]
     "The total number of results"
     totalCount: Int
     "The id of the last TemplateSearchResult in the results"

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -3,7 +3,7 @@ import gql from "graphql-tag";
 export const typeDefs = gql`
   extend type Query {
     "Get the Templates that belong to the current user's affiliation (user must be an Admin)"
-    myTemplates: [TemplateSearchResult]
+    myTemplates(cursor: Int, limit: Int): TemplateSearchResults
     "Get the specified Template (user must be an Admin)"
     template(templateId: Int!): Template
   }
@@ -62,6 +62,18 @@ export const typeDefs = gql`
     modifiedByName: String
     "The timestamp when the Template was last modified"
     modified: String
+  }
+
+   "Paginated results of a search for templates"
+   type TemplateSearchResults {
+    "The TemplateSearchResults that match the search criteria"
+    templateSearchResults: [TemplateSearchResult]
+    "The total number of results"
+    totalCount: Int
+    "The id of the last TemplateSearchResult in the results"
+    cursor: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "A Template used to create DMPs"

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -115,7 +115,7 @@ export const typeDefs = gql`
   "Paginated results of a search for users"
   type UserResults {
     "The users that match the search criteria"
-    users: [User]
+    feed: [User]
     "The total number of results"
     totalCount: Int
     "The id of the last VersionedTemplate in the results"

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -4,8 +4,8 @@ export const typeDefs = gql`
   extend type Query {
     "Returns the currently logged in user's information"
     me: User
-    "Returns all of the users associated with the current user's affiliation (Admin only)"
-    users: [User]
+    "Returns all of the users associated with the current admin's affiliation (Super admins get everything)"
+    users(term: String, cursor: Int, limit: Int): UserResults
     "Returns the specified user (Admin only)"
     user(userId: Int!): User
   }
@@ -110,6 +110,18 @@ export const typeDefs = gql`
 
     "The user's email addresses"
     emails: [UserEmail]
+  }
+
+  "Paginated results of a search for users"
+  type UserResults {
+    "The users that match the search criteria"
+    users: [User]
+    "The total number of results"
+    totalCount: Int
+    "The id of the last VersionedTemplate in the results"
+    cursor: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "A collection of errors related to the User"

--- a/src/schemas/versionedSection.ts
+++ b/src/schemas/versionedSection.ts
@@ -5,7 +5,7 @@ export const typeDefs = gql`
     "Get all of the VersionedSection for the specified Section ID"
     sectionVersions(sectionId: Int!): [VersionedSection]
     "Search for VersionedSection whose name contains the search term"
-    publishedSections(term: String!): [VersionedSection]
+    publishedSections(term: String!, cursor: Int, limit: Int): PublishedSectionSearchResult
   }
 
   "Section version type"
@@ -50,6 +50,18 @@ export const typeDefs = gql`
 
     "The questions associated with this VersionedSection"
     versionedQuestions: [VersionedQuestion!]
+  }
+
+  "Paginated results of a search for publishedTemplates query"
+  type PublishedSectionSearchResult {
+    "The versioned sections"
+    versionedSections: [VersionedSection]
+    "The total number of results"
+    totalCount: Int
+    "The id of the last VersionedSection in the results"
+    cursor: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "A collection of errors related to the VersionedSection"

--- a/src/schemas/versionedSection.ts
+++ b/src/schemas/versionedSection.ts
@@ -55,7 +55,7 @@ export const typeDefs = gql`
   "Paginated results of a search for publishedTemplates query"
   type PublishedSectionSearchResult {
     "The versioned sections"
-    versionedSections: [VersionedSection]
+    feed: [VersionedSection]
     "The total number of results"
     totalCount: Int
     "The id of the last VersionedSection in the results"

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -21,7 +21,7 @@ export const typeDefs = gql`
   "Paginated results of a search for publishedTemplates query"
   type PublishedTemplateResults {
     "The versioned template results"
-    versionedTemplates: [VersionedTemplateSearchResult]
+    feed: [VersionedTemplateSearchResult]
     "The total number of results"
     totalCount: Int
     "The id of the last VersionedTemplate in the results"

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -5,7 +5,7 @@ export const typeDefs = gql`
     "Get all of the VersionedTemplate for the specified Template (a.k. the Template history)"
     templateVersions(templateId: Int!): [VersionedTemplate]
     "Search for VersionedTemplate whose name or owning Org's name contains the search term"
-    publishedTemplates(term: String): [VersionedTemplateSearchResult]
+    publishedTemplates(term: String, cursor: Int, limit: Int): PublishedTemplateResults
     "Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin)"
     myVersionedTemplates: [VersionedTemplateSearchResult]
   }
@@ -16,6 +16,18 @@ export const typeDefs = gql`
     DRAFT
     "Published - saved state for use when creating DMPs"
     PUBLISHED
+  }
+
+  "Paginated results of a search for publishedTemplates query"
+  type PublishedTemplateResults {
+    "The versioned template results"
+    versionedTemplates: [VersionedTemplateSearchResult]
+    "The total number of results"
+    totalCount: Int
+    "The id of the last VersionedTemplate in the results"
+    cursor: Int
+    "Any errors associated with the search"
+    error: PaginationError
   }
 
   "An abbreviated view of a Template for pages that allow search/filtering of published Templates"
@@ -48,6 +60,9 @@ export const typeDefs = gql`
     modifiedByName: String
     "The timestamp when the Template was last modified"
     modified: String
+
+    "The id of the last VersionedTemplate in the results"
+    cursor: String
   }
 
   "A snapshot of a Template when it became published. DMPs are created from published templates"

--- a/src/services/__tests__/paginationService.spec.ts
+++ b/src/services/__tests__/paginationService.spec.ts
@@ -1,0 +1,157 @@
+import casual from "casual";
+import { Affiliation } from "../../models/Affiliation";
+import { paginateResults } from "../paginationService";
+import { generalConfig } from "../../config/generalConfig";
+
+describe('paginateResults', () => {
+  let queryResults;
+
+  beforeEach(() => {
+    queryResults = [
+      new Affiliation({ id: casual.integer(1, 9999), name: casual.sentence }),
+      new Affiliation({ id: casual.integer(1, 9999), name: casual.sentence }),
+      new Affiliation({ id: casual.integer(1, 9999), name: casual.sentence }),
+      new Affiliation({ id: casual.integer(1, 9999), name: casual.sentence }),
+      new Affiliation({ id: casual.integer(1, 9999), name: casual.sentence }),
+    ];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty itemset with no errors and no cursor if the the items were empty', () => {
+    const cursor = queryResults[1].id;
+    const limit = 2;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults([], cursor, field, limit);
+
+    expect(items.length).toEqual(0);
+    expect(nextCursor).toBeFalsy();
+    expect(error).toBeFalsy();
+  });
+
+  it('uses the specified limit', () => {
+    const limit = 1;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, limit);
+
+    expect(items.length).toEqual(1);
+    expect(nextCursor).toEqual(queryResults[0].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('uses the default limit if no limit is specified', () => {
+    generalConfig.defaultSearchLimit = 2;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, null);
+
+    expect(items.length).toEqual(2);
+    expect(nextCursor).toEqual(queryResults[1].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('uses the default limit if the specified limit was zero', () => {
+    generalConfig.defaultSearchLimit = 2;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, 0);
+
+    expect(items.length).toEqual(2);
+    expect(nextCursor).toEqual(queryResults[1].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('uses the default limit if the specified limit was less than zero', () => {
+    generalConfig.defaultSearchLimit = 2;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, -2);
+
+    expect(items.length).toEqual(2);
+    expect(nextCursor).toEqual(queryResults[1].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('does not allow more items than the maximum limit', () => {
+    generalConfig.maximumSearchLimit = 2;
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, 3);
+
+    expect(items.length).toEqual(2);
+    expect(nextCursor).toEqual(queryResults[1].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('returns an empty array and error if the cursor is not found', () => {
+    const cursor = "testing-missing-record";
+    const field = 'id';
+    const { items, nextCursor, error } = paginateResults(queryResults, cursor, field, 1);
+
+    expect(items.length).toEqual(0);
+    expect(nextCursor).toBeFalsy();
+    expect(error).toBeTruthy();
+  });
+
+  it('returns an empty array and error if the cursorField does not exist on the objects', () => {
+    const cursor = queryResults[0].id;
+    const field = 'testing-missing-field';
+    const { items, nextCursor, error } = paginateResults(queryResults, cursor, field, 1);
+
+    expect(items.length).toEqual(0);
+    expect(nextCursor).toBeFalsy();
+    expect(error).toBeTruthy();
+  });
+
+  it('returns the expected items when the cursor is found and there are more pages', () => {
+    const cursor = queryResults[1].id;
+    const field = 'id';
+    const limit = 2;
+    const { items, nextCursor, error } = paginateResults(queryResults, cursor, field, limit);
+
+    expect(items.length).toEqual(2);
+    expect(items[0].id).toEqual(queryResults[2].id);
+    expect(items[1].id).toEqual(queryResults[3].id);
+    expect(nextCursor).toEqual(queryResults[3].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('returns the expected items when the cursor is found and there are no more pages', () => {
+    const cursor = queryResults[3].id;
+    const field = 'id';
+    const limit = 2;
+    const { items, nextCursor, error } = paginateResults(queryResults, cursor, field, limit);
+
+    expect(items.length).toEqual(1);
+    expect(items[0].id).toEqual(queryResults[4].id);
+    expect(nextCursor).toBeFalsy();
+    expect(error).toBeFalsy();
+  });
+
+  it('returns the expected items when the cursor is null and there are more pages', () => {
+    const field = 'id';
+    const limit = 2;
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, limit);
+
+    expect(items.length).toEqual(2);
+    expect(items[0].id).toEqual(queryResults[0].id);
+    expect(items[1].id).toEqual(queryResults[1].id);
+    expect(nextCursor).toEqual(queryResults[1].id);
+    expect(error).toBeFalsy();
+  });
+
+  it('returns the expected items when the cursor is null and there are no more pages', () => {
+    generalConfig.defaultSearchLimit = 20;
+    generalConfig.maximumSearchLimit = 100;
+    const field = 'id';
+    const limit = 10;
+    const { items, nextCursor, error } = paginateResults(queryResults, null, field, limit);
+
+    expect(items.length).toEqual(5);
+    expect(items[0].id).toEqual(queryResults[0].id);
+    expect(items[1].id).toEqual(queryResults[1].id);
+    expect(items[2].id).toEqual(queryResults[2].id);
+    expect(items[3].id).toEqual(queryResults[3].id);
+    expect(items[4].id).toEqual(queryResults[4].id);
+    expect(nextCursor).toBeFalsy();
+    expect(error).toBeFalsy();
+  });
+});

--- a/src/services/paginationService.ts
+++ b/src/services/paginationService.ts
@@ -1,0 +1,48 @@
+import { generalConfig } from "../config/generalConfig";
+import { PaginatedQueryResult } from "../types/general";
+
+// Paginate the results of a query
+export const paginateResults = (
+    results: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
+    cursor: string | number | null,
+    cursorField: string,
+    limit: number,
+  ): PaginatedQueryResult => {
+    // Return an empty array if the results are not an array or empty
+    if (!Array.isArray(results) || results.length === 0) {
+      return { items: [], nextCursor: null, error: null };
+    }
+
+    // Determine the maximum number of results to return
+    const maxNbrResults = Math.min(
+      (limit && limit >= 1) ? limit : generalConfig.defaultSearchLimit,
+      generalConfig.maximumSearchLimit
+    );
+
+    // If a cursor was provided, return only the next set of results
+    if (cursor && cursorField) {
+      const startIndex = results.findIndex((entry) => entry[cursorField] === cursor);
+      if (startIndex > -1) {
+        const paginatedResults = results.slice(startIndex + 1, startIndex + 1 + maxNbrResults);
+        const nextCursor = paginatedResults.length === maxNbrResults
+          ? paginatedResults[paginatedResults.length - 1][cursorField]
+          : null;
+        return { items: paginatedResults, nextCursor, error: null };
+      }
+      // If the cursor was not found, return an error
+      return { items: [], nextCursor: null, error: `Cursor ${cursor} not found` };
+    }
+
+    // If a cursor was provided but the cursorField is invalid, return an error
+    if (cursor && !cursorField) {
+      return { items: [], nextCursor: null, error: `Invalid cursor field: ${cursorField}` };
+    }
+
+    // No cursor provided, return the first N results
+    const paginatedResults = results.slice(0, maxNbrResults);
+    const nextCursor = paginatedResults.length === maxNbrResults
+      ? paginatedResults[paginatedResults.length - 1][cursorField]
+      : null;
+
+    return { items: paginatedResults, nextCursor, error: null };
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2249,7 +2249,7 @@ export type QueryAffiliationsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
   funderOnly?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
-  name: Scalars['String']['input'];
+  term: Scalars['String']['input'];
 };
 
 
@@ -5033,7 +5033,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   affiliationById?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByIdArgs, 'affiliationId'>>;
   affiliationByURI?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByUriArgs, 'uri'>>;
   affiliationTypes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  affiliations?: Resolver<Maybe<ResolversTypes['AffiliationSearchResults']>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
+  affiliations?: Resolver<Maybe<ResolversTypes['AffiliationSearchResults']>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'term'>>;
   answer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerArgs, 'answerId' | 'projectId'>>;
   answers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Answer']>>>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'planId' | 'projectId' | 'versionedSectionId'>>;
   childResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType, RequireFields<QueryChildResearchDomainsArgs, 'parentResearchDomainId'>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,12 +403,24 @@ export type AffiliationSearch = {
   displayName: Scalars['String']['output'];
   /** Whether or not this affiliation is a funder */
   funder: Scalars['Boolean']['output'];
-  /** The unique identifer for the affiliation (typically the ROR id) */
+  /** The unique identifer for the affiliation */
   id: Scalars['Int']['output'];
   /** The categories the Affiliation belongs to */
   types?: Maybe<Array<AffiliationType>>;
-  /** The URI of the affiliation */
+  /** The URI of the affiliation (typically the ROR id) */
   uri: Scalars['String']['output'];
+};
+
+export type AffiliationSearchResults = {
+  __typename?: 'AffiliationSearchResults';
+  /** The list of Affiliation search results */
+  affiliations?: Maybe<Array<Maybe<AffiliationSearch>>>;
+  /** The id of the last Affiliation in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The total number of Affiliation search results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Categories for Affiliation */
@@ -569,6 +581,19 @@ export type ExternalProject = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
+/** A result of the most popular funders */
+export type FunderPopularityResult = {
+  __typename?: 'FunderPopularityResult';
+  /** The official display name */
+  displayName: Scalars['String']['output'];
+  /** The unique identifer for the affiliation */
+  id: Scalars['Int']['output'];
+  /** The number of plans associated with this funder in the past year */
+  nbrPlans: Scalars['Int']['output'];
+  /** The URI of the affiliation (typically the ROR id) */
+  uri: Scalars['String']['output'];
+};
+
 /** Output type for the initializePlanVersion mutation */
 export type InitializePlanVersionOutput = {
   __typename?: 'InitializePlanVersionOutput';
@@ -629,6 +654,18 @@ export type LicenseErrors = {
   uri?: Maybe<Scalars['String']['output']>;
 };
 
+export type LicenseSearchResults = {
+  __typename?: 'LicenseSearchResults';
+  /** The id of the last License in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The list of licenses */
+  licenses?: Maybe<Array<Maybe<License>>>;
+  /** The total number of licenses */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+};
+
 /** A metadata standard used when describing a research output */
 export type MetadataStandard = {
   __typename?: 'MetadataStandard';
@@ -666,6 +703,18 @@ export type MetadataStandardErrors = {
   name?: Maybe<Scalars['String']['output']>;
   researchDomainIds?: Maybe<Scalars['String']['output']>;
   uri?: Maybe<Scalars['String']['output']>;
+};
+
+export type MetadataStandardSearchResults = {
+  __typename?: 'MetadataStandardSearchResults';
+  /** The id of the last MetadataStandard in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The list of metadata standards */
+  metadataStandards?: Maybe<Array<Maybe<MetadataStandard>>>;
+  /** The total number of metadata standards */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Mutation = {
@@ -1367,6 +1416,12 @@ export type OutputTypeErrors = {
   uri?: Maybe<Scalars['String']['output']>;
 };
 
+export type PaginationError = {
+  __typename?: 'PaginationError';
+  /** The error message */
+  general?: Maybe<Scalars['String']['output']>;
+};
+
 /** A Data Managament Plan (DMP) */
 export type Plan = {
   __typename?: 'Plan';
@@ -2007,6 +2062,44 @@ export type ProjectSearchResultFunder = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
+export type ProjectSearchResults = {
+  __typename?: 'ProjectSearchResults';
+  /** The id of the last ProjectSearchResult in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The list of projects */
+  projects?: Maybe<Array<Maybe<ProjectSearchResult>>>;
+  /** The total number of projects */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Paginated results of a search for publishedTemplates query */
+export type PublishedSectionSearchResult = {
+  __typename?: 'PublishedSectionSearchResult';
+  /** The id of the last VersionedSection in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The total number of results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+  /** The versioned sections */
+  versionedSections?: Maybe<Array<Maybe<VersionedSection>>>;
+};
+
+/** Paginated results of a search for publishedTemplates query */
+export type PublishedTemplateResults = {
+  __typename?: 'PublishedTemplateResults';
+  /** The id of the last VersionedTemplate in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The total number of results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+  /** The versioned template results */
+  versionedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
+};
+
 export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']['output']>;
@@ -2017,7 +2110,7 @@ export type Query = {
   /** Retrieve all of the valid Affiliation types */
   affiliationTypes?: Maybe<Array<Scalars['String']['output']>>;
   /** Perform a search for Affiliations matching the specified name */
-  affiliations?: Maybe<Array<Maybe<AffiliationSearch>>>;
+  affiliations?: Maybe<AffiliationSearchResults>;
   /** Get all of the comments associated with the round of admin feedback */
   answer?: Maybe<Answer>;
   /** Get all rounds of admin feedback for the plan */
@@ -2037,17 +2130,17 @@ export type Query = {
   /** Fetch a specific license */
   license?: Maybe<License>;
   /** Search for a license */
-  licenses?: Maybe<Array<Maybe<License>>>;
+  licenses?: Maybe<LicenseSearchResults>;
   /** Returns the currently logged in user's information */
   me?: Maybe<User>;
   /** Fetch a specific metadata standard */
   metadataStandard?: Maybe<MetadataStandard>;
   /** Search for a metadata standard */
-  metadataStandards?: Maybe<Array<Maybe<MetadataStandard>>>;
+  metadataStandards?: Maybe<MetadataStandardSearchResults>;
   /** Get all of the user's projects */
-  myProjects?: Maybe<Array<Maybe<ProjectSearchResult>>>;
+  myProjects?: Maybe<ProjectSearchResults>;
   /** Get the Templates that belong to the current user's affiliation (user must be an Admin) */
-  myTemplates?: Maybe<Array<Maybe<TemplateSearchResult>>>;
+  myTemplates?: Maybe<TemplateSearchResults>;
   /** Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin) */
   myVersionedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
   /** Get all the research output types */
@@ -2066,6 +2159,8 @@ export type Query = {
   planOutputs?: Maybe<Array<Maybe<ProjectOutput>>>;
   /** Get all plans for the research project */
   plans?: Maybe<Array<PlanSearchResult>>;
+  /** Returns a list of the top 20 funders ranked by popularity (nbr of plans) for the past year */
+  popularFunders?: Maybe<Array<Maybe<FunderPopularityResult>>>;
   /** Get a specific project */
   project?: Maybe<Project>;
   /** Get all of the Users that are collaborators for the Project */
@@ -2087,9 +2182,9 @@ export type Query = {
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
   publishedQuestions?: Maybe<Array<Maybe<VersionedQuestion>>>;
   /** Search for VersionedSection whose name contains the search term */
-  publishedSections?: Maybe<Array<Maybe<VersionedSection>>>;
+  publishedSections?: Maybe<PublishedSectionSearchResult>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
-  publishedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
+  publishedTemplates?: Maybe<PublishedTemplateResults>;
   /** Get the specific Question based on questionId */
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
@@ -2109,7 +2204,7 @@ export type Query = {
   /** Get all the realted works for the Project */
   relatedWorks?: Maybe<Array<Maybe<RelatedWork>>>;
   /** Search for a repository */
-  repositories?: Maybe<Array<Maybe<Repository>>>;
+  repositories?: Maybe<RepositorySearchResults>;
   /** Fetch a specific repository */
   repository?: Maybe<Repository>;
   /** Search for projects within external APIs */
@@ -2132,11 +2227,11 @@ export type Query = {
   /** Get all of the VersionedTemplate for the specified Template (a.k. the Template history) */
   templateVersions?: Maybe<Array<Maybe<VersionedTemplate>>>;
   /** Get all of the top level research domains (the most generic ones) */
-  topLevelResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
+  topLevelResearchDomains?: Maybe<ResearchDomainResults>;
   /** Returns the specified user (Admin only) */
   user?: Maybe<User>;
-  /** Returns all of the users associated with the current user's affiliation (Admin only) */
-  users?: Maybe<Array<Maybe<User>>>;
+  /** Returns all of the users associated with the current admin's affiliation (Super admins get everything) */
+  users?: Maybe<UserResults>;
 };
 
 
@@ -2151,7 +2246,9 @@ export type QueryAffiliationByUriArgs = {
 
 
 export type QueryAffiliationsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
   funderOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   name: Scalars['String']['input'];
 };
 
@@ -2195,6 +2292,8 @@ export type QueryLicenseArgs = {
 
 
 export type QueryLicensesArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   term?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2205,8 +2304,22 @@ export type QueryMetadataStandardArgs = {
 
 
 export type QueryMetadataStandardsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   researchDomainId?: InputMaybe<Scalars['Int']['input']>;
   term?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryMyProjectsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryMyTemplatesArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2296,11 +2409,15 @@ export type QueryPublishedQuestionsArgs = {
 
 
 export type QueryPublishedSectionsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   term: Scalars['String']['input'];
 };
 
 
 export type QueryPublishedTemplatesArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   term?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2405,8 +2522,21 @@ export type QueryTemplateVersionsArgs = {
 };
 
 
+export type QueryTopLevelResearchDomainsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
 export type QueryUserArgs = {
   userId: Scalars['Int']['input'];
+};
+
+
+export type QueryUsersArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  term?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Question always belongs to a Section, which always belongs to a Template */
@@ -2770,12 +2900,28 @@ export type RepositoryErrors = {
 };
 
 export type RepositorySearchInput = {
+  /** The cursor for pagination */
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  /** The number of results to return */
+  limit?: InputMaybe<Scalars['Int']['input']>;
   /** The repository category/type */
   repositoryType?: InputMaybe<Scalars['String']['input']>;
   /** The research domain associated with the repository */
   researchDomainId?: InputMaybe<Scalars['Int']['input']>;
   /** The search term */
   term?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type RepositorySearchResults = {
+  __typename?: 'RepositorySearchResults';
+  /** The id of the last Repository in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The list of repositories */
+  repositories?: Maybe<Array<Maybe<Repository>>>;
+  /** The total number of results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type RepositoryType =
@@ -2825,6 +2971,18 @@ export type ResearchDomainErrors = {
   name?: Maybe<Scalars['String']['output']>;
   parentResearchDomainId?: Maybe<Scalars['String']['output']>;
   uri?: Maybe<Scalars['String']['output']>;
+};
+
+export type ResearchDomainResults = {
+  __typename?: 'ResearchDomainResults';
+  /** The id of the last ResearchDomain in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The list of research domains */
+  researchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
+  /** The total number of research domains */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A Section that contains a list of questions in a template */
@@ -3056,6 +3214,19 @@ export type TemplateSearchResult = {
   ownerId?: Maybe<Scalars['String']['output']>;
   /** The template's availability setting: Public is available to everyone, Private only your affiliation */
   visibility?: Maybe<TemplateVisibility>;
+};
+
+/** Paginated results of a search for templates */
+export type TemplateSearchResults = {
+  __typename?: 'TemplateSearchResults';
+  /** The id of the last TemplateSearchResult in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The TemplateSearchResults that match the search criteria */
+  templateSearchResults?: Maybe<Array<Maybe<TemplateSearchResult>>>;
+  /** The total number of results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Template version type */
@@ -3395,6 +3566,19 @@ export type UserErrors = {
   surName?: Maybe<Scalars['String']['output']>;
 };
 
+/** Paginated results of a search for users */
+export type UserResults = {
+  __typename?: 'UserResults';
+  /** The id of the last VersionedTemplate in the results */
+  cursor?: Maybe<Scalars['Int']['output']>;
+  /** Any errors associated with the search */
+  error?: Maybe<PaginationError>;
+  /** The total number of results */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+  /** The users that match the search criteria */
+  users?: Maybe<Array<Maybe<User>>>;
+};
+
 /** The types of roles supported by the DMPTool */
 export type UserRole =
   | 'ADMIN'
@@ -3632,6 +3816,8 @@ export type VersionedTemplateSearchResult = {
   __typename?: 'VersionedTemplateSearchResult';
   /** Whether or not this Template is designated as a 'Best Practice' template */
   bestPractice?: Maybe<Scalars['Boolean']['output']>;
+  /** The id of the last VersionedTemplate in the results */
+  cursor?: Maybe<Scalars['String']['output']>;
   /** A description of the purpose of the template */
   description?: Maybe<Scalars['String']['output']>;
   /** The unique identifer for the Object */
@@ -3751,6 +3937,7 @@ export type ResolversTypes = {
   AffiliationLinkInput: AffiliationLinkInput;
   AffiliationProvenance: AffiliationProvenance;
   AffiliationSearch: ResolverTypeWrapper<AffiliationSearch>;
+  AffiliationSearchResults: ResolverTypeWrapper<AffiliationSearchResults>;
   AffiliationType: AffiliationType;
   Answer: ResolverTypeWrapper<Answer>;
   AnswerComment: ResolverTypeWrapper<AnswerComment>;
@@ -3765,18 +3952,22 @@ export type ResolversTypes = {
   ExternalContributor: ResolverTypeWrapper<ExternalContributor>;
   ExternalFunding: ResolverTypeWrapper<ExternalFunding>;
   ExternalProject: ResolverTypeWrapper<ExternalProject>;
+  FunderPopularityResult: ResolverTypeWrapper<FunderPopularityResult>;
   InitializePlanVersionOutput: ResolverTypeWrapper<InitializePlanVersionOutput>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   InvitedToType: InvitedToType;
   Language: ResolverTypeWrapper<Language>;
   License: ResolverTypeWrapper<License>;
   LicenseErrors: ResolverTypeWrapper<LicenseErrors>;
+  LicenseSearchResults: ResolverTypeWrapper<LicenseSearchResults>;
   MetadataStandard: ResolverTypeWrapper<MetadataStandard>;
   MetadataStandardErrors: ResolverTypeWrapper<MetadataStandardErrors>;
+  MetadataStandardSearchResults: ResolverTypeWrapper<MetadataStandardSearchResults>;
   Mutation: ResolverTypeWrapper<{}>;
   Orcid: ResolverTypeWrapper<Scalars['Orcid']['output']>;
   OutputType: ResolverTypeWrapper<OutputType>;
   OutputTypeErrors: ResolverTypeWrapper<OutputTypeErrors>;
+  PaginationError: ResolverTypeWrapper<PaginationError>;
   Plan: ResolverTypeWrapper<Plan>;
   PlanContributor: ResolverTypeWrapper<PlanContributor>;
   PlanContributorErrors: ResolverTypeWrapper<PlanContributorErrors>;
@@ -3812,6 +4003,9 @@ export type ResolversTypes = {
   ProjectSearchResultCollaborator: ResolverTypeWrapper<ProjectSearchResultCollaborator>;
   ProjectSearchResultContributor: ResolverTypeWrapper<ProjectSearchResultContributor>;
   ProjectSearchResultFunder: ResolverTypeWrapper<ProjectSearchResultFunder>;
+  ProjectSearchResults: ResolverTypeWrapper<ProjectSearchResults>;
+  PublishedSectionSearchResult: ResolverTypeWrapper<PublishedSectionSearchResult>;
+  PublishedTemplateResults: ResolverTypeWrapper<PublishedTemplateResults>;
   Query: ResolverTypeWrapper<{}>;
   Question: ResolverTypeWrapper<Question>;
   QuestionCondition: ResolverTypeWrapper<QuestionCondition>;
@@ -3831,9 +4025,11 @@ export type ResolversTypes = {
   Repository: ResolverTypeWrapper<Repository>;
   RepositoryErrors: ResolverTypeWrapper<RepositoryErrors>;
   RepositorySearchInput: RepositorySearchInput;
+  RepositorySearchResults: ResolverTypeWrapper<RepositorySearchResults>;
   RepositoryType: RepositoryType;
   ResearchDomain: ResolverTypeWrapper<ResearchDomain>;
   ResearchDomainErrors: ResolverTypeWrapper<ResearchDomainErrors>;
+  ResearchDomainResults: ResolverTypeWrapper<ResearchDomainResults>;
   Ror: ResolverTypeWrapper<Scalars['Ror']['output']>;
   Section: ResolverTypeWrapper<Section>;
   SectionErrors: ResolverTypeWrapper<SectionErrors>;
@@ -3847,6 +4043,7 @@ export type ResolversTypes = {
   TemplateCollaboratorErrors: ResolverTypeWrapper<TemplateCollaboratorErrors>;
   TemplateErrors: ResolverTypeWrapper<TemplateErrors>;
   TemplateSearchResult: ResolverTypeWrapper<TemplateSearchResult>;
+  TemplateSearchResults: ResolverTypeWrapper<TemplateSearchResults>;
   TemplateVersionType: TemplateVersionType;
   TemplateVisibility: TemplateVisibility;
   URL: ResolverTypeWrapper<Scalars['URL']['output']>;
@@ -3867,6 +4064,7 @@ export type ResolversTypes = {
   UserEmail: ResolverTypeWrapper<UserEmail>;
   UserEmailErrors: ResolverTypeWrapper<UserEmailErrors>;
   UserErrors: ResolverTypeWrapper<UserErrors>;
+  UserResults: ResolverTypeWrapper<UserResults>;
   UserRole: UserRole;
   VersionedQuestion: ResolverTypeWrapper<VersionedQuestion>;
   VersionedQuestionCondition: ResolverTypeWrapper<VersionedQuestionCondition>;
@@ -3901,6 +4099,7 @@ export type ResolversParentTypes = {
   AffiliationLink: AffiliationLink;
   AffiliationLinkInput: AffiliationLinkInput;
   AffiliationSearch: AffiliationSearch;
+  AffiliationSearchResults: AffiliationSearchResults;
   Answer: Answer;
   AnswerComment: AnswerComment;
   AnswerCommentErrors: AnswerCommentErrors;
@@ -3914,17 +4113,21 @@ export type ResolversParentTypes = {
   ExternalContributor: ExternalContributor;
   ExternalFunding: ExternalFunding;
   ExternalProject: ExternalProject;
+  FunderPopularityResult: FunderPopularityResult;
   InitializePlanVersionOutput: InitializePlanVersionOutput;
   Int: Scalars['Int']['output'];
   Language: Language;
   License: License;
   LicenseErrors: LicenseErrors;
+  LicenseSearchResults: LicenseSearchResults;
   MetadataStandard: MetadataStandard;
   MetadataStandardErrors: MetadataStandardErrors;
+  MetadataStandardSearchResults: MetadataStandardSearchResults;
   Mutation: {};
   Orcid: Scalars['Orcid']['output'];
   OutputType: OutputType;
   OutputTypeErrors: OutputTypeErrors;
+  PaginationError: PaginationError;
   Plan: Plan;
   PlanContributor: PlanContributor;
   PlanContributorErrors: PlanContributorErrors;
@@ -3955,6 +4158,9 @@ export type ResolversParentTypes = {
   ProjectSearchResultCollaborator: ProjectSearchResultCollaborator;
   ProjectSearchResultContributor: ProjectSearchResultContributor;
   ProjectSearchResultFunder: ProjectSearchResultFunder;
+  ProjectSearchResults: ProjectSearchResults;
+  PublishedSectionSearchResult: PublishedSectionSearchResult;
+  PublishedTemplateResults: PublishedTemplateResults;
   Query: {};
   Question: Question;
   QuestionCondition: QuestionCondition;
@@ -3970,8 +4176,10 @@ export type ResolversParentTypes = {
   Repository: Repository;
   RepositoryErrors: RepositoryErrors;
   RepositorySearchInput: RepositorySearchInput;
+  RepositorySearchResults: RepositorySearchResults;
   ResearchDomain: ResearchDomain;
   ResearchDomainErrors: ResearchDomainErrors;
+  ResearchDomainResults: ResearchDomainResults;
   Ror: Scalars['Ror']['output'];
   Section: Section;
   SectionErrors: SectionErrors;
@@ -3984,6 +4192,7 @@ export type ResolversParentTypes = {
   TemplateCollaboratorErrors: TemplateCollaboratorErrors;
   TemplateErrors: TemplateErrors;
   TemplateSearchResult: TemplateSearchResult;
+  TemplateSearchResults: TemplateSearchResults;
   URL: Scalars['URL']['output'];
   UpdateMetadataStandardInput: UpdateMetadataStandardInput;
   UpdateProjectContributorInput: UpdateProjectContributorInput;
@@ -4002,6 +4211,7 @@ export type ResolversParentTypes = {
   UserEmail: UserEmail;
   UserEmailErrors: UserEmailErrors;
   UserErrors: UserErrors;
+  UserResults: UserResults;
   VersionedQuestion: VersionedQuestion;
   VersionedQuestionCondition: VersionedQuestionCondition;
   VersionedQuestionConditionErrors: VersionedQuestionConditionErrors;
@@ -4104,6 +4314,14 @@ export type AffiliationSearchResolvers<ContextType = MyContext, ParentType exten
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   types?: Resolver<Maybe<Array<ResolversTypes['AffiliationType']>>, ParentType, ContextType>;
   uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AffiliationSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AffiliationSearchResults'] = ResolversParentTypes['AffiliationSearchResults']> = {
+  affiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['AffiliationSearch']>>>, ParentType, ContextType>;
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -4211,6 +4429,14 @@ export type ExternalProjectResolvers<ContextType = MyContext, ParentType extends
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type FunderPopularityResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['FunderPopularityResult'] = ResolversParentTypes['FunderPopularityResult']> = {
+  displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  nbrPlans?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type InitializePlanVersionOutputResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['InitializePlanVersionOutput'] = ResolversParentTypes['InitializePlanVersionOutput']> = {
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   planIds?: Resolver<Maybe<Array<ResolversTypes['Int']>>, ParentType, ContextType>;
@@ -4246,6 +4472,14 @@ export type LicenseErrorsResolvers<ContextType = MyContext, ParentType extends R
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type LicenseSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['LicenseSearchResults'] = ResolversParentTypes['LicenseSearchResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  licenses?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type MetadataStandardResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['MetadataStandard'] = ResolversParentTypes['MetadataStandard']> = {
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -4268,6 +4502,14 @@ export type MetadataStandardErrorsResolvers<ContextType = MyContext, ParentType 
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   researchDomainIds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MetadataStandardSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['MetadataStandardSearchResults'] = ResolversParentTypes['MetadataStandardSearchResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  metadataStandards?: Resolver<Maybe<Array<Maybe<ResolversTypes['MetadataStandard']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -4385,6 +4627,11 @@ export type OutputTypeErrorsResolvers<ContextType = MyContext, ParentType extend
   general?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PaginationErrorResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PaginationError'] = ResolversParentTypes['PaginationError']> = {
+  general?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -4757,12 +5004,36 @@ export type ProjectSearchResultFunderResolvers<ContextType = MyContext, ParentTy
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ProjectSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResults'] = ResolversParentTypes['ProjectSearchResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  projects?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectSearchResult']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PublishedSectionSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedSectionSearchResult'] = ResolversParentTypes['PublishedSectionSearchResult']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  versionedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PublishedTemplateResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateResults'] = ResolversParentTypes['PublishedTemplateResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  versionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type QueryResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   affiliationById?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByIdArgs, 'affiliationId'>>;
   affiliationByURI?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByUriArgs, 'uri'>>;
   affiliationTypes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  affiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['AffiliationSearch']>>>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
+  affiliations?: Resolver<Maybe<ResolversTypes['AffiliationSearchResults']>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
   answer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerArgs, 'answerId' | 'projectId'>>;
   answers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Answer']>>>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'planId' | 'projectId' | 'versionedSectionId'>>;
   childResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType, RequireFields<QueryChildResearchDomainsArgs, 'parentResearchDomainId'>>;
@@ -4772,12 +5043,12 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   findCollaborator?: Resolver<Maybe<Array<Maybe<ResolversTypes['CollaboratorSearchResult']>>>, ParentType, ContextType, Partial<QueryFindCollaboratorArgs>>;
   languages?: Resolver<Maybe<Array<Maybe<ResolversTypes['Language']>>>, ParentType, ContextType>;
   license?: Resolver<Maybe<ResolversTypes['License']>, ParentType, ContextType, RequireFields<QueryLicenseArgs, 'uri'>>;
-  licenses?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType, Partial<QueryLicensesArgs>>;
+  licenses?: Resolver<Maybe<ResolversTypes['LicenseSearchResults']>, ParentType, ContextType, Partial<QueryLicensesArgs>>;
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   metadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<QueryMetadataStandardArgs, 'uri'>>;
-  metadataStandards?: Resolver<Maybe<Array<Maybe<ResolversTypes['MetadataStandard']>>>, ParentType, ContextType, Partial<QueryMetadataStandardsArgs>>;
-  myProjects?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectSearchResult']>>>, ParentType, ContextType>;
-  myTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateSearchResult']>>>, ParentType, ContextType>;
+  metadataStandards?: Resolver<Maybe<ResolversTypes['MetadataStandardSearchResults']>, ParentType, ContextType, Partial<QueryMetadataStandardsArgs>>;
+  myProjects?: Resolver<Maybe<ResolversTypes['ProjectSearchResults']>, ParentType, ContextType, Partial<QueryMyProjectsArgs>>;
+  myTemplates?: Resolver<Maybe<ResolversTypes['TemplateSearchResults']>, ParentType, ContextType, Partial<QueryMyTemplatesArgs>>;
   myVersionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
   outputTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['OutputType']>>>, ParentType, ContextType>;
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanArgs, 'planId'>>;
@@ -4787,6 +5058,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   planFunders?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFunder']>>>, ParentType, ContextType, RequireFields<QueryPlanFundersArgs, 'planId'>>;
   planOutputs?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectOutput']>>>, ParentType, ContextType, RequireFields<QueryPlanOutputsArgs, 'planId'>>;
   plans?: Resolver<Maybe<Array<ResolversTypes['PlanSearchResult']>>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'projectId'>>;
+  popularFunders?: Resolver<Maybe<Array<Maybe<ResolversTypes['FunderPopularityResult']>>>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'projectId'>>;
   projectCollaborators?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectCollaborator']>>>, ParentType, ContextType, RequireFields<QueryProjectCollaboratorsArgs, 'projectId'>>;
   projectContributor?: Resolver<Maybe<ResolversTypes['ProjectContributor']>, ParentType, ContextType, RequireFields<QueryProjectContributorArgs, 'projectContributorId'>>;
@@ -4797,8 +5069,8 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectOutputs?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectOutput']>>>, ParentType, ContextType, RequireFields<QueryProjectOutputsArgs, 'projectId'>>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
   publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
-  publishedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
-  publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
+  publishedSections?: Resolver<Maybe<ResolversTypes['PublishedSectionSearchResult']>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
+  publishedTemplates?: Resolver<Maybe<ResolversTypes['PublishedTemplateResults']>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
   question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
   questionConditions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryQuestionConditionsArgs, 'questionId'>>;
   questionOption?: Resolver<Maybe<ResolversTypes['QuestionOption']>, ParentType, ContextType, RequireFields<QueryQuestionOptionArgs, 'id'>>;
@@ -4808,7 +5080,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   recommendedLicenses?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType, RequireFields<QueryRecommendedLicensesArgs, 'recommended'>>;
   relatedWork?: Resolver<Maybe<ResolversTypes['RelatedWork']>, ParentType, ContextType, RequireFields<QueryRelatedWorkArgs, 'id'>>;
   relatedWorks?: Resolver<Maybe<Array<Maybe<ResolversTypes['RelatedWork']>>>, ParentType, ContextType, Partial<QueryRelatedWorksArgs>>;
-  repositories?: Resolver<Maybe<Array<Maybe<ResolversTypes['Repository']>>>, ParentType, ContextType, RequireFields<QueryRepositoriesArgs, 'input'>>;
+  repositories?: Resolver<Maybe<ResolversTypes['RepositorySearchResults']>, ParentType, ContextType, RequireFields<QueryRepositoriesArgs, 'input'>>;
   repository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, RequireFields<QueryRepositoryArgs, 'uri'>>;
   searchExternalProjects?: Resolver<Maybe<Array<Maybe<ResolversTypes['ExternalProject']>>>, ParentType, ContextType, RequireFields<QuerySearchExternalProjectsArgs, 'affiliationId'>>;
   section?: Resolver<Maybe<ResolversTypes['Section']>, ParentType, ContextType, RequireFields<QuerySectionArgs, 'sectionId'>>;
@@ -4820,9 +5092,9 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   template?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<QueryTemplateArgs, 'templateId'>>;
   templateCollaborators?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateCollaborator']>>>, ParentType, ContextType, RequireFields<QueryTemplateCollaboratorsArgs, 'templateId'>>;
   templateVersions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType, RequireFields<QueryTemplateVersionsArgs, 'templateId'>>;
-  topLevelResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType>;
+  topLevelResearchDomains?: Resolver<Maybe<ResolversTypes['ResearchDomainResults']>, ParentType, ContextType, Partial<QueryTopLevelResearchDomainsArgs>>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'userId'>>;
-  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+  users?: Resolver<Maybe<ResolversTypes['UserResults']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
 };
 
 export type QuestionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Question'] = ResolversParentTypes['Question']> = {
@@ -4985,6 +5257,14 @@ export type RepositoryErrorsResolvers<ContextType = MyContext, ParentType extend
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type RepositorySearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['RepositorySearchResults'] = ResolversParentTypes['RepositorySearchResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  repositories?: Resolver<Maybe<Array<Maybe<ResolversTypes['Repository']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ResearchDomainResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ResearchDomain'] = ResolversParentTypes['ResearchDomain']> = {
   childResearchDomains?: Resolver<Maybe<Array<ResolversTypes['ResearchDomain']>>, ParentType, ContextType>;
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -5008,6 +5288,14 @@ export type ResearchDomainErrorsResolvers<ContextType = MyContext, ParentType ex
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   parentResearchDomainId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ResearchDomainResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ResearchDomainResults'] = ResolversParentTypes['ResearchDomainResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  researchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -5147,6 +5435,14 @@ export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type TemplateSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateSearchResults'] = ResolversParentTypes['TemplateSearchResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  templateSearchResults?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateSearchResult']>>>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export interface UrlScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['URL'], any> {
   name: 'URL';
 }
@@ -5225,6 +5521,14 @@ export type UserErrorsResolvers<ContextType = MyContext, ParentType extends Reso
   role?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   ssoId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   surName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['UserResults'] = ResolversParentTypes['UserResults']> = {
+  cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -5363,6 +5667,7 @@ export type VersionedTemplateErrorsResolvers<ContextType = MyContext, ParentType
 
 export type VersionedTemplateSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedTemplateSearchResult'] = ResolversParentTypes['VersionedTemplateSearchResult']> = {
   bestPractice?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  cursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -5386,6 +5691,7 @@ export type Resolvers<ContextType = MyContext> = {
   AffiliationErrors?: AffiliationErrorsResolvers<ContextType>;
   AffiliationLink?: AffiliationLinkResolvers<ContextType>;
   AffiliationSearch?: AffiliationSearchResolvers<ContextType>;
+  AffiliationSearchResults?: AffiliationSearchResultsResolvers<ContextType>;
   Answer?: AnswerResolvers<ContextType>;
   AnswerComment?: AnswerCommentResolvers<ContextType>;
   AnswerCommentErrors?: AnswerCommentErrorsResolvers<ContextType>;
@@ -5398,16 +5704,20 @@ export type Resolvers<ContextType = MyContext> = {
   ExternalContributor?: ExternalContributorResolvers<ContextType>;
   ExternalFunding?: ExternalFundingResolvers<ContextType>;
   ExternalProject?: ExternalProjectResolvers<ContextType>;
+  FunderPopularityResult?: FunderPopularityResultResolvers<ContextType>;
   InitializePlanVersionOutput?: InitializePlanVersionOutputResolvers<ContextType>;
   Language?: LanguageResolvers<ContextType>;
   License?: LicenseResolvers<ContextType>;
   LicenseErrors?: LicenseErrorsResolvers<ContextType>;
+  LicenseSearchResults?: LicenseSearchResultsResolvers<ContextType>;
   MetadataStandard?: MetadataStandardResolvers<ContextType>;
   MetadataStandardErrors?: MetadataStandardErrorsResolvers<ContextType>;
+  MetadataStandardSearchResults?: MetadataStandardSearchResultsResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Orcid?: GraphQLScalarType;
   OutputType?: OutputTypeResolvers<ContextType>;
   OutputTypeErrors?: OutputTypeErrorsResolvers<ContextType>;
+  PaginationError?: PaginationErrorResolvers<ContextType>;
   Plan?: PlanResolvers<ContextType>;
   PlanContributor?: PlanContributorResolvers<ContextType>;
   PlanContributorErrors?: PlanContributorErrorsResolvers<ContextType>;
@@ -5437,6 +5747,9 @@ export type Resolvers<ContextType = MyContext> = {
   ProjectSearchResultCollaborator?: ProjectSearchResultCollaboratorResolvers<ContextType>;
   ProjectSearchResultContributor?: ProjectSearchResultContributorResolvers<ContextType>;
   ProjectSearchResultFunder?: ProjectSearchResultFunderResolvers<ContextType>;
+  ProjectSearchResults?: ProjectSearchResultsResolvers<ContextType>;
+  PublishedSectionSearchResult?: PublishedSectionSearchResultResolvers<ContextType>;
+  PublishedTemplateResults?: PublishedTemplateResultsResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Question?: QuestionResolvers<ContextType>;
   QuestionCondition?: QuestionConditionResolvers<ContextType>;
@@ -5450,8 +5763,10 @@ export type Resolvers<ContextType = MyContext> = {
   RelatedWorkErrors?: RelatedWorkErrorsResolvers<ContextType>;
   Repository?: RepositoryResolvers<ContextType>;
   RepositoryErrors?: RepositoryErrorsResolvers<ContextType>;
+  RepositorySearchResults?: RepositorySearchResultsResolvers<ContextType>;
   ResearchDomain?: ResearchDomainResolvers<ContextType>;
   ResearchDomainErrors?: ResearchDomainErrorsResolvers<ContextType>;
+  ResearchDomainResults?: ResearchDomainResultsResolvers<ContextType>;
   Ror?: GraphQLScalarType;
   Section?: SectionResolvers<ContextType>;
   SectionErrors?: SectionErrorsResolvers<ContextType>;
@@ -5462,12 +5777,14 @@ export type Resolvers<ContextType = MyContext> = {
   TemplateCollaboratorErrors?: TemplateCollaboratorErrorsResolvers<ContextType>;
   TemplateErrors?: TemplateErrorsResolvers<ContextType>;
   TemplateSearchResult?: TemplateSearchResultResolvers<ContextType>;
+  TemplateSearchResults?: TemplateSearchResultsResolvers<ContextType>;
   URL?: GraphQLScalarType;
   UpdateRelatedWorkInput?: UpdateRelatedWorkInputResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
   UserEmail?: UserEmailResolvers<ContextType>;
   UserEmailErrors?: UserEmailErrorsResolvers<ContextType>;
   UserErrors?: UserErrorsResolvers<ContextType>;
+  UserResults?: UserResultsResolvers<ContextType>;
   VersionedQuestion?: VersionedQuestionResolvers<ContextType>;
   VersionedQuestionCondition?: VersionedQuestionConditionResolvers<ContextType>;
   VersionedQuestionConditionErrors?: VersionedQuestionConditionErrorsResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -413,12 +413,12 @@ export type AffiliationSearch = {
 
 export type AffiliationSearchResults = {
   __typename?: 'AffiliationSearchResults';
-  /** The list of Affiliation search results */
-  affiliations?: Maybe<Array<Maybe<AffiliationSearch>>>;
   /** The id of the last Affiliation in the results */
   cursor?: Maybe<Scalars['Int']['output']>;
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
+  /** The list of Affiliation search results */
+  feed?: Maybe<Array<Maybe<AffiliationSearch>>>;
   /** The total number of Affiliation search results */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -661,7 +661,7 @@ export type LicenseSearchResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The list of licenses */
-  licenses?: Maybe<Array<Maybe<License>>>;
+  feed?: Maybe<Array<Maybe<License>>>;
   /** The total number of licenses */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -712,7 +712,7 @@ export type MetadataStandardSearchResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The list of metadata standards */
-  metadataStandards?: Maybe<Array<Maybe<MetadataStandard>>>;
+  feed?: Maybe<Array<Maybe<MetadataStandard>>>;
   /** The total number of metadata standards */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -2069,7 +2069,7 @@ export type ProjectSearchResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The list of projects */
-  projects?: Maybe<Array<Maybe<ProjectSearchResult>>>;
+  feed?: Maybe<Array<Maybe<ProjectSearchResult>>>;
   /** The total number of projects */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -2081,10 +2081,10 @@ export type PublishedSectionSearchResult = {
   cursor?: Maybe<Scalars['Int']['output']>;
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
+  /** The versioned sections */
+  feed?: Maybe<Array<Maybe<VersionedSection>>>;
   /** The total number of results */
   totalCount?: Maybe<Scalars['Int']['output']>;
-  /** The versioned sections */
-  versionedSections?: Maybe<Array<Maybe<VersionedSection>>>;
 };
 
 /** Paginated results of a search for publishedTemplates query */
@@ -2094,10 +2094,10 @@ export type PublishedTemplateResults = {
   cursor?: Maybe<Scalars['Int']['output']>;
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
+  /** The versioned template results */
+  feed?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
   /** The total number of results */
   totalCount?: Maybe<Scalars['Int']['output']>;
-  /** The versioned template results */
-  versionedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
 };
 
 export type Query = {
@@ -2111,9 +2111,9 @@ export type Query = {
   affiliationTypes?: Maybe<Array<Scalars['String']['output']>>;
   /** Perform a search for Affiliations matching the specified name */
   affiliations?: Maybe<AffiliationSearchResults>;
-  /** Get all of the comments associated with the round of admin feedback */
+  /** Get the sepecific answer */
   answer?: Maybe<Answer>;
-  /** Get all rounds of admin feedback for the plan */
+  /** Get all answers for the given project and plan and section */
   answers?: Maybe<Array<Maybe<Answer>>>;
   /** Get all of the research domains related to the specified top level domain (more nuanced ones) */
   childResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
@@ -2919,7 +2919,7 @@ export type RepositorySearchResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The list of repositories */
-  repositories?: Maybe<Array<Maybe<Repository>>>;
+  feed?: Maybe<Array<Maybe<Repository>>>;
   /** The total number of results */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -2980,7 +2980,7 @@ export type ResearchDomainResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The list of research domains */
-  researchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
+  feed?: Maybe<Array<Maybe<ResearchDomain>>>;
   /** The total number of research domains */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -3224,7 +3224,7 @@ export type TemplateSearchResults = {
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
   /** The TemplateSearchResults that match the search criteria */
-  templateSearchResults?: Maybe<Array<Maybe<TemplateSearchResult>>>;
+  feed?: Maybe<Array<Maybe<TemplateSearchResult>>>;
   /** The total number of results */
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
@@ -3573,10 +3573,10 @@ export type UserResults = {
   cursor?: Maybe<Scalars['Int']['output']>;
   /** Any errors associated with the search */
   error?: Maybe<PaginationError>;
+  /** The users that match the search criteria */
+  feed?: Maybe<Array<Maybe<User>>>;
   /** The total number of results */
   totalCount?: Maybe<Scalars['Int']['output']>;
-  /** The users that match the search criteria */
-  users?: Maybe<Array<Maybe<User>>>;
 };
 
 /** The types of roles supported by the DMPTool */
@@ -4318,9 +4318,9 @@ export type AffiliationSearchResolvers<ContextType = MyContext, ParentType exten
 };
 
 export type AffiliationSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AffiliationSearchResults'] = ResolversParentTypes['AffiliationSearchResults']> = {
-  affiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['AffiliationSearch']>>>, ParentType, ContextType>;
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['AffiliationSearch']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -4475,7 +4475,7 @@ export type LicenseErrorsResolvers<ContextType = MyContext, ParentType extends R
 export type LicenseSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['LicenseSearchResults'] = ResolversParentTypes['LicenseSearchResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  licenses?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['License']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -4508,7 +4508,7 @@ export type MetadataStandardErrorsResolvers<ContextType = MyContext, ParentType 
 export type MetadataStandardSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['MetadataStandardSearchResults'] = ResolversParentTypes['MetadataStandardSearchResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  metadataStandards?: Resolver<Maybe<Array<Maybe<ResolversTypes['MetadataStandard']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['MetadataStandard']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -5007,7 +5007,7 @@ export type ProjectSearchResultFunderResolvers<ContextType = MyContext, ParentTy
 export type ProjectSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ProjectSearchResults'] = ResolversParentTypes['ProjectSearchResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  projects?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectSearchResult']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectSearchResult']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -5015,16 +5015,16 @@ export type ProjectSearchResultsResolvers<ContextType = MyContext, ParentType ex
 export type PublishedSectionSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedSectionSearchResult'] = ResolversParentTypes['PublishedSectionSearchResult']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  versionedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type PublishedTemplateResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateResults'] = ResolversParentTypes['PublishedTemplateResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  versionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -5260,7 +5260,7 @@ export type RepositoryErrorsResolvers<ContextType = MyContext, ParentType extend
 export type RepositorySearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['RepositorySearchResults'] = ResolversParentTypes['RepositorySearchResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  repositories?: Resolver<Maybe<Array<Maybe<ResolversTypes['Repository']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['Repository']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -5294,7 +5294,7 @@ export type ResearchDomainErrorsResolvers<ContextType = MyContext, ParentType ex
 export type ResearchDomainResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['ResearchDomainResults'] = ResolversParentTypes['ResearchDomainResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  researchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -5438,7 +5438,7 @@ export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType ex
 export type TemplateSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateSearchResults'] = ResolversParentTypes['TemplateSearchResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
-  templateSearchResults?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateSearchResult']>>>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['TemplateSearchResult']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -5527,8 +5527,8 @@ export type UserErrorsResolvers<ContextType = MyContext, ParentType extends Reso
 export type UserResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['UserResults'] = ResolversParentTypes['UserResults']> = {
   cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaginationError']>, ParentType, ContextType>;
+  feed?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,0 +1,6 @@
+// The results of a query that supports pagination.
+export interface PaginatedQueryResult {
+  items: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
+  nextCursor: string | number | null,
+  error: string | null
+}


### PR DESCRIPTION
## Description

Fixes #180

- Added a new `paginationService`
- Added new ENV variables:
  - `DEFAULT_SEARCH_LIMIT` - the default amount of results that are returned for queries that use pagination (default: 20)
  - `MAXIMUM_SEARCH_LIMIT` - the maximum number of results allowed for queries that use pagination (default: 100) 
- Updated relevant queries to use pagination: `publishedTemplates`, `users`, `myTemplates`, `topLevelResearchDomains`, `repositories`, `myProjects`, `metadataStandards`, `licenses`, `affiliations`
- Updated `affiliations` resolver tests
- Added tests for new service

- I will submit a corresponding PR to the frontend repo to update the way these queries are being handled

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Updated unit tests and verified the pagination logic within the Apollo explorer

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules