### PR TITLE
Added information about which plans a user has access to in the JWT 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added
+- Added `findDMPIdsForEmail` helper method to `TokenService` so that the JWT will now contain a list of DMP ids and the user's access level
+- Added `hasPermissionOnPlan` to the `planService` that checks the info contained within the token to determine access instead of making DB calls
 - Added `ProjectFilterOptions` as a possible input for the `myProjects` resolver
 - Added `PlanFeedback` and `PlanFeedbackComments` models [#243]
 - Added `projectCollaboratorCommentsAdded` to `emailService` so that we can email `project collaborators` when new comments added [#243]
@@ -10,6 +12,8 @@
 - added `publishedQuestion` resolver to `src/resolvers/versionedQuestion.ts`
 
 ### Updated
+- Updated `answer`, `fundings`, `members` and `plans` resolver to use new `hasPermissionOnPlan` function
+- Update the `tokenService` to add `dmpIds` array that stores the DMPs the user has access to
 - Updated the `ProjectSearchResult.search` query to provide plan counts by status and filter by status options
 - updated all existing data migrations and scripts to use `utf8mb4` instead of `utf8mb3`
 - updated `PlanSectionProgress` to use better terminology. Changed `sectionId` to `versionedSectionId` (what it really was) and `sectionTtitle` to `title`

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -13,6 +13,7 @@ import { Plan } from '../models/Plan';
 import { addVersion } from '../models/PlanVersion';
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
+import { hasPermissionOnPlan } from "../services/planService";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -69,8 +70,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError();
           }
 
-          const project = await Project.findById(reference, context, plan.projectId);
-          if (plan && await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
+          if (plan && await hasPermissionOnPlan(context, plan, ProjectCollaboratorAccessLevel.COMMENT)) {
             return await PlanFunding.findByPlanId(reference, context, plan.id);
           }
         }
@@ -209,8 +209,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError();
           }
 
-          const project = await Project.findById(reference, context, plan.projectId);
-          if (await hasPermissionOnProject(context, project)) {
+          if (await hasPermissionOnPlan(context, plan)) {
             const newFunding = new PlanFunding({ planId, projectFundingId });
 
             if (newFunding && !newFunding.hasErrors()) {
@@ -245,8 +244,7 @@ export const resolvers: Resolvers = {
           throw NotFoundError();
         }
 
-        const project = await Project.findById(reference, context, plan.projectId);
-        if (await hasPermissionOnProject(context, project)) {
+        if (await hasPermissionOnPlan(context, plan)) {
 
           const associationErrors = [];
           // Fetch all of the current Funders associated with this Plan
@@ -318,8 +316,7 @@ export const resolvers: Resolvers = {
           }
 
           const plan = await Plan.findById(reference, context, funding.planId);
-          const project = await Project.findById(reference, context, plan.projectId);
-          if (await hasPermissionOnProject(context, project)) {
+          if (await hasPermissionOnPlan(context, plan)) {
             const deletedFunding = await funding.delete(context);
 
             if (deletedFunding && !deletedFunding.hasErrors()) {

--- a/src/services/planService.ts
+++ b/src/services/planService.ts
@@ -4,6 +4,68 @@ import {isNullOrUndefined} from "../utils/helpers";
 import {PlanMember, ProjectMember} from "../models/Member";
 import {Plan} from "../models/Plan";
 import {Project} from "../models/Project";
+import {
+  ProjectCollaboratorAccessLevel
+} from "../models/Collaborator";
+import {isAdmin, isSuperAdmin} from "./authService";
+import {User} from "../models/User";
+import {prepareObjectForLogs} from "../logger";
+
+export const hasPermissionOnPlan = async (
+  context: MyContext,
+  plan: Plan,
+  requiredAccessLevel = ProjectCollaboratorAccessLevel.EDIT,
+): Promise<boolean> => {
+  const reference = 'planService.hasPermissionOnPlan';
+  if (!context || !context.token) return false;
+
+  // Super admins always have permission
+  if (await isSuperAdmin(context.token)) {
+    return true;
+  }
+
+  if (plan && plan.id) {
+    // See if the plan is listed in the token
+    const tokenDMP = context.token.dmpIds.find((entry) => {
+      return entry.dmpId === plan.dmpId
+    });
+
+    // If the user created the plan then they have access
+    if (plan.createdById === context.token.id) {
+      return true;
+    }
+
+    // If the current user is an Admin and the creator of the plan has the same affiliation
+    if (await isAdmin(context.token)) {
+      const planCreator = await User.findById(reference, context, plan.createdById);
+      if (planCreator && planCreator.affiliationId === context.token.affiliationId) {
+        return true;
+      }
+    }
+
+    // The DMP was not listed on their token then they do not have access
+    if (!tokenDMP) {
+      return false;
+    }
+
+    // Otherwise check to make sure the user has the desired access level
+    switch (requiredAccessLevel) {
+      case ProjectCollaboratorAccessLevel.COMMENT:
+        return true;
+      case ProjectCollaboratorAccessLevel.EDIT:
+        return tokenDMP.accessLevel === ProjectCollaboratorAccessLevel.OWN ||
+          tokenDMP.accessLevel === ProjectCollaboratorAccessLevel.EDIT;
+      case ProjectCollaboratorAccessLevel.OWN:
+        return tokenDMP.accessLevel === ProjectCollaboratorAccessLevel.OWN;
+      default:
+        return false;
+    }
+  }
+
+  const payload = { planId: plan?.id, userId: context.token?.id };
+  context.logger.error(prepareObjectForLogs(payload), `AUTH failure: ${reference}`);
+  return false;
+}
 
 export async function updateMemberRoles(
   reference: string,
@@ -93,3 +155,4 @@ export const ensureDefaultPlanContact = async (
   }
   return false
 }
+


### PR DESCRIPTION
## Description

Fixes #392 

After starting the work on the narrative generation service, I realized I need to make a check to see if the user had permission to access the DMP in the first place. This PR attempts to fix that issue by adding information to the JWT as:
```
"dmpIds": [
  { "dmpId": "https://doi.org/11.22222/A1B2C3", "accessLevel": "OWN" },
  { "dmpId": "https://doi.org/99.88888/Z9Y8X7", "accessLevel": "COMMENT" }
]
```
This also solves a performance issue where we were needing to make extra DB calls to fetch the project from the DB on any request that interacts with an `answer`, `planFunding`, planMembers`, or the `plan` itself.

- Added new function to the `tokenService` to fetch DMP Ids and the logged in user's access level for the DMP
- Updated the `tokenService` to add the `dmpIds` array to the JWT
- Added a new `hasPermissionOnPlan` function to the `planService`
- Updated the resolvers for `answer`, `planFunding`, planMembers`, and `plan` to use the new auth function
- Fixed tests that were broken by the change and added a new one for the `hasPermissionOnPlan` function

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

Unit tests are passing. Also did a manually walk through of the plan -> answer to make sure things still load and that update/create were working

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules