### PR TITLE
[Feature] - Allow adding and removing multiple funders from plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## v0.2 - Initial deploy to the stage environment
 
 ### Added
+- Added `updatePlanFunding` to allow the update of multiple `planFunding` records [#305]
 - Added 'apiTarget' to the PopularFunders objects and query for use in the frontend
 - Added `updatePlanTitle` resolver
 - Added a `title` field to the `plans` table and then updated Plan model and schema to use it

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -191,69 +191,37 @@ export const resolvers: Resolvers = {
     },
 
     // add a new plan funding
-    updatePlanFunding: async (_, { planId, projectFundingIds }, context: MyContext): Promise<PlanFunding[]> => {
+    addPlanFunding: async (_, { planId, projectFundingId }, context: MyContext): Promise<PlanFunding> => {
       const reference = 'addPlanFunding resolver';
       try {
+        if (isAuthorized(context.token)) {
+          const plan = await Plan.findById(reference, context, planId);
+          if (isNullOrUndefined(plan)) {
+            throw NotFoundError();
+          }
 
-        if (!isAuthorized(context.token)) {
-          throw context.token ? ForbiddenError() : AuthenticationError();
-        }
+          const projectFunding = await ProjectFunding.findById(
+            reference,
+            context,
+            projectFundingId
+          );
+          if (isNullOrUndefined(projectFunding)) {
+            throw NotFoundError();
+          }
 
-        const plan = await Plan.findById(reference, context, planId);
-        if (isNullOrUndefined(plan)) {
-          throw NotFoundError();
-        }
+          const project = await Project.findById(reference, context, plan.projectId);
+          if (await hasPermissionOnProject(context, project)) {
+            const newFunding = new PlanFunding({ planId, projectFundingId });
 
-        // Version all of the plans (if any) and sync with the DMPHub
-        await addVersion(context, plan, reference);
-
-
-        const associationErrors = [];
-        // Fetch all of the current Funders associated with this Plan
-        const fundings = await PlanFunding.findByPlanId(reference, context, plan.id);
-        const currentPlanFundingids = fundings ? fundings.map((d) => d.projectFundingId) : [];
-        // Use the helper function to determine which funders to keep and which to remove
-        const {
-          idsToBeRemoved,
-          idsToBeSaved
-        } = PlanFunding.reconcileAssociationIds(
-          currentPlanFundingids,
-          projectFundingIds
-        );
-
-        const removeErrors = [];
-        // Remove records that are not in the newly supplied projectFundingIds array
-        for (const id of idsToBeRemoved) {
-          const funding = await PlanFunding.findByProjectFundingId(reference, context, planId, id);
-          if (funding) {
-            const wasRemoved = funding.removeFromPlanFunding(context, planId, id);
-            if (!wasRemoved) {
-              removeErrors.push(funding.projectFundingId);
+            if (newFunding && !newFunding.hasErrors()) {
+              // Version all of the plans (if any) and sync with the DMPHub
+              await addVersion(context, plan, reference);
             }
+
+            return await newFunding.create(context);
           }
         }
-        // If any failed to be removed, then add an error
-        if (removeErrors.length > 0) {
-          associationErrors.push(`unable to remove funding: ${removeErrors.join(', ')}`);
-        }
-
-        const addErrors = [];
-        // Add new records for projectFundingIds that are not already in planFundings table
-        for (const id of idsToBeSaved) {
-          const funding = new PlanFunding({ planId, projectFundingId: id });
-
-          const wasAdded = funding.addToPlanFunding(context, planId, id);
-          if (!wasAdded) {
-            addErrors.push(funding.projectFundingId);
-          }
-
-        }
-        // If any failed to be added, then add an error to the ProjectMember
-        if (addErrors.length > 0) {
-          associationErrors.push(`unable to assign roles: ${addErrors.join(', ')}`);
-        }
-
-        return await PlanFunding.findByPlanId(reference, context, plan.id);
+        throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
 
@@ -262,7 +230,83 @@ export const resolvers: Resolvers = {
       }
     },
 
-    // remove a plan funding
+    // Update any number of planFundings by passing in an array of the new projectFundingIds. New ones will be added and existing ones
+    // that are not included in the projectFundingIds array will be removed
+    updatePlanFunding: async (_, { planId, projectFundingIds }, context: MyContext): Promise<PlanFunding[]> => {
+      const reference = 'updatePlanFunding resolver';
+      try {
+
+        if (isAuthorized(context.token)) {
+          const plan = await Plan.findById(reference, context, planId);
+          if (isNullOrUndefined(plan)) {
+            throw NotFoundError();
+          }
+
+          const project = await Project.findById(reference, context, plan.projectId);
+          if (await hasPermissionOnProject(context, project)) {
+            const associationErrors = [];
+            // Fetch all of the current Funders associated with this Plan
+            const fundings = await PlanFunding.findByPlanId(reference, context, plan.id);
+            const currentPlanFundingids = fundings ? fundings.map((d) => d.projectFundingId) : [];
+            // Use the helper function to determine which funders to keep and which to remove
+            const {
+              idsToBeRemoved,
+              idsToBeSaved
+            } = PlanFunding.reconcileAssociationIds(
+              currentPlanFundingids,
+              projectFundingIds
+            );
+
+            const removeErrors = [];
+            // Remove records that are not in the newly supplied projectFundingIds array
+            for (const id of idsToBeRemoved) {
+              const funding = await PlanFunding.findByProjectFundingId(reference, context, planId, id);
+              if (funding) {
+                const wasRemoved = funding.removeFromPlanFunding(context, planId, id);
+                if (!wasRemoved) {
+                  removeErrors.push(funding.projectFundingId);
+                }
+              }
+            }
+            // If any failed to be removed, then add an error
+            if (removeErrors.length > 0) {
+              associationErrors.push(`unable to remove funding: ${removeErrors.join(', ')}`);
+            }
+
+            const addErrors = [];
+            // Add new records for projectFundingIds that are not already in planFundings table
+            for (const id of idsToBeSaved) {
+              const funding = new PlanFunding({ planId, projectFundingId: id });
+
+              const wasAdded = funding.addToPlanFunding(context, planId, id);
+              if (!wasAdded) {
+                addErrors.push(funding.projectFundingId);
+              }
+
+            }
+            // If any failed to be added, then add an error
+            if (addErrors.length > 0) {
+              associationErrors.push(`unable to assign roles: ${addErrors.join(', ')}`);
+            }
+
+            if (associationErrors.length > 0) {
+              context.logger.warn(`Plan funding update had issues: ${associationErrors.join(', ')}`);
+            }
+
+            await addVersion(context, plan, reference);
+            return await PlanFunding.findByPlanId(reference, context, plan.id);
+          }
+        }
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+
+    // remove one plan funding
     removePlanFunding: async (_, { planFundingId }, context: MyContext): Promise<PlanFunding> => {
       const reference = 'removePlanFunding resolver';
       try {

--- a/src/schemas/funding.ts
+++ b/src/schemas/funding.ts
@@ -21,7 +21,7 @@ export const typeDefs = gql`
     removeProjectFunding(projectFundingId: Int!): ProjectFunding
 
     "Add a Funding information to a Plan"
-    addPlanFunding(planId: Int!, projectFundingId: Int!): PlanFunding
+    updatePlanFunding(planId: Int!, projectFundingIds: [Int!]!): [PlanFunding]
     "Remove a Funding from a Plan"
     removePlanFunding(planFundingId: Int!): PlanFunding
   }

--- a/src/schemas/funding.ts
+++ b/src/schemas/funding.ts
@@ -21,6 +21,8 @@ export const typeDefs = gql`
     removeProjectFunding(projectFundingId: Int!): ProjectFunding
 
     "Add a Funding information to a Plan"
+    addPlanFunding(planId: Int!, projectFundingId: Int!): PlanFunding
+    "Update multiple Plan Fundings passing in an array of projectFundingIds"
     updatePlanFunding(planId: Int!, projectFundingIds: [Int!]!): [PlanFunding]
     "Remove a Funding from a Plan"
     removePlanFunding(planFundingId: Int!): PlanFunding

--- a/src/types.ts
+++ b/src/types.ts
@@ -762,6 +762,8 @@ export type Mutation = {
   addMetadataStandard?: Maybe<MetadataStandard>;
   /** Create a plan */
   addPlan?: Maybe<Plan>;
+  /** Add a Funding information to a Plan */
+  addPlanFunding?: Maybe<PlanFunding>;
   /** Add a Member to a Plan */
   addPlanMember?: Maybe<PlanMember>;
   /** Create a project */
@@ -880,7 +882,7 @@ export type Mutation = {
   updateMetadataStandard?: Maybe<MetadataStandard>;
   /** Change the current user's password */
   updatePassword?: Maybe<User>;
-  /** Add a Funding information to a Plan */
+  /** Update multiple Plan Fundings passing in an array of projectFundingIds */
   updatePlanFunding?: Maybe<Array<Maybe<PlanFunding>>>;
   /** Chnage a Member's accessLevel on a Plan */
   updatePlanMember?: Maybe<PlanMember>;
@@ -974,6 +976,12 @@ export type MutationAddMetadataStandardArgs = {
 export type MutationAddPlanArgs = {
   projectId: Scalars['Int']['input'];
   versionedTemplateId: Scalars['Int']['input'];
+};
+
+
+export type MutationAddPlanFundingArgs = {
+  planId: Scalars['Int']['input'];
+  projectFundingId: Scalars['Int']['input'];
 };
 
 
@@ -4623,6 +4631,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addMemberRole?: Resolver<Maybe<ResolversTypes['MemberRole']>, ParentType, ContextType, RequireFields<MutationAddMemberRoleArgs, 'displayOrder' | 'label' | 'url'>>;
   addMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationAddMetadataStandardArgs, 'input'>>;
   addPlan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationAddPlanArgs, 'projectId' | 'versionedTemplateId'>>;
+  addPlanFunding?: Resolver<Maybe<ResolversTypes['PlanFunding']>, ParentType, ContextType, RequireFields<MutationAddPlanFundingArgs, 'planId' | 'projectFundingId'>>;
   addPlanMember?: Resolver<Maybe<ResolversTypes['PlanMember']>, ParentType, ContextType, RequireFields<MutationAddPlanMemberArgs, 'planId' | 'projectMemberId'>>;
   addProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<MutationAddProjectArgs, 'title'>>;
   addProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationAddProjectCollaboratorArgs, 'email' | 'projectId'>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -762,8 +762,6 @@ export type Mutation = {
   addMetadataStandard?: Maybe<MetadataStandard>;
   /** Create a plan */
   addPlan?: Maybe<Plan>;
-  /** Add a Funding information to a Plan */
-  addPlanFunding?: Maybe<PlanFunding>;
   /** Add a Member to a Plan */
   addPlanMember?: Maybe<PlanMember>;
   /** Create a project */
@@ -882,6 +880,8 @@ export type Mutation = {
   updateMetadataStandard?: Maybe<MetadataStandard>;
   /** Change the current user's password */
   updatePassword?: Maybe<User>;
+  /** Add a Funding information to a Plan */
+  updatePlanFunding?: Maybe<Array<Maybe<PlanFunding>>>;
   /** Chnage a Member's accessLevel on a Plan */
   updatePlanMember?: Maybe<PlanMember>;
   /** Change the plan's status */
@@ -974,12 +974,6 @@ export type MutationAddMetadataStandardArgs = {
 export type MutationAddPlanArgs = {
   projectId: Scalars['Int']['input'];
   versionedTemplateId: Scalars['Int']['input'];
-};
-
-
-export type MutationAddPlanFundingArgs = {
-  planId: Scalars['Int']['input'];
-  projectFundingId: Scalars['Int']['input'];
 };
 
 
@@ -1296,6 +1290,12 @@ export type MutationUpdatePasswordArgs = {
   email: Scalars['String']['input'];
   newPassword: Scalars['String']['input'];
   oldPassword: Scalars['String']['input'];
+};
+
+
+export type MutationUpdatePlanFundingArgs = {
+  planId: Scalars['Int']['input'];
+  projectFundingIds: Array<Scalars['Int']['input']>;
 };
 
 
@@ -4623,7 +4623,6 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addMemberRole?: Resolver<Maybe<ResolversTypes['MemberRole']>, ParentType, ContextType, RequireFields<MutationAddMemberRoleArgs, 'displayOrder' | 'label' | 'url'>>;
   addMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationAddMetadataStandardArgs, 'input'>>;
   addPlan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationAddPlanArgs, 'projectId' | 'versionedTemplateId'>>;
-  addPlanFunding?: Resolver<Maybe<ResolversTypes['PlanFunding']>, ParentType, ContextType, RequireFields<MutationAddPlanFundingArgs, 'planId' | 'projectFundingId'>>;
   addPlanMember?: Resolver<Maybe<ResolversTypes['PlanMember']>, ParentType, ContextType, RequireFields<MutationAddPlanMemberArgs, 'planId' | 'projectMemberId'>>;
   addProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<MutationAddProjectArgs, 'title'>>;
   addProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationAddProjectCollaboratorArgs, 'email' | 'projectId'>>;
@@ -4683,6 +4682,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateMemberRole?: Resolver<Maybe<ResolversTypes['MemberRole']>, ParentType, ContextType, RequireFields<MutationUpdateMemberRoleArgs, 'displayOrder' | 'id' | 'label' | 'url'>>;
   updateMetadataStandard?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationUpdateMetadataStandardArgs, 'input'>>;
   updatePassword?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdatePasswordArgs, 'email' | 'newPassword' | 'oldPassword'>>;
+  updatePlanFunding?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFunding']>>>, ParentType, ContextType, RequireFields<MutationUpdatePlanFundingArgs, 'planId' | 'projectFundingIds'>>;
   updatePlanMember?: Resolver<Maybe<ResolversTypes['PlanMember']>, ParentType, ContextType, RequireFields<MutationUpdatePlanMemberArgs, 'planId' | 'planMemberId'>>;
   updatePlanStatus?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationUpdatePlanStatusArgs, 'planId' | 'status'>>;
   updatePlanTitle?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationUpdatePlanTitleArgs, 'planId' | 'title'>>;


### PR DESCRIPTION
## Description

- Added a new resolver, `updatePlanFunding`, to allows users to pass in an array of `projectFundingIds` with their `planId` in order to `remove` or `add` new ones.

Fixes # ([305](https://github.com/CDLUC3/dmsp_backend_prototype/issues/305))

## Type of change
Please delete options that are not relevant

- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Tested manually and made sure unit tests didn't break


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## To Test
- In Apollo Explorer, pass in a list of the `projectFundingIds` you would like to add to the `planFundings` page using the `updatePlanFunding` resolver