### PR TITLE
Fixed myTemplates query so that TemplateSearchResult returns the ownerDisplayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed myTemplates query so that `TemplateSearchResult` returns the `ownerDisplayName` specified in schema.
 - Fixed an issue where adding `templateCollaborators` was failing due to the fact that the `userId` field was required.
 -Was getting `undefined` bestPractice in `updateTemplate` when none was passed in because of the logic on how it was set. Added a check for whether `bestPractice` is defined before setting value. Also, added an update to `createTemplateVersion`, so that errors from the `generateTemplateVersion` will be caught and passed back in graphql response. Previously, when trying to save a DRAFT of a template, the mutation wouldn't return an error to the client, even though the `Save draft` did not successfully complete. [#265]
 - Removed `Copy of` from in front of copied `Section` and `Template` names [#261]

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -275,6 +275,17 @@ export const resolvers: Resolvers = {
     },
   },
 
+  TemplateSearchResult: {
+    // Resolver for ownerDisplayName based on owner.displayName
+    ownerDisplayName: async (parent: TemplateSearchResult, _, context: MyContext): Promise<string | null> => {
+      if (parent.ownerId) {
+        const owner = await Affiliation.findByURI('TemplateSearchResult.owner', context, parent.ownerId);
+        return owner?.displayName || null;
+      }
+      return null;
+    },
+  },
+
   Template: {
     // Chained resolver to fetch the Affiliation info for the user
     owner: async (parent: Template, _, context: MyContext): Promise<Affiliation> => {


### PR DESCRIPTION

## Description

Currently the TemplateSearchResult type includes `ownerDisplayName` but it is never returned because the resolver doesn't include that info. This info is needed for the template list page in the NextJS app.

I added a chained resolver to add that info to the query.

Fixes # ([292](https://github.com/CDLUC3/dmsp_backend_prototype/issues/292))

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested update with frontend and Apollo Explorer.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules