### PR TITLE
Should always ensure that Project and Plan have a member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added
+- Added checks in `ProjectMember` and `PlanMember` to prevent the deletion of a member if they are the last one [#358]
+- Added a fallback to set a `default` role if none was provided while adding a new `ProjectMember` [#358]
 - Added `findDMPIdsForEmail` helper method to `TokenService` so that the JWT will now contain a list of DMP ids and the user's access level
 - Added `hasPermissionOnPlan` to the `planService` that checks the info contained within the token to determine access instead of making DB calls
 - Added `ProjectFilterOptions` as a possible input for the `myProjects` resolver

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -9,7 +9,7 @@ import { MyContext } from '../context';
 import { isAuthorized } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
 import { hasPermissionOnProject } from '../services/projectService';
-import {hasPermissionOnPlan, updateMemberRoles} from '../services/planService';
+import { hasPermissionOnPlan, updateMemberRoles } from '../services/planService';
 import { GraphQLError } from 'graphql';
 import { Plan } from '../models/Plan';
 import { addVersion } from '../models/PlanVersion';
@@ -24,7 +24,7 @@ export const resolvers: Resolvers = {
       try {
         if (isAuthorized(context.token)) {
           const project = await Project.findById(reference, context, projectId);
-          if (isNullOrUndefined(project)){
+          if (isNullOrUndefined(project)) {
             throw NotFoundError();
           }
 
@@ -46,7 +46,7 @@ export const resolvers: Resolvers = {
       try {
         if (isAuthorized(context.token)) {
           const member = await ProjectMember.findById(reference, context, projectMemberId);
-          if (isNullOrUndefined(member)){
+          if (isNullOrUndefined(member)) {
             throw NotFoundError();
           }
 
@@ -70,7 +70,7 @@ export const resolvers: Resolvers = {
       try {
         if (isAuthorized(context.token)) {
           const plan = await Plan.findById(reference, context, planId);
-          if (isNullOrUndefined(plan)){
+          if (isNullOrUndefined(plan)) {
             throw NotFoundError();
           }
 
@@ -130,6 +130,10 @@ export const resolvers: Resolvers = {
                   created.addError('memberRoles', `Created but unable to assign roles: ${addErrors.join(', ')}`);
                 }
               }
+            } else {
+              // Since no roles were provided, we will default to one
+              const role = await MemberRole.defaultRole(context, reference);
+              await role.addToProjectMember(context, created.id);
             }
             return created;
           }
@@ -155,7 +159,7 @@ export const resolvers: Resolvers = {
 
           // Fetch the project and run a permission check
           const project = await Project.findById(reference, context, member.projectId);
-          if (isNullOrUndefined(project)){
+          if (isNullOrUndefined(project)) {
             throw NotFoundError();
           }
 
@@ -252,7 +256,7 @@ export const resolvers: Resolvers = {
 
           // Fetch the project and run a permission check
           const project = await Project.findById(reference, context, member.projectId);
-          if (isNullOrUndefined(project)){
+          if (isNullOrUndefined(project)) {
             throw NotFoundError();
           }
 
@@ -284,12 +288,12 @@ export const resolvers: Resolvers = {
       try {
         if (isAuthorized(context.token)) {
           const plan = await Plan.findById(reference, context, planId);
-          if (isNullOrUndefined(plan)){
+          if (isNullOrUndefined(plan)) {
             throw NotFoundError();
           }
 
           const projectMember = await ProjectMember.findById(reference, context, projectMemberId);
-          if (isNullOrUndefined(projectMember)){
+          if (isNullOrUndefined(projectMember)) {
             throw NotFoundError();
           }
 
@@ -440,7 +444,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError();
           }
 
-          // Fetch the project and run a permission check
+          // Fetch the plan and run a permission check
           const plan = await Plan.findById(reference, context, member.planId);
 
           if (await hasPermissionOnPlan(context, plan)) {


### PR DESCRIPTION
## Description

- Updated `ProjectMember.delete` to check whether there is more than one projectMember, otherwise, we return an error.
-- Also, checked that for all the plans associated with that `projectMemberId` in the `planMembers` table, none of them would be left with no member. If so, we stop the deletion of that member and return an error.
-- We delete the `planMembers` records only if there is more than one planMember left for the associated planIds.
- Updated 'PlanMember.delete` to only delete the planMember if there is more than one planMember left under the given `planId`. If not, then return an error.
- Updated unit tests
- Updated `addProjectMember` resolver to default the new member to a role if none was provided

Fixes # ([358](https://github.com/CDLUC3/dmsp_backend_prototype/issues/358))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested and with unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
*Note: There is a related frontend ticket to display a modal warning a user when they want to delete a ProjectMember: https://github.com/CDLUC3/dmsp_frontend_prototype/issues/737