### PR TITLE
Bug/js address errors when adding collaborator that has no account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed an issue where adding `projectCollaborators` was failing due to the fact that the `userId` field was required. This should not be required to add a new collaborator [#260]
 - When calling `updatePlanContributors`, the resolver should set isPrimaryContact to `false` for all contributors other than the one marked as isPrimary.
 - Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.
 - Fixed bugs related to addPlanContributor and updatePlanContributor since these were not working without missing contributorRoles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,11 +123,8 @@
 - added bestPractice flag to the Section
 
 ### Removed
-<<<<<<< HEAD
 - Dropped the `PlanVersion` table
-=======
 - Removed `prepareAPITarget` function.
->>>>>>> development
 - Removed `id` from `Project` model's constructor (already handled in base `MySQLModel`)
 - Removed old `dmphubAPI` datasource and renamed `dmptoolAPI` to `dmpHubAPI`
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic

--- a/data-migrations/2025-04-29-0713-update-projectCollaborator-so-userId-not-required.sql
+++ b/data-migrations/2025-04-29-0713-update-projectCollaborator-so-userId-not-required.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `projectCollaborators` 
+MODIFY `userId` INT NULL;


### PR DESCRIPTION
## Description

Currently, the projectCollaborators table requires a value for userId. However, when adding new project collaborators in the frontend, a `userId` should not be required.

I added a data-migration script so that `userId` field is no longer required.

Fixes # ([260](https://github.com/CDLUC3/dmsp_backend_prototype/issues/260))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- I ran this backend code, with the frontend branch, `feature/JS-invite-and-manage-collaborators`, which is currently in PR review here: [feature/JS-invite-and-manage-collaborators](https://github.com/CDLUC3/dmsp_frontend_prototype/tree/feature/JS-invite-and-manage-collaborators)
- I made sure that I could add users as collaborators that do not have accounts.

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules