### PR TITLE
fixed issue where apiTarget could not be null in the graphQL schema f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # DMP Tool Apollo Server Change Log
 
+### Fixed
+- Bug with `FunderPopularityResult` in the GraphQL schema that was making `apiTarget` non-nullable
+
 ## v0.2 - Initial deploy to the stage environment
 
 ### Added

--- a/src/schemas/affiliation.ts
+++ b/src/schemas/affiliation.ts
@@ -67,7 +67,7 @@ export const typeDefs = gql`
     "The official display name"
     displayName: String!
     "The apiTarget for the affiliation (if available)"
-    apiTarget: String!
+    apiTarget: String
     "The number of plans associated with this funder in the past year"
     nbrPlans: Int!
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -558,7 +558,7 @@ export type ExternalSearchInput = {
 export type FunderPopularityResult = {
   __typename?: 'FunderPopularityResult';
   /** The apiTarget for the affiliation (if available) */
-  apiTarget: Scalars['String']['output'];
+  apiTarget?: Maybe<Scalars['String']['output']>;
   /** The official display name */
   displayName: Scalars['String']['output'];
   /** The unique identifer for the affiliation */
@@ -4498,7 +4498,7 @@ export type ExternalProjectResolvers<ContextType = MyContext, ParentType extends
 };
 
 export type FunderPopularityResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['FunderPopularityResult'] = ResolversParentTypes['FunderPopularityResult']> = {
-  apiTarget?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  apiTarget?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   nbrPlans?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;


### PR DESCRIPTION
## Description

Fixed a bug in the popular funders query that was requiring `apiTarget` to be non-null

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in Apollo explorer

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules