### PR TITLE
Added a new resolver for 'answerByVersionedQuestionId' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2 - Initial deploy to the stage environment
 
 ### Added
+- Added a new resolver for `answerByVersionedQuestionId` so that we can get the question-specific answer to populate the question in the Question detail page.
 - Added a new MySQL container to host the test DB to the docker compose stack
 - Added JSON column `questionType` to `questions` and `versionedQuestions` tables
 - Added JSON column `json` to the `answers` table

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -1,5 +1,7 @@
 import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
+import { removeNullAndUndefinedFromJSON } from "../utils/helpers";
+
 
 export class Answer extends MySqlModel {
   public planId: number;
@@ -16,6 +18,12 @@ export class Answer extends MySqlModel {
     this.versionedSectionId = options.versionedSectionId;
     this.versionedQuestionId = options.versionedQuestionId;
     this.json = options.json;
+    // Ensure json is stored as a string
+    try {
+      this.json = removeNullAndUndefinedFromJSON(options.json);
+    } catch (e) {
+      this.addError('json', e.message);
+    }
   }
 
   // Validation to be used prior to saving the record

--- a/src/models/__tests__/Answer.spec.ts
+++ b/src/models/__tests__/Answer.spec.ts
@@ -24,7 +24,7 @@ describe('Answer', () => {
     planId: casual.integer(1, 9999),
     versionedQuestionId: casual.integer(1, 9999),
     versionedSectionId: casual.integer(1, 9999),
-    json: casual.sentences(3),
+    json: "{\"answer\":\"California\"}"
   }
   beforeEach(() => {
     answer = new Answer(answerData);
@@ -77,7 +77,7 @@ describe('findBy Queries', () => {
     context = buildContext(logger, mockToken());
 
     answer = new Answer({
-      id: casual.integer(1,9999),
+      id: casual.integer(1, 9999),
       planId: casual.integer(1, 9999),
       versionedQuestionId: casual.integer(1, 9999),
       versionedSectionId: casual.integer(1, 9999),
@@ -178,7 +178,7 @@ describe('update', () => {
       planId: casual.integer(1, 9999),
       versionedQuestionId: casual.integer(1, 9999),
       versionedSectionId: casual.integer(1, 9999),
-      json: casual.sentences(3),
+      json: "{\"answer\":\"California\"}"
     })
   });
 
@@ -235,7 +235,7 @@ describe('create', () => {
       planId: casual.integer(1, 9999),
       versionedQuestionId: casual.integer(1, 9999),
       versionedSectionId: casual.integer(1, 9999),
-      json: casual.sentences(3),
+      json: "{\"answer\":\"California\"}"
     });
   });
 
@@ -297,7 +297,7 @@ describe('delete', () => {
       planId: casual.integer(1, 9999),
       versionedQuestionId: casual.integer(1, 9999),
       versionedSectionId: casual.integer(1, 9999),
-      json: casual.sentences(3),
+      json: "{\"answer\":\"California\"}"
     });
   })
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -6,6 +6,7 @@ import { orcidScalar } from './resolvers/scalars/orcid';
 import { rorScalar } from './resolvers/scalars/ror';
 
 import { resolvers as affiliationResolvers } from './resolvers/affiliation';
+import { resolvers as answerResolvers } from './resolvers/answer';
 import { resolvers as collaboratorResolvers } from './resolvers/collaborator';
 import { resolvers as memberResolvers } from './resolvers/member';
 import { resolvers as memberRoleResolvers } from './resolvers/memberRole';
@@ -41,6 +42,7 @@ export const resolvers: IResolvers = mergeResolvers([
   scalarResolvers,
 
   affiliationResolvers,
+  answerResolvers,
   collaboratorResolvers,
   memberResolvers,
   memberRoleResolvers,

--- a/src/schemas/answer.ts
+++ b/src/schemas/answer.ts
@@ -5,6 +5,9 @@ export const typeDefs = gql`
     "Get all answers for the given project and plan and section"
     answers(projectId: Int!, planId: Int!, versionedSectionId: Int!): [Answer]
 
+    "Get an answer by versionedQuestionId"
+    answerByVersionedQuestionId(projectId: Int!, planId: Int!, versionedQuestionId: Int!): Answer
+
     "Get the sepecific answer"
     answer(projectId: Int!, answerId: Int!): Answer
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2154,6 +2154,8 @@ export type Query = {
   affiliations?: Maybe<AffiliationSearchResults>;
   /** Get the sepecific answer */
   answer?: Maybe<Answer>;
+  /** Get answer by versionedQuestionId */
+  answerByVersionedQuestionId?: Maybe<Answer>;
   /** Get all answers for the given project and plan and section */
   answers?: Maybe<Array<Maybe<Answer>>>;
   /** Get all of the best practice VersionedSection */
@@ -2294,6 +2296,13 @@ export type QueryAffiliationsArgs = {
 export type QueryAnswerArgs = {
   answerId: Scalars['Int']['input'];
   projectId: Scalars['Int']['input'];
+};
+
+
+export type QueryAnswerByVersionedQuestionIdArgs = {
+  planId: Scalars['Int']['input'];
+  projectId: Scalars['Int']['input'];
+  versionedQuestionId: Scalars['Int']['input'];
 };
 
 
@@ -5101,6 +5110,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   affiliationTypes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   affiliations?: Resolver<Maybe<ResolversTypes['AffiliationSearchResults']>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
   answer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerArgs, 'answerId' | 'projectId'>>;
+  answerByVersionedQuestionId?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerByVersionedQuestionIdArgs, 'planId' | 'projectId' | 'versionedQuestionId'>>;
   answers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Answer']>>>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'planId' | 'projectId' | 'versionedSectionId'>>;
   bestPracticeSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;
   childResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType, RequireFields<QueryChildResearchDomainsArgs, 'parentResearchDomainId'>>;


### PR DESCRIPTION


## Description
- Added a new resolver, `answerByVersionedQuestionId` so that we can get the question-specific answer to populate the question in the Question details page
- In `Answer` model, added a check for for valid json because it was preventing me from adding `json` for answers

Fixes # (issue)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Unit test and manual testing


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ *] Any dependent changes have been merged and published in downstream modules
* The frontend ticket that uses these changes is still being worked on ([#320](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/320)), but I don't think we'll need any more backend changes for that ticket