### PR TITLE
[Bug fix] - totalCount returned as 0, or was changing with each request…

### DIFF
--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -177,7 +177,7 @@ describe('MySqlModel abstract class', () => {
       const countField = 'id';
       const values = ['value'];
       const reference = 'Testing';
-      const mockResponse = [{ total: 42 }];
+      const mockResponse = [{ total: 4 }, { total: 3 }, { total: 4 }];
 
       localQuery.mockResolvedValueOnce(mockResponse);
 
@@ -198,7 +198,7 @@ describe('MySqlModel abstract class', () => {
         values,
         reference
       );
-      expect(result).toEqual(42);
+      expect(result).toEqual(3);
     });
 
     it('returns 0 when the query returns an empty array', async () => {
@@ -268,7 +268,7 @@ describe('MySqlModel abstract class', () => {
       const countField = 't1.id';
       const values = ['value'];
       const reference = 'Testing';
-      const mockResponse = [{ total: 10 }];
+      const mockResponse = [{ total: 10 }, { total: 3 }, { total: 5 }];
 
       localQuery.mockResolvedValueOnce(mockResponse);
 
@@ -289,7 +289,7 @@ describe('MySqlModel abstract class', () => {
         values,
         reference
       );
-      expect(result).toEqual(10);
+      expect(result).toEqual(3);
     });
   });
 });


### PR DESCRIPTION

## Description

While working on the frontend ticket [647](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/647), I noticed that when making requests for myProjects, I was getting a totalCount =0 even though there was more than one item found from a search.

- I updated `paginatedQueryByCursor` to use the original `whereClause` when calling `getTotalCountForPagination` because otherwise,  the `totalCount` was changing on each request.
- Made update to return `countResponse` differently based on whether there was a `groupBy` clause. Previously, the totalCount returned was incorrect, and looked something like the following, with each object representing one found item in the query due to the `groupBy` clause
```
[{ total: 3 },{ total: 3 },{ total: 1 }]
```

Fixes # ([373](https://github.com/CDLUC3/dmsp_backend_prototype/issues/373))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual test and unit test


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
* Note: Not a dependency but I am working on a frontend ticket that needs the correct totalCount (#[647](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/647))