### PR TITLE
update backend so that it returns whether the question was answered or not for the publishedquestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## v0.2 - Initial deploy to the stage environment
 
 ### Added
+- Added `findFilledAnswersByQuestionIds` which takes versionedQuestionIds and returns the answers for those questions.
 - Added data migration to clean up old question JSON so it conforms with new @dmptool/types schemas
 - Added data migration to drop the old `questionTypes` table
 - Added `updatePlanFunding` to allow the update of multiple `planFunding` records [#305]

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -142,7 +142,7 @@ export class Answer extends MySqlModel {
   }
 
   // given a list of question ids, return all filled answers, flexible to handle different groupings of question ids
-  static async findFilledAnswersByQuestionIds(
+  static async findAnswersByQuestionIds(
     context: MyContext,
     questionIds: number[]
   ): Promise<Answer[]> {
@@ -150,7 +150,7 @@ export class Answer extends MySqlModel {
 
     const placeholders = questionIds.map(() => '?').join(', ');
     const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (${placeholders}) AND json IS NOT NULL AND json != ''`;
-    const results = await Answer.query(context, sql, questionIds.map(String), 'Answer.findFilledAnswersByQuestionIds');
+    const results = await Answer.query(context, sql, questionIds.map(String), 'Answer.findAnswersByQuestionIds');
     return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
   }
 };

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -148,7 +148,8 @@ export class Answer extends MySqlModel {
   ): Promise<Answer[]> {
     if (!Array.isArray(questionIds) || questionIds.length === 0) return [];
 
-    const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (?) AND json IS NOT NULL AND json != ''`;
+    const placeholders = questionIds.map(() => '?').join(', ');
+    const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (${placeholders}) AND json IS NOT NULL AND json != ''`;
     const results = await Answer.query(context, sql, questionIds.map(String), 'Answer.findFilledAnswersByQuestionIds');
     return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
   }

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -143,6 +143,7 @@ export class Answer extends MySqlModel {
 
   // given a list of question ids, return all filled answers, flexible to handle different groupings of question ids
   static async findAnswersByQuestionIds(
+    reference: string,
     context: MyContext,
     questionIds: number[]
   ): Promise<Answer[]> {
@@ -150,7 +151,7 @@ export class Answer extends MySqlModel {
 
     const placeholders = questionIds.map(() => '?').join(', ');
     const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (${placeholders}) AND json IS NOT NULL AND json != ''`;
-    const results = await Answer.query(context, sql, questionIds.map(String), 'Answer.findAnswersByQuestionIds');
+    const results = await Answer.query(context, sql, questionIds.map(String), reference);
     return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
   }
 };

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -142,16 +142,17 @@ export class Answer extends MySqlModel {
   }
 
   // given a list of question ids, return all filled answers, flexible to handle different groupings of question ids
-  static async findAnswersByQuestionIds(
+  static async findFilledAnswersByQuestionIds(
     reference: string,
     context: MyContext,
+    planId: number,
     questionIds: number[]
   ): Promise<Answer[]> {
     if (!Array.isArray(questionIds) || questionIds.length === 0) return [];
 
     const placeholders = questionIds.map(() => '?').join(', ');
-    const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (${placeholders}) AND json IS NOT NULL AND json != ''`;
-    const results = await Answer.query(context, sql, questionIds.map(String), reference);
+    const sql = `SELECT * FROM answers WHERE planId = ? AND versionedQuestionId IN (${placeholders}) AND json IS NOT NULL AND json != ''`;
+    const results = await Answer.query(context, sql, [String(planId), ...questionIds.map(String)], reference);
     return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
   }
 };

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -103,14 +103,14 @@ export class Answer extends MySqlModel {
     return null;
   }
 
-  // Fetch a Answer by it's id
+  // Fetch a Answer by its id
   static async findById(reference: string, context: MyContext, licenseId: number): Promise<Answer> {
     const sql = `SELECT * FROM ${Answer.tableName} WHERE id = ?`;
     const results = await Answer.query(context, sql, [licenseId?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new Answer(results[0]) : null;
   }
 
-  // Fetch a Answer by it's planId and versionedQuestionId
+  // Fetch an Answer by its planId and versionedQuestionId
   static async findByPlanIdAndVersionedQuestionId(
     reference: string,
     context: MyContext,
@@ -138,6 +138,18 @@ export class Answer extends MySqlModel {
   static async findByPlanId(reference: string, context: MyContext, planId: number): Promise<Answer[]> {
     const sql = `SELECT * FROM answers WHERE planId = ?`;
     const results = await Answer.query(context, sql, [planId.toString()], reference);
+    return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
+  }
+
+  // given a list of question ids, return all filled answers, flexible to handle different groupings of question ids
+  static async findFilledAnswersByQuestionIds(
+    context: MyContext,
+    questionIds: number[]
+  ): Promise<Answer[]> {
+    if (!Array.isArray(questionIds) || questionIds.length === 0) return [];
+
+    const sql = `SELECT * FROM answers WHERE versionedQuestionId IN (?) AND json IS NOT NULL AND json != ''`;
+    const results = await Answer.query(context, sql, questionIds.map(String), 'Answer.findFilledAnswersByQuestionIds');
     return Array.isArray(results) && results.length > 0 ? results.map((ans) => new Answer(ans)) : [];
   }
 };

--- a/src/models/__tests__/Answer.spec.ts
+++ b/src/models/__tests__/Answer.spec.ts
@@ -139,6 +139,19 @@ describe('findBy Queries', () => {
     expect(result).toEqual([answer]);
   });
 
+  it('findAnswersByQuestionIds should call query with correct params and return the objects', async () => {
+    // Mock the localQuery to return an array of answers, these are the same answer repeated, but the mock simply
+    // returns what is written here if it's called. So mocking additional different answers doesn't add additional value to the test.
+    localQuery.mockResolvedValueOnce([answer, answer, answer]);
+    const questionIds = [ casual.integer(1, 9999), casual.integer(1, 9999), casual.integer(1, 9999)];
+    const result = await Answer.findAnswersByQuestionIds('testing', context, questionIds);
+    const expectedSql = 'SELECT * FROM answers WHERE versionedQuestionId IN (?, ?, ?) AND json IS NOT NULL AND json != \'\'';
+    const vals = questionIds.map(String)
+    expect(localQuery).toHaveBeenCalledTimes(1);
+    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, vals, 'testing')
+    expect(result).toEqual([answer, answer, answer]);
+  });
+
   it('findByPlanIdAndVersionedSectionId should return an empty array if it finds no records', async () => {
     localQuery.mockResolvedValueOnce([]);
     const planId = casual.integer(1, 9999);

--- a/src/models/__tests__/Answer.spec.ts
+++ b/src/models/__tests__/Answer.spec.ts
@@ -139,16 +139,17 @@ describe('findBy Queries', () => {
     expect(result).toEqual([answer]);
   });
 
-  it('findAnswersByQuestionIds should call query with correct params and return the objects', async () => {
+  it('findFilledAnswersByQuestionIds should call query with correct params and return the objects', async () => {
+    const planId = casual.integer(1, 9999);
     // Mock the localQuery to return an array of answers, these are the same answer repeated, but the mock simply
     // returns what is written here if it's called. So mocking additional different answers doesn't add additional value to the test.
     localQuery.mockResolvedValueOnce([answer, answer, answer]);
     const questionIds = [ casual.integer(1, 9999), casual.integer(1, 9999), casual.integer(1, 9999)];
-    const result = await Answer.findAnswersByQuestionIds('testing', context, questionIds);
-    const expectedSql = 'SELECT * FROM answers WHERE versionedQuestionId IN (?, ?, ?) AND json IS NOT NULL AND json != \'\'';
+    const result = await Answer.findFilledAnswersByQuestionIds('testing', context, planId, questionIds);
+    const expectedSql = 'SELECT * FROM answers WHERE planId = ? AND versionedQuestionId IN (?, ?, ?) AND json IS NOT NULL AND json != \'\'';
     const vals = questionIds.map(String)
     expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, vals, 'testing')
+    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [String(planId), ...vals], 'testing')
     expect(result).toEqual([answer, answer, answer]);
   });
 

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -23,7 +23,7 @@ export const resolvers: Resolvers = {
 
           // Fetch answers for the questions
           const questionIds = questions.map(q => q.id);
-          const answers = await Answer.findFilledAnswersByQuestionIds(context, questionIds);
+          const answers = await Answer.findAnswersByQuestionIds(context, questionIds);
 
           // Map the answers to the questions
           const answersMap = new Set(answers.map(a => a.versionedQuestionId));

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -1,6 +1,7 @@
 import { Resolvers } from "../types";
 import { MyContext } from "../context";
 import { VersionedQuestion } from "../models/VersionedQuestion";
+import { Answer } from "../models/Answer";
 import { AuthenticationError, ForbiddenError, InternalServerError } from "../utils/graphQLErrors";
 import { VersionedQuestionCondition } from "../models/VersionedQuestionCondition";
 import { prepareObjectForLogs } from "../logger";
@@ -8,14 +9,51 @@ import { isAuthorized } from "../services/authService";
 import { GraphQLError } from "graphql";
 import { normaliseDateTime } from "../utils/helpers";
 
+type VersionedQuestionWithFilled = VersionedQuestion & { hasAnswer: boolean };
+// Define the interface for VersionedQuestionWithFilled
+/*
+interface VersionedQuestionWithFilled {
+  id: number;
+  createdById: number;
+  created: string;
+  modifiedById: number;
+  modified: string;
+  errors: Record<string, string>;
+  versionedTemplateId: number;
+  versionedSectionId: number;
+  questionId: number;
+  displayOrder?: number;
+  json: string;
+  questionText: string;
+  requirementText?: string;
+  guidanceText?: string;
+  sampleText?: string;
+  useSampleTextAsDefault?: boolean;
+  required?: boolean;
+  versionedQuestionConditions?: VersionedQuestionCondition[];
+  hasAnswer: boolean;
+}
+*/
+
 export const resolvers: Resolvers = {
   Query: {
     // return all of the published questions for the specified versioned section
-    publishedQuestions: async (_, { versionedSectionId }, context: MyContext): Promise<VersionedQuestion[]> => {
+    publishedQuestions: async (_, { versionedSectionId }, context: MyContext): Promise<VersionedQuestionWithFilled[]> => {
       const reference = 'publishedQuestions resolver';
       try {
         if (isAuthorized(context.token)) {
-          return await VersionedQuestion.findByVersionedSectionId(reference, context, versionedSectionId);
+          const questions = await VersionedQuestion.findByVersionedSectionId(reference, context, versionedSectionId);
+
+          // Fetch answers for the questions
+          const questionIds = questions.map(q => q.id);
+          const answers = await Answer.findFilledAnswersByQuestionIds(context, questionIds);
+
+          // Map the answers to the questions
+          const answersMap = new Set(answers.map(a => a.versionedQuestionId));
+          return questions.map(question => ({
+            ...question,
+            hasAnswer: answersMap.has(question.id),
+          })) as VersionedQuestionWithFilled[];
         }
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -45,7 +83,7 @@ export const resolvers: Resolvers = {
   },
 
   VersionedQuestion: {
-    // Chained resolver to return the VersionedQuestionConditionss associated with this VersionedQuestion
+    // Chained resolver to return the VersionedQuestionConditions associated with this VersionedQuestion
     versionedQuestionConditions: async (parent: VersionedQuestion, _, context: MyContext): Promise<VersionedQuestionCondition[]> => {
       return await VersionedQuestionCondition.findByVersionedQuestionId(
         'Chained VersionedQuestion.versionedQuestionConditions',

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -23,7 +23,7 @@ export const resolvers: Resolvers = {
 
           // Fetch answers for the questions
           const questionIds = questions.map(q => q.id);
-          const answers = await Answer.findAnswersByQuestionIds(context, questionIds);
+          const answers = await Answer.findAnswersByQuestionIds(reference, context, questionIds);
 
           // Map the answers to the questions
           const answersMap = new Set(answers.map(a => a.versionedQuestionId));

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -9,35 +9,12 @@ import { isAuthorized } from "../services/authService";
 import { GraphQLError } from "graphql";
 import { normaliseDateTime } from "../utils/helpers";
 
+// Define new output structure for the published questions including whether they have an answer
 type VersionedQuestionWithFilled = VersionedQuestion & { hasAnswer: boolean };
-// Define the interface for VersionedQuestionWithFilled
-/*
-interface VersionedQuestionWithFilled {
-  id: number;
-  createdById: number;
-  created: string;
-  modifiedById: number;
-  modified: string;
-  errors: Record<string, string>;
-  versionedTemplateId: number;
-  versionedSectionId: number;
-  questionId: number;
-  displayOrder?: number;
-  json: string;
-  questionText: string;
-  requirementText?: string;
-  guidanceText?: string;
-  sampleText?: string;
-  useSampleTextAsDefault?: boolean;
-  required?: boolean;
-  versionedQuestionConditions?: VersionedQuestionCondition[];
-  hasAnswer: boolean;
-}
-*/
 
 export const resolvers: Resolvers = {
   Query: {
-    // return all of the published questions for the specified versioned section
+    // return all published questions for the specified versioned section
     publishedQuestions: async (_, { versionedSectionId }, context: MyContext): Promise<VersionedQuestionWithFilled[]> => {
       const reference = 'publishedQuestions resolver';
       try {

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 import {VersionedQuestion} from "../models/VersionedQuestion";
 
-// because ESLint doesn't like it, but removing it makes GraphQL complain about the type not being defined
+// because ESLint doesn't like it, but removing it makes GraphQL build complain about the type not being defined
 void VersionedQuestion;
 
 export const typeDefs = gql`

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import {VersionedQuestion} from "../models/VersionedQuestion";
 
 export const typeDefs = gql`
   extend type Query {
@@ -48,6 +49,51 @@ type VersionedQuestion {
 
     "The conditional logic associated with this VersionedQuestion"
     versionedQuestionConditions: [VersionedQuestionCondition!]
+}
+
+"A snapshot of a Question when it became published."
+interface VersionedQuestionWithFilled {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: VersionedQuestionErrors
+
+    "The unique id of the VersionedTemplate that the VersionedQuestion belongs to"
+    versionedTemplateId: Int!
+    "The unique id of the VersionedSection that the VersionedQuestion belongs to"
+    versionedSectionId: Int!
+    "Id of the original question that was versioned"
+    questionId: Int!
+    "The display order of the VersionedQuestion"
+    displayOrder: Int
+    "The JSON representation of the question type"
+    json: String
+    "This will be used as a sort of title for the Question"
+    questionText: String
+    "Requirements associated with the Question"
+    requirementText: String
+    "Guidance to complete the question"
+    guidanceText: String
+    "Sample text to possibly provide a starting point or example to answer question"
+    sampleText: String
+    "Whether or not the sample text should be used as the default answer for this question"
+    useSampleTextAsDefault: Boolean
+    "To indicate whether the question is required to be completed"
+    required: Boolean
+
+    "The conditional logic associated with this VersionedQuestion"
+    versionedQuestionConditions: [VersionedQuestionCondition!]
+
+    "Indicates whether the question has an answer"
+    hasAnswer: Boolean
 }
 
 "A collection of errors related to the VersionedQuestion"

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -4,7 +4,7 @@ import {VersionedQuestion} from "../models/VersionedQuestion";
 export const typeDefs = gql`
   extend type Query {
     "Search for VersionedQuestions that belong to Section specified by sectionId"
-    publishedQuestions(versionedSectionId: Int!): [VersionedQuestion]
+    publishedQuestions(versionedSectionId: Int!): [VersionedQuestionWithFilled]
     "Get a specific VersionedQuestion based on versionedQuestionId"
     publishedQuestion(versionedQuestionId: Int!): VersionedQuestion
   }
@@ -52,7 +52,7 @@ type VersionedQuestion {
 }
 
 "A snapshot of a Question when it became published."
-interface VersionedQuestionWithFilled {
+type VersionedQuestionWithFilled {
     "The unique identifer for the Object"
     id: Int
     "The user who created the Object"

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -1,10 +1,15 @@
 import gql from 'graphql-tag';
 import {VersionedQuestion} from "../models/VersionedQuestion";
 
+// because ESLint doesn't like it, but removing it makes GraphQL complain about the type not being defined
+void VersionedQuestion;
+
 export const typeDefs = gql`
   extend type Query {
     "Search for VersionedQuestions that belong to Section specified by sectionId"
-    publishedQuestions(versionedSectionId: Int!): [VersionedQuestionWithFilled]
+    publishedQuestions(versionedSectionId: Int!): [VersionedQuestion]
+    "Search for VersionedQuestions that belong to Section specified by sectionId, with an answered flag for a plan"
+    publishedQuestionsWithAnsweredFlag(planId: Int!, versionedSectionId: Int!): [VersionedQuestionWithFilled]
     "Get a specific VersionedQuestion based on versionedQuestionId"
     publishedQuestion(versionedQuestionId: Int!): VersionedQuestion
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2266,7 +2266,7 @@ export type Query = {
   /** Get a specific VersionedQuestion based on versionedQuestionId */
   publishedQuestion?: Maybe<VersionedQuestion>;
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
-  publishedQuestions?: Maybe<Array<Maybe<VersionedQuestion>>>;
+  publishedQuestions?: Maybe<Array<Maybe<VersionedQuestionWithFilled>>>;
   /** Fetch a specific VersionedSection */
   publishedSection?: Maybe<VersionedSection>;
   /** Search for VersionedSection whose name contains the search term */
@@ -3731,6 +3731,7 @@ export type VersionedQuestionErrors = {
 
 /** A snapshot of a Question when it became published. */
 export type VersionedQuestionWithFilled = {
+  __typename?: 'VersionedQuestionWithFilled';
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
@@ -4028,7 +4029,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   PaginatedQueryResults: ( AffiliationSearchResults ) | ( LicenseSearchResults ) | ( MetadataStandardSearchResults ) | ( ProjectSearchResults ) | ( PublishedTemplateSearchResults ) | ( RepositorySearchResults ) | ( ResearchDomainSearchResults ) | ( TemplateSearchResults ) | ( UserSearchResults ) | ( VersionedSectionSearchResults );
-  VersionedQuestionWithFilled: never;
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -4185,7 +4185,7 @@ export type ResolversTypes = {
   VersionedQuestionConditionCondition: VersionedQuestionConditionCondition;
   VersionedQuestionConditionErrors: ResolverTypeWrapper<VersionedQuestionConditionErrors>;
   VersionedQuestionErrors: ResolverTypeWrapper<VersionedQuestionErrors>;
-  VersionedQuestionWithFilled: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['VersionedQuestionWithFilled']>;
+  VersionedQuestionWithFilled: ResolverTypeWrapper<VersionedQuestionWithFilled>;
   VersionedSection: ResolverTypeWrapper<VersionedSection>;
   VersionedSectionErrors: ResolverTypeWrapper<VersionedSectionErrors>;
   VersionedSectionSearchResult: ResolverTypeWrapper<VersionedSectionSearchResult>;
@@ -4328,7 +4328,7 @@ export type ResolversParentTypes = {
   VersionedQuestionCondition: VersionedQuestionCondition;
   VersionedQuestionConditionErrors: VersionedQuestionConditionErrors;
   VersionedQuestionErrors: VersionedQuestionErrors;
-  VersionedQuestionWithFilled: ResolversInterfaceTypes<ResolversParentTypes>['VersionedQuestionWithFilled'];
+  VersionedQuestionWithFilled: VersionedQuestionWithFilled;
   VersionedSection: VersionedSection;
   VersionedSectionErrors: VersionedSectionErrors;
   VersionedSectionSearchResult: VersionedSectionSearchResult;
@@ -5210,7 +5210,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectOutputs?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectOutput']>>>, ParentType, ContextType, RequireFields<QueryProjectOutputsArgs, 'projectId'>>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
   publishedQuestion?: Resolver<Maybe<ResolversTypes['VersionedQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedQuestionArgs, 'versionedQuestionId'>>;
-  publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
+  publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionWithFilled']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
   publishedSection?: Resolver<Maybe<ResolversTypes['VersionedSection']>, ParentType, ContextType, RequireFields<QueryPublishedSectionArgs, 'versionedSectionId'>>;
   publishedSections?: Resolver<Maybe<ResolversTypes['VersionedSectionSearchResults']>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
   publishedTemplates?: Resolver<Maybe<ResolversTypes['PublishedTemplateSearchResults']>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;
@@ -5721,7 +5721,6 @@ export type VersionedQuestionErrorsResolvers<ContextType = MyContext, ParentType
 };
 
 export type VersionedQuestionWithFilledResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedQuestionWithFilled'] = ResolversParentTypes['VersionedQuestionWithFilled']> = {
-  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   displayOrder?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -5741,6 +5740,7 @@ export type VersionedQuestionWithFilledResolvers<ContextType = MyContext, Parent
   versionedQuestionConditions?: Resolver<Maybe<Array<ResolversTypes['VersionedQuestionCondition']>>, ParentType, ContextType>;
   versionedSectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   versionedTemplateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type VersionedSectionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedSection'] = ResolversParentTypes['VersionedSection']> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2266,7 +2266,9 @@ export type Query = {
   /** Get a specific VersionedQuestion based on versionedQuestionId */
   publishedQuestion?: Maybe<VersionedQuestion>;
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
-  publishedQuestions?: Maybe<Array<Maybe<VersionedQuestionWithFilled>>>;
+  publishedQuestions?: Maybe<Array<Maybe<VersionedQuestion>>>;
+  /** Search for VersionedQuestions that belong to Section specified by sectionId, with an answered flag for a plan */
+  publishedQuestionsWithAnsweredFlag?: Maybe<Array<Maybe<VersionedQuestionWithFilled>>>;
   /** Fetch a specific VersionedSection */
   publishedSection?: Maybe<VersionedSection>;
   /** Search for VersionedSection whose name contains the search term */
@@ -2495,6 +2497,12 @@ export type QueryPublishedQuestionArgs = {
 
 
 export type QueryPublishedQuestionsArgs = {
+  versionedSectionId: Scalars['Int']['input'];
+};
+
+
+export type QueryPublishedQuestionsWithAnsweredFlagArgs = {
+  planId: Scalars['Int']['input'];
   versionedSectionId: Scalars['Int']['input'];
 };
 
@@ -5210,7 +5218,8 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectOutputs?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectOutput']>>>, ParentType, ContextType, RequireFields<QueryProjectOutputsArgs, 'projectId'>>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
   publishedQuestion?: Resolver<Maybe<ResolversTypes['VersionedQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedQuestionArgs, 'versionedQuestionId'>>;
-  publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionWithFilled']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
+  publishedQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsArgs, 'versionedSectionId'>>;
+  publishedQuestionsWithAnsweredFlag?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionWithFilled']>>>, ParentType, ContextType, RequireFields<QueryPublishedQuestionsWithAnsweredFlagArgs, 'planId' | 'versionedSectionId'>>;
   publishedSection?: Resolver<Maybe<ResolversTypes['VersionedSection']>, ParentType, ContextType, RequireFields<QueryPublishedSectionArgs, 'versionedSectionId'>>;
   publishedSections?: Resolver<Maybe<ResolversTypes['VersionedSectionSearchResults']>, ParentType, ContextType, RequireFields<QueryPublishedSectionsArgs, 'term'>>;
   publishedTemplates?: Resolver<Maybe<ResolversTypes['PublishedTemplateSearchResults']>, ParentType, ContextType, Partial<QueryPublishedTemplatesArgs>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3729,6 +3729,48 @@ export type VersionedQuestionErrors = {
   versionedTemplateId?: Maybe<Scalars['String']['output']>;
 };
 
+/** A snapshot of a Question when it became published. */
+export type VersionedQuestionWithFilled = {
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** The display order of the VersionedQuestion */
+  displayOrder?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<VersionedQuestionErrors>;
+  /** Guidance to complete the question */
+  guidanceText?: Maybe<Scalars['String']['output']>;
+  /** Indicates whether the question has an answer */
+  hasAnswer?: Maybe<Scalars['Boolean']['output']>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The JSON representation of the question type */
+  json?: Maybe<Scalars['String']['output']>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** Id of the original question that was versioned */
+  questionId: Scalars['Int']['output'];
+  /** This will be used as a sort of title for the Question */
+  questionText?: Maybe<Scalars['String']['output']>;
+  /** To indicate whether the question is required to be completed */
+  required?: Maybe<Scalars['Boolean']['output']>;
+  /** Requirements associated with the Question */
+  requirementText?: Maybe<Scalars['String']['output']>;
+  /** Sample text to possibly provide a starting point or example to answer question */
+  sampleText?: Maybe<Scalars['String']['output']>;
+  /** Whether or not the sample text should be used as the default answer for this question */
+  useSampleTextAsDefault?: Maybe<Scalars['Boolean']['output']>;
+  /** The conditional logic associated with this VersionedQuestion */
+  versionedQuestionConditions?: Maybe<Array<VersionedQuestionCondition>>;
+  /** The unique id of the VersionedSection that the VersionedQuestion belongs to */
+  versionedSectionId: Scalars['Int']['output'];
+  /** The unique id of the VersionedTemplate that the VersionedQuestion belongs to */
+  versionedTemplateId: Scalars['Int']['output'];
+};
+
 /** A snapshot of a Section when it became published. */
 export type VersionedSection = {
   __typename?: 'VersionedSection';
@@ -3986,6 +4028,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   PaginatedQueryResults: ( AffiliationSearchResults ) | ( LicenseSearchResults ) | ( MetadataStandardSearchResults ) | ( ProjectSearchResults ) | ( PublishedTemplateSearchResults ) | ( RepositorySearchResults ) | ( ResearchDomainSearchResults ) | ( TemplateSearchResults ) | ( UserSearchResults ) | ( VersionedSectionSearchResults );
+  VersionedQuestionWithFilled: never;
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -4142,6 +4185,7 @@ export type ResolversTypes = {
   VersionedQuestionConditionCondition: VersionedQuestionConditionCondition;
   VersionedQuestionConditionErrors: ResolverTypeWrapper<VersionedQuestionConditionErrors>;
   VersionedQuestionErrors: ResolverTypeWrapper<VersionedQuestionErrors>;
+  VersionedQuestionWithFilled: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['VersionedQuestionWithFilled']>;
   VersionedSection: ResolverTypeWrapper<VersionedSection>;
   VersionedSectionErrors: ResolverTypeWrapper<VersionedSectionErrors>;
   VersionedSectionSearchResult: ResolverTypeWrapper<VersionedSectionSearchResult>;
@@ -4284,6 +4328,7 @@ export type ResolversParentTypes = {
   VersionedQuestionCondition: VersionedQuestionCondition;
   VersionedQuestionConditionErrors: VersionedQuestionConditionErrors;
   VersionedQuestionErrors: VersionedQuestionErrors;
+  VersionedQuestionWithFilled: ResolversInterfaceTypes<ResolversParentTypes>['VersionedQuestionWithFilled'];
   VersionedSection: VersionedSection;
   VersionedSectionErrors: VersionedSectionErrors;
   VersionedSectionSearchResult: VersionedSectionSearchResult;
@@ -5675,6 +5720,29 @@ export type VersionedQuestionErrorsResolvers<ContextType = MyContext, ParentType
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type VersionedQuestionWithFilledResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedQuestionWithFilled'] = ResolversParentTypes['VersionedQuestionWithFilled']> = {
+  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  displayOrder?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<ResolversTypes['VersionedQuestionErrors']>, ParentType, ContextType>;
+  guidanceText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hasAnswer?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  json?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  questionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  questionText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  requirementText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sampleText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  useSampleTextAsDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  versionedQuestionConditions?: Resolver<Maybe<Array<ResolversTypes['VersionedQuestionCondition']>>, ParentType, ContextType>;
+  versionedSectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  versionedTemplateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+};
+
 export type VersionedSectionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedSection'] = ResolversParentTypes['VersionedSection']> = {
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -5891,6 +5959,7 @@ export type Resolvers<ContextType = MyContext> = {
   VersionedQuestionCondition?: VersionedQuestionConditionResolvers<ContextType>;
   VersionedQuestionConditionErrors?: VersionedQuestionConditionErrorsResolvers<ContextType>;
   VersionedQuestionErrors?: VersionedQuestionErrorsResolvers<ContextType>;
+  VersionedQuestionWithFilled?: VersionedQuestionWithFilledResolvers<ContextType>;
   VersionedSection?: VersionedSectionResolvers<ContextType>;
   VersionedSectionErrors?: VersionedSectionErrorsResolvers<ContextType>;
   VersionedSectionSearchResult?: VersionedSectionSearchResultResolvers<ContextType>;


### PR DESCRIPTION
## Description

https://github.com/CDLUC3/dmsp_backend_prototype/issues/366

- Adds a boolean of `hasAnswer` to the resolver data so that it indicates whether the question is answered.
- Adds a finder to the Answer to find the filled answers for a list of versionQuestions.
- Logic is currently simple (there is a record, not null, not blank) for the question since we do not yet know how specific we need to get or if we need to check different JSON values for a whole different list of question types.  I suspect it may not be super useful or easy to know answered for all types, anyway.  Like if there are lists of checkboxes and they have not checked any, they may have done so deliberately since it's often a valid state to not check any checkboxes (not radio buttons).
- Non-breaking: added new `publishedQuestionsWithAnsweredFlag` but kept existing `publishedQuestions`.

I added tests for the changes to `answers` but not clear how to test this resolver right now since tests don't really exist for resolvers right now.  I think this was something Brian was working through.

Fixes # (366)

## Type of change
Please delete options that are not relevant

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added test for findAnswersByQuestionIds finder in Answer.
- Verified that the resolver returns appropriate data from GraphQL and marks items correctly with `hasAnswer` boolean.
<img width="1616" height="1121" alt="Screenshot 2025-08-08 at 4 29 26 PM" src="https://github.com/user-attachments/assets/272d0e59-7bc4-4334-8b28-0792b53e90fe" />
- Testing for the resolvers is unclear right now and the test file for this resolver doesn't currently exist.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
