### PR TITLE
Fix issues with Section create when selecting an existing section to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `VersionedSectionSearchResult` to optimize the query for displaying an org's published sections and the bestPractice sections
 - Added `popularFunders` query to the `affiliations` resolver
 - Added `accessLevel` to projectCollaborator and removed `userId`
 - Added new resolvers related to `projectCollaborators`. Also, when project is created, automatically add user as `projectCollaborator` with `access level`= `OWN`
@@ -76,6 +77,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Updated `publishedSections` resolver to return the new `VersionedSectionSearchResult` array
 - Format ORCID identifiers consistently, in the `Contributor` and `User` models, the `projectImport` resolver and `orcid` scalar.
 - Changed a number of GraphQL definitions to PascalCase.
 - Fixed projectCollaborators table which had an FKey on the plans table instead of the projects table
@@ -124,6 +126,7 @@
 - added bestPractice flag to the Section
 
 ### Removed
+- Removed duplicate section check from `Section.create` that was just going off of the "name"
 - Dropped the `PlanVersion` table
 - Removed `prepareAPITarget` function.
 - Removed `id` from `Project` model's constructor (already handled in base `MySQLModel`)
@@ -133,7 +136,7 @@
 ### Fixed
 -Was getting `undefined` bestPractice in `updateTemplate` when none was passed in because of the logic on how it was set. Added a check for whether `bestPractice` is defined before setting value. Also, added an update to `createTemplateVersion`, so that errors from the `generateTemplateVersion` will be caught and passed back in graphql response. Previously, when trying to save a DRAFT of a template, the mutation wouldn't return an error to the client, even though the `Save draft` did not successfully complete. [#265]
 - Removed `Copy of` from in front of copied `Section` and `Template` names [#261]
-- Fixed an issue where adding `templateCollaborators` was failing due to the fact that the `userId` field was required. 
+- Fixed an issue where adding `templateCollaborators` was failing due to the fact that the `userId` field was required.
 - Fixed an issue where adding `projectCollaborators` was failing due to the fact that the `userId` field was required. This should not be required to add a new collaborator [#260]
 - When calling `updatePlanContributors`, the resolver should set isPrimaryContact to `false` for all contributors other than the one marked as isPrimary.
 - Fixed an issue where Jest tests failed on Linux due to case-sensitive file paths. The tests passed on macOS because its file system is case-insensitive by default.

--- a/src/models/Section.ts
+++ b/src/models/Section.ts
@@ -56,24 +56,11 @@ export class Section extends MySqlModel {
 
     // First make sure the record is valid
     if (await this.isValid()) {
-      const current = await Section.findBySectionName(
-        'Section.create',
-        context,
-        this.name,
-        templateId
-      );
-
-      // Then make sure it doesn't already exist
-      if (current) {
-        this.addError('general', 'Section with this name already exists');
-      } else {
-        this.prepForSave();
-
-        // Save the record and then fetch it
-        const newId = await Section.insert(context, this.tableName, this, 'Section.create', ['tags']);
-        const response = await Section.findById('Section.create', context, newId);
-        return response;
-      }
+      this.templateId = templateId;
+      // Save the record and then fetch it
+      const newId = await Section.insert(context, this.tableName, this, 'Section.create', ['tags']);
+      const response = await Section.findById('Section.create', context, newId);
+      return response;
     }
     // Otherwise return as-is with all the errors
     return new Section(this);

--- a/src/models/__tests__/Section.spec.ts
+++ b/src/models/__tests__/Section.spec.ts
@@ -215,30 +215,10 @@ describe('create', () => {
     expect(result.errors).toEqual({});
     expect(localValidator).toHaveBeenCalledTimes(1);
   });
-  it('returns the Section with an error if the section already exists', async () => {
-    const localValidator = jest.fn();
-    (section.isValid as jest.Mock) = localValidator;
-    localValidator.mockResolvedValueOnce(true);
-
-    const mockFindBy = jest.fn();
-    (Section.findBySectionName as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(section);
-
-    const result = await section.create(context);
-    expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(1);
-    expect(result.errors['general']).toBeTruthy();
-  });
   it('returns the newly added Section', async () => {
     const localValidator = jest.fn();
     (section.isValid as jest.Mock) = localValidator;
     localValidator.mockResolvedValueOnce(true);
-
-    const mockFindBy = jest.fn();
-    (Section.findBySectionName as jest.Mock) = mockFindBy;
-    mockFindBy.mockResolvedValueOnce(null);
-    mockFindBy.mockResolvedValue(section);
 
     const mockFindById = jest.fn();
     (Section.findById as jest.Mock) = mockFindById;
@@ -246,7 +226,6 @@ describe('create', () => {
 
     const result = await section.create(context);
     expect(localValidator).toHaveBeenCalledTimes(1);
-    expect(mockFindBy).toHaveBeenCalledTimes(1);
     expect(mockFindById).toHaveBeenCalledTimes(1);
     expect(insertQuery).toHaveBeenCalledTimes(1);
     expect(Object.keys(result.errors).length).toBe(0);

--- a/src/models/__tests__/VersionedSection.spec.ts
+++ b/src/models/__tests__/VersionedSection.spec.ts
@@ -1,5 +1,5 @@
 import casual from "casual";
-import { VersionedSection } from "../VersionedSection";
+import { VersionedSection, VersionedSectionSearchResult } from "../VersionedSection";
 import { logger } from '../../__mocks__/logger';
 import { buildContext, mockToken } from "../../__mocks__/context";
 
@@ -12,6 +12,95 @@ beforeEach(() => {
 
   context = buildContext(logger, mockToken());
 });
+
+describe('VersionedSectionSearchResult', () => {
+  let versionedSectionSearchResult;
+  const versionedSectionSearchResultData = {
+    name: casual.sentence,
+    introduction: casual.sentence,
+    displayOrder: casual.integer(1, 20),
+    bestPractice: casual.boolean,
+    versionedTemplateId: casual.integer(1, 20),
+    versionedTemplateName: casual.sentence,
+    versionedQuestionCount: casual.integer(1, 20),
+  }
+  beforeEach(() => {
+    versionedSectionSearchResult = new VersionedSectionSearchResult(versionedSectionSearchResultData);
+  });
+
+  it('should initialize options as expected', () => {
+    expect(versionedSectionSearchResult.name).toEqual(versionedSectionSearchResultData.name);
+    expect(versionedSectionSearchResult.introduction).toEqual(versionedSectionSearchResultData.introduction);
+    expect(versionedSectionSearchResult.displayOrder).toEqual(versionedSectionSearchResultData.displayOrder);
+    expect(versionedSectionSearchResult.bestPractice).toEqual(versionedSectionSearchResultData.bestPractice);
+    expect(versionedSectionSearchResult.versionedTemplateId).toEqual(versionedSectionSearchResultData.versionedTemplateId);
+    expect(versionedSectionSearchResult.versionedTemplateName).toEqual(versionedSectionSearchResultData.versionedTemplateName);
+    expect(versionedSectionSearchResult.versionedQuestionCount).toEqual(versionedSectionSearchResultData.versionedQuestionCount);
+  });
+
+  it('should initialize with default values', () => {
+    const defaultVersionedSectionSearchResult = new VersionedSectionSearchResult({});
+    expect(defaultVersionedSectionSearchResult.name).toEqual(undefined);
+    expect(defaultVersionedSectionSearchResult.introduction).toEqual(undefined);
+    expect(defaultVersionedSectionSearchResult.displayOrder).toEqual(0);
+    expect(defaultVersionedSectionSearchResult.bestPractice).toEqual(false);
+    expect(defaultVersionedSectionSearchResult.versionedTemplateId).toEqual(undefined);
+    expect(defaultVersionedSectionSearchResult.versionedTemplateName).toEqual(undefined);
+    expect(defaultVersionedSectionSearchResult.versionedQuestionCount).toEqual(0);
+  });
+
+  describe('search', () => {
+    const originalQuery = VersionedSection.query;
+
+    let localQuery;
+    let context;
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      localQuery = jest.fn();
+      (VersionedSection.query as jest.Mock) = localQuery;
+
+      context = buildContext(logger, mockToken());
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      VersionedSection.query = originalQuery;
+    });
+
+    it('should call query with correct params and return the default', async () => {
+      localQuery.mockResolvedValueOnce([versionedSectionSearchResult]);
+      const affiliationId = context.token?.affiliationId;
+      const searchTerm = 'tesTIing';
+      const result = await VersionedSectionSearchResult.search('testing', context, searchTerm);
+      const expectedSql = `
+      SELECT vs.id, vs.modified, vs.created, vs.name, vs.introduction, vs.displayOrder, vt.bestPractice,
+              vt.id as versionedTemplateId, vt.name as versionedTemplateName,
+              COUNT(vq.id) as versionedQuestionCount
+        FROM versionedSections vs
+          INNER JOIN versionedTemplates vt ON vs.versionedTemplateId = vt.id
+          LEFT JOIN versionedQuestions vq ON vs.id = vq.versionedSectionId
+        WHERE vs.name LIKE ? AND (vt.ownerId = ? OR vt.bestPractice = 1)
+        GROUP BY vs.id, vs.modified, vs.created, vs.name, vs.introduction, vs.displayOrder, vt.bestPractice,
+              vt.id, vt.name
+        ORDER BY vs.modified DESC;
+    `;
+      const vals = [`%${searchTerm.toLowerCase()}%`, affiliationId];
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, vals, 'testing')
+      expect(result).toEqual([versionedSectionSearchResult]);
+    });
+
+    it('should return empty array if it finds no default', async () => {
+      localQuery.mockResolvedValueOnce([]);
+      const searchTerm = 'tesTIing';
+      const result = await VersionedSectionSearchResult.search('testing', context, searchTerm);
+      expect(result).toEqual([]);
+    });
+  });
+});
+
 
 describe('VersionedSection', () => {
   let versionedSection;
@@ -130,61 +219,6 @@ the getVersionedSectionsBySectionId method returns an empty array for tags, and 
 
     const result = await VersionedSection.findByName('VersionedSection query', context, versionedSection.name);
     expect(result).toEqual(null);
-  });
-});
-
-describe('findByNameAndAffiliation', () => {
-  const originalQuery = VersionedSection.query;
-
-  let localQuery;
-  let context;
-  let versionedSection;
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-
-    localQuery = jest.fn();
-    (VersionedSection.query as jest.Mock) = localQuery;
-
-    context = buildContext(logger, mockToken());
-
-    versionedSection = new VersionedSection({
-      name: casual.sentence,
-      introduction: casual.sentence,
-      requirements: casual.sentence,
-      guidance: casual.sentence,
-      displayOrder: casual.integer(1, 20),
-    })
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    VersionedSection.query = originalQuery;
-  });
-
-  it('findByNameAndAffiliation should call query with correct params and return the default', async () => {
-    localQuery.mockResolvedValueOnce([versionedSection]);
-    const affiliationId = context.token?.affiliationId;
-    const searchTerm = 'tesTIing';
-    const result = await VersionedSection.findByNameAndAffiliation('testing', context, searchTerm);
-    const expectedSql = `
-      SELECT vs.*
-        FROM versionedSections vs
-          INNER JOIN versionedTemplates vt ON vs.versionedTemplateId = vt.id
-        WHERE vs.name LIKE ? AND vt.ownerId = ?
-        ORDER BY vs.modified DESC;
-    `;
-    const vals = [`%${searchTerm.toLowerCase()}%`, affiliationId];
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, vals, 'testing')
-    expect(result).toEqual([versionedSection]);
-  });
-
-  it('findByNameAndAffiliation should return empty array if it finds no default', async () => {
-    localQuery.mockResolvedValueOnce([]);
-    const searchTerm = 'tesTIing';
-    const result = await VersionedSection.findByNameAndAffiliation('testing', context, searchTerm);
-    expect(result).toEqual([]);
   });
 });
 

--- a/src/resolvers/section.ts
+++ b/src/resolvers/section.ts
@@ -75,7 +75,6 @@ export const resolvers: Resolvers = {
           // if a copyFromVersionedSectionId is provided, clone the section
           if (copyFromVersionedSectionId) {
             const original = await VersionedSection.findById(reference, context, copyFromVersionedSectionId);
-
             if (!original) {
               throw NotFoundError('Unable to copy the specified section');
             }

--- a/src/resolvers/versionedSection.ts
+++ b/src/resolvers/versionedSection.ts
@@ -1,6 +1,6 @@
 import { Resolvers } from "../types";
 import { MyContext } from "../context";
-import { VersionedSection } from "../models/VersionedSection";
+import { VersionedSection, VersionedSectionSearchResult } from "../models/VersionedSection";
 import { Section } from "../models/Section";
 import { Tag } from "../models/Tag";
 import { VersionedTemplate } from "../models/VersionedTemplate";
@@ -33,18 +33,18 @@ export const resolvers: Resolvers = {
       }
     },
     // Get all of the published versionedSections with the given name
-    publishedSections: async (_, { term }, context: MyContext): Promise<VersionedSection[]> => {
+    publishedSections: async (_, { term }, context: MyContext): Promise<VersionedSectionSearchResult[]> => {
       const reference = 'publishedSections resolver';
       try {
         // Find published versionedSections with similar names for the current user
-        return await VersionedSection.findByNameAndAffiliation(reference, context, term);
+        return await VersionedSectionSearchResult.search(reference, context, term);
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
 
         formatLogMessage(context).error(err, `Failure in ${reference}`);
         throw InternalServerError();
       }
-    }
+    },
   },
 
   VersionedSection: {

--- a/src/resolvers/versionedSection.ts
+++ b/src/resolvers/versionedSection.ts
@@ -36,8 +36,8 @@ export const resolvers: Resolvers = {
     publishedSections: async (_, { term }, context: MyContext): Promise<VersionedSection[]> => {
       const reference = 'publishedSections resolver';
       try {
-        // Find published versionedSections with similar names
-        return await VersionedSection.findByName(reference, context, term);
+        // Find published versionedSections with similar names for the current user
+        return await VersionedSection.findByNameAndAffiliation(reference, context, term);
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
 

--- a/src/schemas/versionedSection.ts
+++ b/src/schemas/versionedSection.ts
@@ -5,7 +5,9 @@ export const typeDefs = gql`
     "Get all of the VersionedSection for the specified Section ID"
     sectionVersions(sectionId: Int!): [VersionedSection]
     "Search for VersionedSection whose name contains the search term"
-    publishedSections(term: String!): [VersionedSection]
+    publishedSections(term: String!): [VersionedSectionSearchResult]
+    "Get all of the best practice VersionedSection"
+    bestPracticeSections: [VersionedSection]
   }
 
   "Section version type"
@@ -14,6 +16,29 @@ export const typeDefs = gql`
     DRAFT
     "Published - saved state for use when creating DMPs"
     PUBLISHED
+  }
+
+  type VersionedSectionSearchResult {
+    "The unique identifer for the Object"
+    id: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "The timestamp when the Object was created"
+    created: String
+    "The VersionedSection name/title"
+    name: String!
+    "The VersionedSection introduction"
+    introduction: String
+    "The displayOrder of this VersionedSection"
+    displayOrder: Int!
+    "Whether or not this VersionedSection is designated as a 'Best Practice' section"
+    bestPractice: Boolean
+    "The id of the VersionedTemplate that this VersionedSection belongs to"
+    versionedTemplateId: Int
+    "The name of the VersionedTemplate that this VersionedSection belongs to"
+    versionedTemplateName: String
+    "The number of questions associated with this VersionedSection"
+    versionedQuestionCount: Int
   }
 
   "A snapshot of a Section when it became published."

--- a/src/types.ts
+++ b/src/types.ts
@@ -2035,6 +2035,8 @@ export type Query = {
   answer?: Maybe<Answer>;
   /** Get all rounds of admin feedback for the plan */
   answers?: Maybe<Array<Maybe<Answer>>>;
+  /** Get all of the best practice VersionedSection */
+  bestPracticeSections?: Maybe<Array<Maybe<VersionedSection>>>;
   /** Get all of the research domains related to the specified top level domain (more nuanced ones) */
   childResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
   /** Get the contributor role by it's id */
@@ -2102,7 +2104,7 @@ export type Query = {
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
   publishedQuestions?: Maybe<Array<Maybe<VersionedQuestion>>>;
   /** Search for VersionedSection whose name contains the search term */
-  publishedSections?: Maybe<Array<Maybe<VersionedSection>>>;
+  publishedSections?: Maybe<Array<Maybe<VersionedSectionSearchResult>>>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
   publishedTemplates?: Maybe<Array<Maybe<VersionedTemplateSearchResult>>>;
   /** Get the specific Question based on questionId */
@@ -3584,6 +3586,30 @@ export type VersionedSectionErrors = {
   versionedTemplateId?: Maybe<Scalars['String']['output']>;
 };
 
+export type VersionedSectionSearchResult = {
+  __typename?: 'VersionedSectionSearchResult';
+  /** Whether or not this VersionedSection is designated as a 'Best Practice' section */
+  bestPractice?: Maybe<Scalars['Boolean']['output']>;
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The displayOrder of this VersionedSection */
+  displayOrder: Scalars['Int']['output'];
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The VersionedSection introduction */
+  introduction?: Maybe<Scalars['String']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The VersionedSection name/title */
+  name: Scalars['String']['output'];
+  /** The number of questions associated with this VersionedSection */
+  versionedQuestionCount?: Maybe<Scalars['Int']['output']>;
+  /** The id of the VersionedTemplate that this VersionedSection belongs to */
+  versionedTemplateId?: Maybe<Scalars['Int']['output']>;
+  /** The name of the VersionedTemplate that this VersionedSection belongs to */
+  versionedTemplateName?: Maybe<Scalars['String']['output']>;
+};
+
 /** A snapshot of a Template when it became published. DMPs are created from published templates */
 export type VersionedTemplate = {
   __typename?: 'VersionedTemplate';
@@ -3892,6 +3918,7 @@ export type ResolversTypes = {
   VersionedQuestionErrors: ResolverTypeWrapper<VersionedQuestionErrors>;
   VersionedSection: ResolverTypeWrapper<VersionedSection>;
   VersionedSectionErrors: ResolverTypeWrapper<VersionedSectionErrors>;
+  VersionedSectionSearchResult: ResolverTypeWrapper<VersionedSectionSearchResult>;
   VersionedTemplate: ResolverTypeWrapper<VersionedTemplate>;
   VersionedTemplateErrors: ResolverTypeWrapper<VersionedTemplateErrors>;
   VersionedTemplateSearchResult: ResolverTypeWrapper<VersionedTemplateSearchResult>;
@@ -4025,6 +4052,7 @@ export type ResolversParentTypes = {
   VersionedQuestionErrors: VersionedQuestionErrors;
   VersionedSection: VersionedSection;
   VersionedSectionErrors: VersionedSectionErrors;
+  VersionedSectionSearchResult: VersionedSectionSearchResult;
   VersionedTemplate: VersionedTemplate;
   VersionedTemplateErrors: VersionedTemplateErrors;
   VersionedTemplateSearchResult: VersionedTemplateSearchResult;
@@ -4790,6 +4818,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   affiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['AffiliationSearch']>>>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
   answer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerArgs, 'answerId' | 'projectId'>>;
   answers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Answer']>>>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'planId' | 'projectId' | 'versionedSectionId'>>;
+  bestPracticeSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;
   childResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType, RequireFields<QueryChildResearchDomainsArgs, 'parentResearchDomainId'>>;
   contributorRoleById?: Resolver<Maybe<ResolversTypes['ContributorRole']>, ParentType, ContextType, RequireFields<QueryContributorRoleByIdArgs, 'contributorRoleId'>>;
   contributorRoleByURL?: Resolver<Maybe<ResolversTypes['ContributorRole']>, ParentType, ContextType, RequireFields<QueryContributorRoleByUrlArgs, 'contributorRoleURL'>>;
@@ -4823,7 +4852,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectOutputs?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectOutput']>>>, ParentType, ContextType, RequireFields<QueryProjectOutputsArgs, 'projectId'>>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
   publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
-  publishedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
+  publishedSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSectionSearchResult']>>>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
   publishedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
   question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
   questionConditions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryQuestionConditionsArgs, 'questionId'>>;
@@ -5350,6 +5379,20 @@ export type VersionedSectionErrorsResolvers<ContextType = MyContext, ParentType 
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type VersionedSectionSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedSectionSearchResult'] = ResolversParentTypes['VersionedSectionSearchResult']> = {
+  bestPractice?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayOrder?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  introduction?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  versionedQuestionCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  versionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  versionedTemplateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type VersionedTemplateResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedTemplate'] = ResolversParentTypes['VersionedTemplate']> = {
   active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   bestPractice?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -5501,6 +5544,7 @@ export type Resolvers<ContextType = MyContext> = {
   VersionedQuestionErrors?: VersionedQuestionErrorsResolvers<ContextType>;
   VersionedSection?: VersionedSectionResolvers<ContextType>;
   VersionedSectionErrors?: VersionedSectionErrorsResolvers<ContextType>;
+  VersionedSectionSearchResult?: VersionedSectionSearchResultResolvers<ContextType>;
   VersionedTemplate?: VersionedTemplateResolvers<ContextType>;
   VersionedTemplateErrors?: VersionedTemplateErrorsResolvers<ContextType>;
   VersionedTemplateSearchResult?: VersionedTemplateSearchResultResolvers<ContextType>;


### PR DESCRIPTION
## Description

Part of #[448](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/448)

- Removed duplicate section check from `Section.create` that was just going off of the "name"
- Added `VersionedSectionSearchResult` to optimize the query for displaying an org's published sections and the bestPractice sections
- Updated `publishedSections` resolver to return the new `VersionedSectionSearchResult` array
- Updated tests and added new ones

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Updated all tests and added new ones for `VersionedSectionSearchResult`
- tested in Apollo explorer
- tested via updated frontend code (see corresponding PR)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules