### PR TITLE
Fixing user creation for signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- Fixed an issue where signup failed because context had been reset to different object
 - Fixed an issue causing the DMP version to not include sections/questions in the narrative if they had not been answered
 - Fixed an issue with the null/undefined check on model queries that use 'searchTerm'
 - When generating a new `versionedTemplate`, we need to deactivate the old ones in the db [#363]

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -393,7 +393,6 @@ export class User extends MySqlModel {
                       (password, role, givenName, surName, affiliationId, acceptedTerms) \
                      VALUES(?, ?, ?, ?, ?, ?)`;
         const vals = [this.password, this.role, this.givenName, this.surName, this.affiliationId, this.acceptedTerms];
-        const context = buildContext(logger);
         context.logger.debug(prepareObjectForLogs({ email }), 'User.register');
         const result = await User.query(context, sql, vals, 'User.register');
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,7 +1,6 @@
 import bcrypt from 'bcryptjs';
 import {capitalizeFirstLetter, formatORCID, getCurrentDate, isNullOrUndefined, validateEmail} from '../utils/helpers';
-import { buildContext } from '../context';
-import { logger, prepareObjectForLogs } from '../logger';
+import { prepareObjectForLogs } from '../logger';
 import { MySqlModel } from './MySqlModel';
 import { MyContext } from '../context';
 import { generalConfig } from '../config/generalConfig';


### PR DESCRIPTION
## Description

See https://github.com/CDLUC3/dmsp_frontend_prototype/issues/708 .  User signup fails with unknown error.

Fixes https://github.com/CDLUC3/dmsp_frontend_prototype/issues/708

This was an odd problem since it seemed to be re-assigning context to a different value with a definition like `const context = ...`.  A weird part about it was that the git history showed this line was created in February and hadn't been changed since then. I'm not sure why it began failing now--maybe because it used to be reassigned after it was used the last time or 🤷   Or maybe it's been failing for a long while and no one noticed until now.

I'm also not sure what the purpose of the line was but removing it seems to fix the problem and I don't see any reason it needed to be there.

Changes to the user.ts file are to make it pass linting even though I didn't touch it in my changes.  Unused imports were present.

## Type of change
Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested signup with new user (with all required fields) and it succeeds in creating user and logging in.

Checked database and expected information is present.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] ~I have added tests that prove my fix is effective or that my feature works~ I believe there are outstanding tests for these controllers and similar that Brian began working on but seemed to fail and needed additional work to be reliable.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules