### PR TITLE
Fixed a template publish error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@
 - Old DMPHubAPI datasource and renamed DMPToolAPI to DMPHubAPI since that one had all of the new auth logic
 
 ### Fixed
+- Fixed a bug where clients calling `createTemplateVersion` in the `template` resolver would get an error when trying to publish because adding data to `versionedQuestions` required that `questionTypeId` not be null. I added a data-migration script to allow null because I believe we store the question type in the `json` field now and do not require `questionTypeId` [#328]
 - Update profile was not working due to missing `createdById` and `modifiedById` values in db. Added data migration script to populate those fields [#278]
 - Fixed myTemplates query so that `TemplateSearchResult` returns the `ownerDisplayName` specified in schema.
 - Fixed an issue where adding `templateCollaborators` was failing due to the fact that the `userId` field was required.

--- a/data-migrations/2025-07-09-0123-update-versionedQuestions-to-allow-nullable-questionTypeId.sql
+++ b/data-migrations/2025-07-09-0123-update-versionedQuestions-to-allow-nullable-questionTypeId.sql
@@ -1,0 +1,6 @@
+-- Migration script to make questionTypeId nullable in versionedQuestions table
+-- This will resolve the "Field 'questionTypeId' doesn't have a default value" error
+
+ALTER TABLE `versionedQuestions` 
+MODIFY COLUMN `questionTypeId` INT NULL;
+


### PR DESCRIPTION

## Description

Fixed bug where clients calling `createTemplateVersion` in the `template` resolver would get an error when trying to publish because adding data to `versionedQuestions` table required that `questionTypeId` not be `null`. I added a `data-migration script` to allow `null` because we now store the `question type` in the `json` field do not require `questionTypeId` field to tell us which question type the question is using.

Fixes # ([328](https://github.com/CDLUC3/dmsp_backend_prototype/issues/328))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually to make sure we could publish a template now.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules