### PR TITLE
 Updated the 'addProject' resolver to also add the owner as a member when project is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Updated `addProject` to add the owner as a `projectMember` [#307]
 - Updated `sections` and `questions` queries to order by `displayOrder` [#324]
 - Refactor the way we initialize the pino Logger and pass it around. Also removed the old `formatLogMessage` function and replaced with `prepareObjectForLogs`
 - Consolidated handling of the Cache, so that we always pass the `adapter`


### PR DESCRIPTION

## Description

- Updated the `addProject` resolver to add the owner as a member when a project is created

Fixes # ([307]( https://github.com/CDLUC3/dmsp_backend_prototype/issues/307))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested manually


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules