### PR TITLE
[Bug] - Removed 'Copy of' from in front of copied Section and Template names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Removed `Copy of` from in front of copied `Section` and `Template` names [#261]
 - Fixed an issue where adding `projectCollaborators` was failing due to the fact that the `userId` field was required. This should not be required to add a new collaborator [#260]
 - When calling `updatePlanContributors`, the resolver should set isPrimaryContact to `false` for all contributors other than the one marked as isPrimary.
 - Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.

--- a/src/services/__tests__/sectionService.spec.ts
+++ b/src/services/__tests__/sectionService.spec.ts
@@ -123,7 +123,7 @@ describe('cloneSection', () => {
     expect(copy.id).toBeFalsy();
     expect(copy.sourceSectionId).toEqual(section.id);
     expect(copy.templateId).toEqual(templateId);
-    expect(copy.name).toEqual(`Copy of ${section.name}`);
+    expect(copy.name).toEqual(section.name);
     expect(copy.introduction).toEqual(introduction);
     expect(copy.requirements).toEqual(requirements);
     expect(copy.guidance).toEqual(guidance);
@@ -153,7 +153,7 @@ describe('cloneSection', () => {
     expect(copy).toBeInstanceOf(Section);
     expect(copy.id).toBeFalsy();
     expect(copy.sourceSectionId).toEqual(published.sectionId);
-    expect(copy.name).toEqual(`Copy of ${published.name}`);
+    expect(copy.name).toEqual(published.name);
     expect(copy.introduction).toEqual(published.introduction);
     expect(copy.requirements).toEqual(published.requirements);
     expect(copy.guidance).toEqual(published.guidance);

--- a/src/services/__tests__/templateService.spec.ts
+++ b/src/services/__tests__/templateService.spec.ts
@@ -124,7 +124,7 @@ describe('cloneTemplate', () => {
     expect(copy).toBeInstanceOf(Template);
     expect(copy.id).toBeFalsy();
     expect(copy.sourceTemplateId).toEqual(tmplt.id);
-    expect(copy.name).toEqual(`Copy of ${tmplt.name}`);
+    expect(copy.name).toEqual(tmplt.name);
     expect(copy.ownerId).toEqual(newOwnerId);
     expect(copy.visibility).toEqual(TemplateVisibility.PRIVATE);
     expect(copy.latestPublishVersion).toBeFalsy();
@@ -153,7 +153,7 @@ describe('cloneTemplate', () => {
     expect(copy).toBeInstanceOf(Template);
     expect(copy.id).toBeFalsy();
     expect(copy.sourceTemplateId).toEqual(published.templateId);
-    expect(copy.name).toEqual(`Copy of ${published.name}`);
+    expect(copy.name).toEqual(published.name);
     expect(copy.ownerId).toEqual(newOwnerId);
     expect(copy.visibility).toEqual(TemplateVisibility.PRIVATE);
     expect(copy.latestPublishVersion).toBeFalsy();

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -92,7 +92,7 @@ export const cloneSection = (
   const sourceId = Object.keys(section).includes('sectionId') ? section['sectionId'] : section.id;
   const sectionCopy = new Section({
     sourceSectionId: sourceId,
-    name: `Copy of ${section.name}`,
+    name: section.name,
     introduction: section.introduction,
     requirements: section.requirements,
     guidance: section.guidance,

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -141,7 +141,7 @@ export const cloneTemplate = (
   // If the incoming is a VersionedTemplate, then use the templateId (the template it was based off of)
   const sourceId = Object.keys(template).includes('templateId') ? template['templateId'] : template.id;
   const templateCopy = new Template({
-    name: `Copy of ${template.name}`,
+    name: template.name,
     description: template.description,
     languageId: template.languageId,
     ownerId: newOwnerId,


### PR DESCRIPTION
## Description

Currently, when a user creates a template, and copies from an existing template, we had `Copy of` in front of the `Section` and `Template` names. We want to remove that text.

Fixes # ([261](https://github.com/CDLUC3/dmsp_backend_prototype/issues/261))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested pages to check that `Copy of` was no longer being concatenated to Section and Template names. Updated and ran unit tests.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules