### PR TITLE
Add filter options to myProjects resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added
+- Added `ProjectFilterOptions` as a possible input for the `myProjects` resolver
 - added `publishedSection` resolver to `src/resolvers/versionedSection.ts`
 - added `publishedQuestion` resolver to `src/resolvers/versionedQuestion.ts`
 
 ### Updated
+- Updated the `ProjectSearchResult.search` query to provide plan counts by status and filter by status options
 - updated `PlanSectionProgress` to use better terminology. Changed `sectionId` to `versionedSectionId` (what it really was) and `sectionTtitle` to `title`
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- Fixed an issue with the null/undefined check on model queries that use 'searchTerm'
 - When generating a new `versionedTemplate`, we need to deactivate the old ones in the db [#363]
 - Bug with `FunderPopularityResult` in the GraphQL schema that was making `apiTarget` non-nullable
 - added a data migration script to repair bad option based question JSON

--- a/src/models/Affiliation.ts
+++ b/src/models/Affiliation.ts
@@ -340,7 +340,7 @@ export class AffiliationSearch {
 
     // Handle the incoming search term
     const searchTerm = (name ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(a.searchName) LIKE ?)');
       values.push(`%${searchTerm}%`);
     }

--- a/src/models/License.ts
+++ b/src/models/License.ts
@@ -137,7 +137,7 @@ export class License extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (name ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(l.name) LIKE ? OR LOWER(l.description) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/MetadataStandard.ts
+++ b/src/models/MetadataStandard.ts
@@ -181,7 +181,7 @@ export class MetadataStandard extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(m.name) LIKE ? OR LOWER(m.keywords) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils/helpers";
 import { MySqlModel } from "./MySqlModel";
 import { addVersion, removeVersions, updateVersion } from "./PlanVersion";
-import {Project} from "./Project";
+import { Project } from "./Project";
 
 export const DEFAULT_TEMPORARY_DMP_ID_PREFIX = 'temp-dmpId-';
 

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -61,7 +61,7 @@ export class ProjectSearchResult {
     term: string,
     userId: number,
     affiliationId: string | null = null,
-    filterOptions: ProjectFilterOptions = Project.defaultSearchFilterOptions,
+    filterOptions: ProjectFilterOptions = {},
     options: PaginationOptions = Project.getDefaultPaginationOptions()
   ): Promise<PaginatedQueryResults<ProjectSearchResult>> {
     const whereFilters = [];
@@ -72,6 +72,10 @@ export class ProjectSearchResult {
     if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(p.title) LIKE ? OR LOWER(p.abstractText) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
+    }
+
+    if (isNullOrUndefined(filterOptions?.status)) {
+      filterOptions.status = PlanStatus.DRAFT;
     }
 
     // Handle the Plan.status filter
@@ -329,11 +333,6 @@ export class Project extends MySqlModel {
       }
     }
     return null;
-  }
-
-  // Default filter options
-  static defaultSearchFilterOptions: ProjectFilterOptions = {
-    status: PlanStatus.DRAFT
   }
 
   // Return all of projects for the User

--- a/src/models/Repository.ts
+++ b/src/models/Repository.ts
@@ -191,7 +191,7 @@ export class Repository extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(r.name) LIKE ? OR LOWER(r.description) LIKE ? OR LOWER(r.keywords) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/ResearchDomain.ts
+++ b/src/models/ResearchDomain.ts
@@ -209,7 +209,7 @@ export class ResearchDomain extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(rd.name) LIKE ? OR LOWER(rd.description) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -61,7 +61,7 @@ export class TemplateSearchResult {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(t.name) LIKE ? OR LOWER(t.description) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -199,7 +199,7 @@ export class User extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push(`(
         (LOWER(u.givenName) LIKE ? OR
         LOWER(u.surName) LIKE ? OR
@@ -262,7 +262,7 @@ export class User extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push(`(
         LOWER(u.givenName) LIKE ? OR
         LOWER(u.surName) LIKE ? OR

--- a/src/models/VersionedSection.ts
+++ b/src/models/VersionedSection.ts
@@ -46,7 +46,7 @@ export class VersionedSectionSearchResult {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('LOWER(vs.name) LIKE ?');
       values.push(`%${searchTerm}%`);
     }
@@ -186,7 +186,7 @@ export class VersionedSection extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('LOWER(vs.name) LIKE ?');
       values.push(`%${searchTerm}%`);
     }

--- a/src/models/VersionedTemplate.ts
+++ b/src/models/VersionedTemplate.ts
@@ -57,7 +57,7 @@ export class VersionedTemplateSearchResult {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (searchTerm) {
+    if (!isNullOrUndefined(searchTerm)) {
       whereFilters.push('(LOWER(vt.name) LIKE ? OR LOWER(a.searchName) LIKE ?)');
       values.push(`%${searchTerm}%`, `%${searchTerm}%`);
     }

--- a/src/models/__tests__/MetadataStandard.spec.ts
+++ b/src/models/__tests__/MetadataStandard.spec.ts
@@ -218,8 +218,11 @@ describe('findBy Queries', () => {
     const result = await MetadataStandard.search('testing', context, null, researchDomainId);
     const sql = 'SELECT m.* FROM metadataStandards m ' +
                 'LEFT OUTER JOIN metadataStandardResearchDomains msrd ON m.id = msrd.metadataStandardId';
-    const whereFilters = ['msrd.researchDomainId = ?'];
-    const vals = [researchDomainId.toString()];
+    const whereFilters = [
+      "(LOWER(m.name) LIKE ? OR LOWER(m.keywords) LIKE ?)",
+      'msrd.researchDomainId = ?'
+    ];
+    const vals = ["%%", "%%", researchDomainId.toString()];
     const opts = {
       cursor: null,
       limit: generalConfig.defaultSearchLimit,
@@ -268,7 +271,9 @@ describe('findBy Queries', () => {
       cursorField: 'LOWER(REPLACE(CONCAT(m.name, m.id), \' \', \'_\'))',
     };
     expect(localPaginationQuery).toHaveBeenCalledTimes(1);
-    expect(localPaginationQuery).toHaveBeenLastCalledWith(context, sql, [], '', [], opts, 'testing')
+    const where = ["(LOWER(m.name) LIKE ? OR LOWER(m.keywords) LIKE ?)"];
+    const vals = ["%%", "%%"];
+    expect(localPaginationQuery).toHaveBeenLastCalledWith(context, sql, where, '', vals, opts, 'testing')
     expect(result).toEqual([standard]);
   });
 

--- a/src/models/__tests__/Repository.spec.ts
+++ b/src/models/__tests__/Repository.spec.ts
@@ -234,8 +234,11 @@ describe('findBy Queries', () => {
     const result = await Repository.search('testing', context, null, researchDomainId, null);
     const sql = 'SELECT r.* FROM repositories r ' +
                 'LEFT OUTER JOIN repositoryResearchDomains rrd ON r.id = rrd.repositoryId';
-    const vals = [researchDomainId.toString()];
-    const whereFilters = ['rrd.researchDomainId = ?'];
+    const vals = ['%%', '%%', '%%', researchDomainId.toString()];
+    const whereFilters = [
+      '(LOWER(r.name) LIKE ? OR LOWER(r.description) LIKE ? OR LOWER(r.keywords) LIKE ?)',
+      'rrd.researchDomainId = ?'
+    ];
     const opts = {
       cursor: null,
       limit: generalConfig.defaultSearchLimit,
@@ -255,8 +258,11 @@ describe('findBy Queries', () => {
     const result = await Repository.search('testing', context, null, null, repositoryType);
     const sql = 'SELECT r.* FROM repositories r ' +
                 'LEFT OUTER JOIN repositoryResearchDomains rrd ON r.id = rrd.repositoryId';
-    const vals = [repositoryType];
-    const whereFilters = ['JSON_CONTAINS(r.repositoryTypes, ?, \'$\')'];
+    const vals = ['%%', '%%', '%%', repositoryType];
+    const whereFilters = [
+      '(LOWER(r.name) LIKE ? OR LOWER(r.description) LIKE ? OR LOWER(r.keywords) LIKE ?)',
+      'JSON_CONTAINS(r.repositoryTypes, ?, \'$\')'
+    ];
     const opts = {
       cursor: null,
       limit: generalConfig.defaultSearchLimit,
@@ -277,8 +283,12 @@ describe('findBy Queries', () => {
     const result = await Repository.search('testing', context, null, researchDomainId, repositoryType);
     const sql = 'SELECT r.* FROM repositories r ' +
                 'LEFT OUTER JOIN repositoryResearchDomains rrd ON r.id = rrd.repositoryId';
-    const vals = [repositoryType, researchDomainId.toString()];
-    const whereFilters = ['JSON_CONTAINS(r.repositoryTypes, ?, \'$\')', 'rrd.researchDomainId = ?'];
+    const vals = ['%%', '%%', '%%', repositoryType, researchDomainId.toString()];
+    const whereFilters = [
+      '(LOWER(r.name) LIKE ? OR LOWER(r.description) LIKE ? OR LOWER(r.keywords) LIKE ?)',
+      'JSON_CONTAINS(r.repositoryTypes, ?, \'$\')',
+      'rrd.researchDomainId = ?'
+    ];
     const opts = {
       cursor: null,
       limit: generalConfig.defaultSearchLimit,

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -1,45 +1,71 @@
-import { prepareObjectForLogs } from '../logger';
-import { ExternalProject, ProjectSearchResults, Resolvers } from "../types";
-import { Project, ProjectSearchResult } from "../models/Project";
+import {prepareObjectForLogs} from '../logger';
+import {ExternalProject, ProjectSearchResults, Resolvers} from "../types";
+import {Project, ProjectSearchResult} from "../models/Project";
 import {
   ProjectCollaborator,
   ProjectCollaboratorAccessLevel
 } from '../models/Collaborator';
-import { MyContext } from '../context';
+import {MyContext} from '../context';
 import {isAdmin, isAuthorized, isSuperAdmin} from '../services/authService';
-import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
-import { ProjectFunding } from '../models/Funding';
-import { ProjectMember } from '../models/Member';
+import {
+  AuthenticationError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError
+} from '../utils/graphQLErrors';
+import {ProjectFunding} from '../models/Funding';
+import {ProjectMember} from '../models/Member';
 import {
   ensureDefaultProjectContact,
-  hasPermissionOnProject, setCurrentUserAsProjectOwner
+  hasPermissionOnProject,
+  setCurrentUserAsProjectOwner
 } from '../services/projectService';
-import { Affiliation } from '../models/Affiliation';
-import { ResearchDomain } from '../models/ResearchDomain';
-import { ProjectOutput } from '../models/Output';
-import { MemberRole } from '../models/MemberRole';
-import { GraphQLError } from 'graphql';
-import { Plan, PlanSearchResult } from '../models/Plan';
-import { addVersion } from '../models/PlanVersion';
-import { isNullOrUndefined, normaliseDate, normaliseDateTime } from '../utils/helpers';
-import { parseMember } from '../services/commonStandardService';
-import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationType } from '../types/general';
+import {Affiliation} from '../models/Affiliation';
+import {ResearchDomain} from '../models/ResearchDomain';
+import {ProjectOutput} from '../models/Output';
+import {MemberRole} from '../models/MemberRole';
+import {GraphQLError} from 'graphql';
+import {Plan, PlanSearchResult, PlanStatus} from '../models/Plan';
+import {addVersion} from '../models/PlanVersion';
+import {
+  isNullOrUndefined,
+  normaliseDate,
+  normaliseDateTime
+} from '../utils/helpers';
+import {parseMember} from '../services/commonStandardService';
+import {
+  PaginationOptionsForCursors,
+  PaginationOptionsForOffsets,
+  PaginationType
+} from '../types/general';
 
 export const resolvers: Resolvers = {
   Query: {
     // return all of the projects that the current user owns or is a collaborator on
-    myProjects: async (_, { term, paginationOptions }, context: MyContext): Promise<ProjectSearchResults> => {
+    myProjects: async (
+      _,
+      { term, paginationOptions, filterOptions },
+      context: MyContext
+    ): Promise<ProjectSearchResults> => {
       const reference = 'myProjects resolver';
       try {
         if (isAuthorized(context.token)) {
-          const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+          const pagOpts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
                       ? paginationOptions as PaginationOptionsForOffsets
                       : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
           const userId = isAdmin(context.token) ? null : context.token?.id;
           const affiliationId = isSuperAdmin(context.token) ? null : context.token?.affiliationId;
 
-          return await ProjectSearchResult.search(reference, context, term, userId, affiliationId, opts);
+          return await ProjectSearchResult.search(
+            reference,
+            context,
+            term,
+            userId,
+            affiliationId,
+            filterOptions,
+            pagOpts
+          );
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -1,38 +1,38 @@
-import {prepareObjectForLogs} from '../logger';
-import {ExternalProject, ProjectSearchResults, Resolvers} from "../types";
-import {Project, ProjectSearchResult} from "../models/Project";
+import { prepareObjectForLogs } from '../logger';
+import { ExternalProject, ProjectSearchResults, Resolvers } from "../types";
+import { Project, ProjectSearchResult } from "../models/Project";
 import {
   ProjectCollaborator,
   ProjectCollaboratorAccessLevel
 } from '../models/Collaborator';
-import {MyContext} from '../context';
-import {isAdmin, isAuthorized, isSuperAdmin} from '../services/authService';
+import { MyContext } from '../context';
+import { isAdmin, isAuthorized, isSuperAdmin } from '../services/authService';
 import {
   AuthenticationError,
   ForbiddenError,
   InternalServerError,
   NotFoundError
 } from '../utils/graphQLErrors';
-import {ProjectFunding} from '../models/Funding';
-import {ProjectMember} from '../models/Member';
+import { ProjectFunding } from '../models/Funding';
+import { ProjectMember } from '../models/Member';
 import {
   ensureDefaultProjectContact,
   hasPermissionOnProject,
   setCurrentUserAsProjectOwner
 } from '../services/projectService';
-import {Affiliation} from '../models/Affiliation';
-import {ResearchDomain} from '../models/ResearchDomain';
-import {ProjectOutput} from '../models/Output';
-import {MemberRole} from '../models/MemberRole';
-import {GraphQLError} from 'graphql';
-import {Plan, PlanSearchResult, PlanStatus} from '../models/Plan';
-import {addVersion} from '../models/PlanVersion';
+import { Affiliation } from '../models/Affiliation';
+import { ResearchDomain } from '../models/ResearchDomain';
+import { ProjectOutput } from '../models/Output';
+import { MemberRole } from '../models/MemberRole';
+import { GraphQLError } from 'graphql';
+import { Plan, PlanSearchResult } from '../models/Plan';
+import { addVersion } from '../models/PlanVersion';
 import {
   isNullOrUndefined,
   normaliseDate,
   normaliseDateTime
 } from '../utils/helpers';
-import {parseMember} from '../services/commonStandardService';
+import { parseMember } from '../services/commonStandardService';
 import {
   PaginationOptionsForCursors,
   PaginationOptionsForOffsets,

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -6,7 +6,11 @@ import {typeDefs as funderTypeDefs} from "./funding"
 export const projectTypeDefs = gql`
   extend type Query {
     "Get all of the user's projects"
-    myProjects(term: String, paginationOptions: PaginationOptions): ProjectSearchResults
+    myProjects(
+      term: String,
+      paginationOptions: PaginationOptions,
+      filterOptions: ProjectFilterOptions
+    ): ProjectSearchResults
 
     "Get a specific project"
     project(projectId: Int!): Project
@@ -160,6 +164,12 @@ export const projectTypeDefs = gql`
     name: String
     "The grant id/url"
     grantId: String
+  }
+
+  "Project search filter options"
+  input ProjectFilterOptions {
+    "Filter results by the plan's status"
+    status: PlanStatus
   }
 
   input UpdateProjectInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1912,6 +1912,12 @@ export type ProjectErrors = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
+/** Project search filter options */
+export type ProjectFilterOptions = {
+  /** Filter results by the plan's status */
+  status?: InputMaybe<PlanStatus>;
+};
+
 /** Funding that is supporting a research project */
 export type ProjectFunding = {
   __typename?: 'ProjectFunding';
@@ -2398,6 +2404,7 @@ export type QueryMetadataStandardsArgs = {
 
 
 export type QueryMyProjectsArgs = {
+  filterOptions?: InputMaybe<ProjectFilterOptions>;
   paginationOptions?: InputMaybe<PaginationOptions>;
   term?: InputMaybe<Scalars['String']['input']>;
 };
@@ -4066,6 +4073,7 @@ export type ResolversTypes = {
   ProjectCollaboratorAccessLevel: ProjectCollaboratorAccessLevel;
   ProjectCollaboratorErrors: ResolverTypeWrapper<ProjectCollaboratorErrors>;
   ProjectErrors: ResolverTypeWrapper<ProjectErrors>;
+  ProjectFilterOptions: ProjectFilterOptions;
   ProjectFunding: ResolverTypeWrapper<ProjectFunding>;
   ProjectFundingErrors: ResolverTypeWrapper<ProjectFundingErrors>;
   ProjectFundingStatus: ProjectFundingStatus;
@@ -4220,6 +4228,7 @@ export type ResolversParentTypes = {
   ProjectCollaborator: ProjectCollaborator;
   ProjectCollaboratorErrors: ProjectCollaboratorErrors;
   ProjectErrors: ProjectErrors;
+  ProjectFilterOptions: ProjectFilterOptions;
   ProjectFunding: ProjectFunding;
   ProjectFundingErrors: ProjectFundingErrors;
   ProjectImportInput: ProjectImportInput;


### PR DESCRIPTION
## Description

Part of #368

- Add `ProjectFilterOptions` as an optional input for the `myProjects` resolver.
- Updated the `ProjectSearchResult.search` query so that it now returns plan counts by status and also adhere's to `status` filter options
- - `ARCHIVED` returns all projects that have at least one archived plan
- - `COMPLETE` returns all projects that have at least one complete plan
- - `DRAFT` (default) returns all projects that have at least one draft plan or NO plans yet
- Also fixed an issue with queries that have a `searchTerm` but were not accurately doing a null/undefined check

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Updated all unit tests. Manually tested in Apollo explorer

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules