### PR TITLE
[Bug fix] - Update sections and questions queries to order by displayOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Updated `sections` and `questions` queries to order by `displayOrder` [#324]
 - Refactor the way we initialize the pino Logger and pass it around. Also removed the old `formatLogMessage` function and replaced with `prepareObjectForLogs`
 - Consolidated handling of the Cache, so that we always pass the `adapter`
 - Updated `mysqlConfig` to use the new test DB when running in `test` mode

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -145,7 +145,7 @@ export class Question extends MySqlModel {
 
   // Fetch all of the Questions for the specified Section
   static async findBySectionId(reference: string, context: MyContext, sectionId: number): Promise<Question[]> {
-    const sql = 'SELECT * FROM questions WHERE sectionId = ?';
+    const sql = 'SELECT * FROM questions WHERE sectionId = ? ORDER BY displayOrder ASC';
     const results = await Question.query(context, sql, [sectionId?.toString()], reference);
     return Array.isArray(results) ? results.map((entry) => new Question(entry)) : [];
   }

--- a/src/models/Section.ts
+++ b/src/models/Section.ts
@@ -128,7 +128,7 @@ export class Section extends MySqlModel {
 
   // Find all Sections associated with the specified templateId
   static async findByTemplateId(reference: string, context: MyContext, templateId: number): Promise<Section[]> {
-    const sql = 'SELECT * FROM sections WHERE templateId = ?';
+    const sql = 'SELECT * FROM sections WHERE templateId = ? ORDER BY displayOrder ASC';
     const results = await Section.query(context, sql, [templateId?.toString()], reference);
     return Array.isArray(results) ? results.map((entry) => new Section(entry)) : [];
   }

--- a/src/models/__tests__/Question.spec.ts
+++ b/src/models/__tests__/Question.spec.ts
@@ -174,7 +174,7 @@ describe('findBy Queries', () => {
     localQuery.mockResolvedValueOnce([question]);
     const questionId = casual.integer(1, 999);
     const result = await Question.findBySectionId('testing', context, questionId);
-    const expectedSql = 'SELECT * FROM questions WHERE sectionId = ?';
+    const expectedSql = 'SELECT * FROM questions WHERE sectionId = ? ORDER BY displayOrder ASC';
     expect(localQuery).toHaveBeenCalledTimes(1);
     expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [questionId.toString()], 'testing')
     expect(result).toEqual([question]);

--- a/src/models/__tests__/Section.spec.ts
+++ b/src/models/__tests__/Section.spec.ts
@@ -122,7 +122,7 @@ describe('findByTemplateId', () => {
     localQuery.mockResolvedValueOnce([section]);
     const templateId = 1;
     const result = await Section.findByTemplateId('Section query', context, templateId);
-    const expectedSql = 'SELECT * FROM sections WHERE templateId = ?';
+    const expectedSql = 'SELECT * FROM sections WHERE templateId = ? ORDER BY displayOrder ASC';
     expect(localQuery).toHaveBeenCalledTimes(1);
     expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [templateId.toString()], 'Section query')
     expect(result).toEqual([section]);

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -78,8 +78,6 @@ export const resolvers: Resolvers = {
             required
           });
 
-console.log(question.json);
-
           // create the new question
           const newQuestion = await question.create(context);
 
@@ -158,13 +156,9 @@ console.log(question.json);
             await Template.markTemplateAsDirty('Question resolver - updateQuestion', context, questionData.templateId);
 
             // Refetch the question or the updated question with errors
-             const final = await Question.findById(reference, context, questionId);
+            const final = await Question.findById(reference, context, questionId);
 
-console.log(final);
-console.log(final.json)
-console.log(typeof final.json)
-
-             return final;
+            return final;
           }
 
           // Otherwise return the Question with errors


### PR DESCRIPTION
## Description

- Updated the `sections` and `questions` queries to be ordered by `displayOrder`
- 
Fixes # ([324](https://github.com/CDLUC3/dmsp_backend_prototype/issues/324))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
This was done by manually testing and with unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules