### PR TITLE
Updated publishedTemplates query so that I can request only bestPractice or funder templates

### DIFF
--- a/src/models/VersionedTemplate.ts
+++ b/src/models/VersionedTemplate.ts
@@ -288,7 +288,7 @@ export class VersionedTemplate extends MySqlModel {
   }
 
   static async hasBestPracticeTemplates(reference: string, context: MyContext, term?: string): Promise<boolean> {
-    const whereFilters = ['vt.active = 1 AND vt.versionType = ?'];
+    const whereFilters = ['vt.active = 1 AND vt.bestPractice = 1 AND vt.versionType = ?'];
     const values = [TemplateVersionType.PUBLISHED.toString()];
 
     // Handle the incoming search term
@@ -305,6 +305,8 @@ export class VersionedTemplate extends MySqlModel {
     WHERE ${whereFilters.join(' AND ')}
   `;
 
+    console.log("***SQL", sql);
+    console.log("***VALUES", values);
     const result = await VersionedTemplate.query(context, sql, values, reference);
     const results = Array.isArray(result) ? result : [];
     return results.length > 0 && results[0].count > 0;

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -38,7 +38,7 @@ export const resolvers: Resolvers = {
 
     // Search for PublishedTemplates whose name or owning Org's name contains the search term
     //    - called by the Template Builder - prior template selection page
-      publishedTemplates: async (_, { term, paginationOptions }, context: MyContext): Promise<PublishedTemplateSearchResults> => {
+    publishedTemplates: async (_, { term, paginationOptions }, context: MyContext): Promise<PublishedTemplateSearchResults> => {
       const reference = 'publishedTemplates resolver';
 
       try {

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -38,14 +38,14 @@ export const resolvers: Resolvers = {
 
     // Search for PublishedTemplates whose name or owning Org's name contains the search term
     //    - called by the Template Builder - prior template selection page
-    publishedTemplates: async (_, { term, paginationOptions }, context: MyContext): Promise<PublishedTemplateSearchResults> => {
+      publishedTemplates: async (_, { term, paginationOptions }, context: MyContext): Promise<PublishedTemplateSearchResults> => {
       const reference = 'publishedTemplates resolver';
 
       try {
         if (isAuthorized(context.token)) {
           const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
-            ? paginationOptions as PaginationOptionsForOffsets
-            : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+                      ? paginationOptions as PaginationOptionsForOffsets
+                      : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
           return await VersionedTemplateSearchResult.search(reference, context, term, opts);
         }
@@ -60,17 +60,13 @@ export const resolvers: Resolvers = {
     },
 
     // Get metadata for client to provide the unique template affiliations, as well as whether there are any best practice templates
-    publishedTemplatesMetaData: async (_, { term, paginationOptions }, context: MyContext): Promise<PublishedTemplateMetaDataResults> => {
+    publishedTemplatesMetaData: async (_, __, context: MyContext): Promise<PublishedTemplateMetaDataResults> => {
       const reference = 'publishedTemplatesMetaData resolver';
 
       try {
         if (isAuthorized(context.token)) {
-          const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
-            ? paginationOptions as PaginationOptionsForOffsets
-            : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
-
           // returns associated availableAffiliations and hasBestPracticeTemplates
-          return await VersionedTemplate.getFilterMetadata(reference, context, term);
+          return await VersionedTemplate.getFilterMetadata(reference, context);
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -42,8 +42,6 @@ export const typeDefs = gql`
     sortField: String
     "The sort order (used for standard offset pagination only!)"
     sortDir: String
-    "Specify that you want additional metadata, like whether the result set includes bestPractice options"
-    includeMetadata: Boolean
     "Request just the bestPractice templates"
     bestPractice: Boolean
     "Request templates whose ownerIds match the provided array of ownerURIs"

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -42,6 +42,12 @@ export const typeDefs = gql`
     sortField: String
     "The sort order (used for standard offset pagination only!)"
     sortDir: String
+    "Specify that you want additional metadata, like whether the result set includes bestPractice options"
+    includeMetadata: Boolean
+    "Request just the bestPractice templates"
+    bestPractice: Boolean
+    "Request templates whose ownerIds match the provided array of ownerURIs"
+    selectOwnerURIs: [String]
   }
 
   interface PaginatedQueryResults {

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -6,6 +6,8 @@ export const typeDefs = gql`
     templateVersions(templateId: Int!): [VersionedTemplate]
     "Search for VersionedTemplate whose name or owning Org's name contains the search term"
     publishedTemplates(term: String, paginationOptions: PaginationOptions): PublishedTemplateSearchResults
+    "Search for templates for lightweight info on what unique affiliations are in the data set, and whether any of them have best practice"
+    publishedTemplatesMetaData(term: String, paginationOptions: PaginationOptions): PublishedTemplateMetaDataResults
     "Get the VersionedTemplates that belong to the current user's affiliation (user must be an Admin)"
     myVersionedTemplates: [VersionedTemplateSearchResult]
   }
@@ -16,6 +18,13 @@ export const typeDefs = gql`
     DRAFT
     "Published - saved state for use when creating DMPs"
     PUBLISHED
+  }
+
+  type PublishedTemplateMetaDataResults {
+    "Whether the result set includes bestPractice templates"
+    hasBestPracticeTemplates: Boolean
+    "The available affiliations in the result set"
+    availableAffiliations: [String]
   }
 
   type PublishedTemplateSearchResults implements PaginatedQueryResults {
@@ -35,10 +44,6 @@ export const typeDefs = gql`
     hasPreviousPage: Boolean
     "The sortFields that are available for this query (for standard offset pagination only!)"
     availableSortFields: [String]
-    "Whether the result set includes bestPractice templates"
-    hasBestPracticeTemplates: Boolean
-    "The available affiliations in the result set"
-    availableAffiliations: [String]
   }
 
   "An abbreviated view of a Template for pages that allow search/filtering of published Templates"

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -35,6 +35,10 @@ export const typeDefs = gql`
     hasPreviousPage: Boolean
     "The sortFields that are available for this query (for standard offset pagination only!)"
     availableSortFields: [String]
+    "Whether the result set includes bestPractice templates"
+    hasBestPracticeTemplates: Boolean
+    "The available affiliations in the result set"
+    availableAffiliations: [String]
   }
 
   "An abbreviated view of a Template for pages that allow search/filtering of published Templates"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1473,12 +1473,18 @@ export type PaginatedQueryResults = {
 
 /** Pagination options, either cursor-based (inifite-scroll) or offset-based pagination (standard first, next, etc.) */
 export type PaginationOptions = {
+  /** Request just the bestPractice templates */
+  bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
   /** The cursor to start the pagination from (used for cursor infinite scroll/load more only!) */
   cursor?: InputMaybe<Scalars['String']['input']>;
+  /** Specify that you want additional metadata, like whether the result set includes bestPractice options */
+  includeMetadata?: InputMaybe<Scalars['Boolean']['input']>;
   /** The number of items to return */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** The number of items to skip before starting the pagination (used for standard offset pagination only!) */
   offset?: InputMaybe<Scalars['Int']['input']>;
+  /** Request templates whose ownerIds match the provided array of ownerURIs */
+  selectOwnerURIs?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The sort order (used for standard offset pagination only!) */
   sortDir?: InputMaybe<Scalars['String']['input']>;
   /** The sort field (used for standard offset pagination only!) */
@@ -2162,10 +2168,14 @@ export type ProjectSearchResults = PaginatedQueryResults & {
 
 export type PublishedTemplateSearchResults = PaginatedQueryResults & {
   __typename?: 'PublishedTemplateSearchResults';
+  /** The available affiliations in the result set */
+  availableAffiliations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The sortFields that are available for this query (for standard offset pagination only!) */
   availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The current offset of the results (for standard offset pagination) */
   currentOffset?: Maybe<Scalars['Int']['output']>;
+  /** Whether the result set includes bestPractice templates */
+  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a next page */
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
@@ -5111,8 +5121,10 @@ export type ProjectSearchResultsResolvers<ContextType = MyContext, ParentType ex
 };
 
 export type PublishedTemplateSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateSearchResults'] = ResolversParentTypes['PublishedTemplateSearchResults']> = {
+  availableAffiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   availableSortFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   currentOffset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hasBestPracticeTemplates?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hasNextPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hasPreviousPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   items?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1477,8 +1477,6 @@ export type PaginationOptions = {
   bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
   /** The cursor to start the pagination from (used for cursor infinite scroll/load more only!) */
   cursor?: InputMaybe<Scalars['String']['input']>;
-  /** Specify that you want additional metadata, like whether the result set includes bestPractice options */
-  includeMetadata?: InputMaybe<Scalars['Boolean']['input']>;
   /** The number of items to return */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** The number of items to skip before starting the pagination (used for standard offset pagination only!) */
@@ -2166,16 +2164,20 @@ export type ProjectSearchResults = PaginatedQueryResults & {
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
-export type PublishedTemplateSearchResults = PaginatedQueryResults & {
-  __typename?: 'PublishedTemplateSearchResults';
+export type PublishedTemplateMetaDataResults = {
+  __typename?: 'PublishedTemplateMetaDataResults';
   /** The available affiliations in the result set */
   availableAffiliations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** Whether the result set includes bestPractice templates */
+  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type PublishedTemplateSearchResults = PaginatedQueryResults & {
+  __typename?: 'PublishedTemplateSearchResults';
   /** The sortFields that are available for this query (for standard offset pagination only!) */
   availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The current offset of the results (for standard offset pagination) */
   currentOffset?: Maybe<Scalars['Int']['output']>;
-  /** Whether the result set includes bestPractice templates */
-  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a next page */
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
@@ -2283,6 +2285,8 @@ export type Query = {
   publishedSections?: Maybe<VersionedSectionSearchResults>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
   publishedTemplates?: Maybe<PublishedTemplateSearchResults>;
+  /** Search for templates for lightweight info on what unique affiliations are in the data set, and whether any of them have best practice */
+  publishedTemplatesMetaData?: Maybe<PublishedTemplateMetaDataResults>;
   /** Get the specific Question based on questionId */
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
@@ -2521,6 +2525,12 @@ export type QueryPublishedSectionsArgs = {
 
 
 export type QueryPublishedTemplatesArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
+  term?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPublishedTemplatesMetaDataArgs = {
   paginationOptions?: InputMaybe<PaginationOptions>;
   term?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3995,7 +4005,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
-  PaginatedQueryResults: ( AffiliationSearchResults ) | ( LicenseSearchResults ) | ( MetadataStandardSearchResults ) | ( ProjectSearchResults ) | ( PublishedTemplateSearchResults ) | ( RepositorySearchResults ) | ( ResearchDomainSearchResults ) | ( TemplateSearchResults ) | ( UserSearchResults ) | ( VersionedSectionSearchResults );
+  PaginatedQueryResults: (AffiliationSearchResults) | (LicenseSearchResults) | (MetadataStandardSearchResults) | (ProjectSearchResults) | (PublishedTemplateSearchResults) | (RepositorySearchResults) | (ResearchDomainSearchResults) | (TemplateSearchResults) | (UserSearchResults) | (VersionedSectionSearchResults);
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -4089,6 +4099,7 @@ export type ResolversTypes = {
   ProjectSearchResultFunding: ResolverTypeWrapper<ProjectSearchResultFunding>;
   ProjectSearchResultMember: ResolverTypeWrapper<ProjectSearchResultMember>;
   ProjectSearchResults: ResolverTypeWrapper<ProjectSearchResults>;
+  PublishedTemplateMetaDataResults: ResolverTypeWrapper<PublishedTemplateMetaDataResults>;
   PublishedTemplateSearchResults: ResolverTypeWrapper<PublishedTemplateSearchResults>;
   Query: ResolverTypeWrapper<{}>;
   Question: ResolverTypeWrapper<Question>;
@@ -4242,6 +4253,7 @@ export type ResolversParentTypes = {
   ProjectSearchResultFunding: ProjectSearchResultFunding;
   ProjectSearchResultMember: ProjectSearchResultMember;
   ProjectSearchResults: ProjectSearchResults;
+  PublishedTemplateMetaDataResults: PublishedTemplateMetaDataResults;
   PublishedTemplateSearchResults: PublishedTemplateSearchResults;
   Query: {};
   Question: Question;
@@ -5120,11 +5132,15 @@ export type ProjectSearchResultsResolvers<ContextType = MyContext, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type PublishedTemplateSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateSearchResults'] = ResolversParentTypes['PublishedTemplateSearchResults']> = {
+export type PublishedTemplateMetaDataResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateMetaDataResults'] = ResolversParentTypes['PublishedTemplateMetaDataResults']> = {
   availableAffiliations?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  hasBestPracticeTemplates?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PublishedTemplateSearchResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PublishedTemplateSearchResults'] = ResolversParentTypes['PublishedTemplateSearchResults']> = {
   availableSortFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   currentOffset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  hasBestPracticeTemplates?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hasNextPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   hasPreviousPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   items?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
@@ -5181,6 +5197,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   publishedSection?: Resolver<Maybe<ResolversTypes['VersionedSection']>, ParentType, ContextType, RequireFields<QueryPublishedSectionArgs, 'versionedSectionId'>>;
   publishedSections?: Resolver<Maybe<ResolversTypes['VersionedSectionSearchResults']>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
   publishedTemplates?: Resolver<Maybe<ResolversTypes['PublishedTemplateSearchResults']>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
+  publishedTemplatesMetaData?: Resolver<Maybe<ResolversTypes['PublishedTemplateMetaDataResults']>, ParentType, ContextType, Partial<QueryPublishedTemplatesMetaDataArgs>>;
   question?: Resolver<Maybe<ResolversTypes['Question']>, ParentType, ContextType, RequireFields<QueryQuestionArgs, 'questionId'>>;
   questionConditions?: Resolver<Maybe<Array<Maybe<ResolversTypes['QuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryQuestionConditionsArgs, 'questionId'>>;
   questions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Question']>>>, ParentType, ContextType, RequireFields<QueryQuestionsArgs, 'sectionId'>>;
@@ -5865,6 +5882,7 @@ export type Resolvers<ContextType = MyContext> = {
   ProjectSearchResultFunding?: ProjectSearchResultFundingResolvers<ContextType>;
   ProjectSearchResultMember?: ProjectSearchResultMemberResolvers<ContextType>;
   ProjectSearchResults?: ProjectSearchResultsResolvers<ContextType>;
+  PublishedTemplateMetaDataResults?: PublishedTemplateMetaDataResultsResolvers<ContextType>;
   PublishedTemplateSearchResults?: PublishedTemplateSearchResultsResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Question?: QuestionResolvers<ContextType>;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,4 +1,9 @@
-export type PaginationOptions = PaginationOptionsForOffsets | PaginationOptionsForCursors;
+
+export interface TemplateFilterOptions {
+  bestPractice?: boolean;        // Only return records where bestPractice = 1 if present
+  selectOwnerURIs?: string[];    // Only return records with the specified ownerURIs
+  includeMetadata?: boolean;     // Request that metadata be included
+}
 
 export enum PaginationType {
   OFFSET = 'OFFSET', // Standard pagination using offsets (first, next, previous, last)
@@ -34,14 +39,20 @@ export interface PaginationOptionsForCursors {
   sortDir?: string;             // The order to sort by (must be 'ASC' or 'DESC')
 }
 
+export type PaginationOptions = PaginationOptionsForOffsets | PaginationOptionsForCursors;
+
 // The results of a query that supports pagination.
 export interface PaginatedQueryResults<T> {
   items: T[],
-  limit: number,                  // The number of items returned
-  nextCursor?: string,            // The cursor to use to retrieve the next page when using cursor based pagination
-  currentOffset?: number,         // The current offset of the results when using offset based pagination
-  totalCount: number | null,      // The total number of items in the result set (returned if requested)
-  hasNextPage: boolean,           // Whether or not there is a next page
-  hasPreviousPage?: boolean,      // Whether or not there is a previous page (offset based pagination only)
-  availableSortFields?: string[], // The available sort fields (offset based pagination only)
+  limit: number,                    // The number of items returned
+  nextCursor?: string,              // The cursor to use to retrieve the next page when using cursor based pagination
+  currentOffset?: number,           // The current offset of the results when using offset based pagination
+  totalCount: number | null,        // The total number of items in the result set (returned if requested)
+  hasNextPage: boolean,             // Whether or not there is a next page
+  hasPreviousPage?: boolean,        // Whether or not there is a previous page (offset based pagination only)
+  availableSortFields?: string[],   // The available sort fields (offset based pagination only)
+  availableAffiliations?: string[], // Return the list of available affiliations in the result set
+  hasBestPracticeTemplates?: boolean  // Indicate whether the result set includes bestPractice templates
 }
+
+export type TemplateQueryOptions = TemplateFilterOptions & PaginationOptions;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -43,13 +43,13 @@ export type PaginationOptions = PaginationOptionsForOffsets | PaginationOptionsF
 // The results of a query that supports pagination.
 export interface PaginatedQueryResults<T> {
   items: T[],
-  limit: number,                    // The number of items returned
-  nextCursor?: string,              // The cursor to use to retrieve the next page when using cursor based pagination
-  currentOffset?: number,           // The current offset of the results when using offset based pagination
-  totalCount: number | null,        // The total number of items in the result set (returned if requested)
-  hasNextPage: boolean,             // Whether or not there is a next page
-  hasPreviousPage?: boolean,        // Whether or not there is a previous page (offset based pagination only)
-  availableSortFields?: string[],   // The available sort fields (offset based pagination only)
+  limit: number,                  // The number of items returned
+  nextCursor?: string,            // The cursor to use to retrieve the next page when using cursor based pagination
+  currentOffset?: number,         // The current offset of the results when using offset based pagination
+  totalCount: number | null,      // The total number of items in the result set (returned if requested)
+  hasNextPage: boolean,           // Whether or not there is a next page
+  hasPreviousPage?: boolean,      // Whether or not there is a previous page (offset based pagination only)
+  availableSortFields?: string[], // The available sort fields (offset based pagination only)
 }
 
 export type TemplateQueryOptions = TemplateFilterOptions & PaginationOptions;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -2,7 +2,6 @@
 export interface TemplateFilterOptions {
   bestPractice?: boolean;        // Only return records where bestPractice = 1 if present
   selectOwnerURIs?: string[];    // Only return records with the specified ownerURIs
-  includeMetadata?: boolean;     // Request that metadata be included
 }
 
 export enum PaginationType {
@@ -51,8 +50,6 @@ export interface PaginatedQueryResults<T> {
   hasNextPage: boolean,             // Whether or not there is a next page
   hasPreviousPage?: boolean,        // Whether or not there is a previous page (offset based pagination only)
   availableSortFields?: string[],   // The available sort fields (offset based pagination only)
-  availableAffiliations?: string[], // Return the list of available affiliations in the result set
-  hasBestPracticeTemplates?: boolean  // Indicate whether the result set includes bestPractice templates
 }
 
 export type TemplateQueryOptions = TemplateFilterOptions & PaginationOptions;


### PR DESCRIPTION
## Description

While working on the frontend ticket to use pagination on the `Plan Create` page, https://github.com/CDLUC3/dmsp_frontend_prototype/issues/686, we needed a better way to toggle between requesting `best practice` or `funder` project templates.

- Now that the page is getting incrementally parsed data with the new pagination, we needed a way to get info about the full list of templates, like whether the list includes `best practice templates` or a list of the `affiliations` being returned. That way the frontend could use that data to display the appropriate `checkbox filters` and request the correct filtered data when the page was being rendered.
- Added new `publishedTemplatesMetaData` resolver to get  `availableAffiliations` list and `hasBestPracticeTemplates` boolean
- Added new filter, `TemplateFilterOptions`, to the `PaginatedOptions` so that the client can pass in a `bestPractice` option to request only the `bestPractice` templates, or `selectOwnerURIs` array to request only templates with those `affilation ids/ownerUris`.

Fixes # ([378](https://github.com/CDLUC3/dmsp_backend_prototype/issues/378))

## Type of change
Please delete options that are not relevant
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules