### PR TITLE
Updated templateCollaborators table so that userId is not required.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed an issue where adding `templateCollaborators` was failing due to the fact that the `userId` field was required. 
 - Fixed an issue where adding `projectCollaborators` was failing due to the fact that the `userId` field was required. This should not be required to add a new collaborator [#260]
 - When calling `updatePlanContributors`, the resolver should set isPrimaryContact to `false` for all contributors other than the one marked as isPrimary.
 - Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.

--- a/data-migrations/2025-04-29-1355-update-templateCollaborators-to-not-require-userId
+++ b/data-migrations/2025-04-29-1355-update-templateCollaborators-to-not-require-userId
@@ -1,0 +1,2 @@
+ALTER TABLE `templateCollaborators` 
+MODIFY `userId` INT NULL;


### PR DESCRIPTION

## Description

Currently, we are not able to add template collaborators that do not have user accounts in our system, because the `userId` is a required field in the `templateCollaborators` table.


Fixes # ([433](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/433))

- Added data migration script to make `userId` optional in `templateCollaborators` table

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested this manually by adding emails for both users with and without existing accounts to `http://localhost:3000/en-US/template/15/access` page.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules