### PR TITLE
Remove expiresIn from contents of JWT payloads

### DIFF
--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -33,13 +33,11 @@ export interface JWTAccessToken extends JwtPayload {
   languageId: string,
   dmpIds: JWTAccessTokenDMPId[],
   jti: string,
-  expiresIn: number,
  }
 
 export interface JWTRefreshToken extends JwtPayload {
   jti: string,
   id: number,
-  expiresIn: number,
 }
 
 // Hash a token before placing it in the cache
@@ -88,11 +86,9 @@ const generateAccessToken = async (context: MyContext, jti: string, user: User):
       languageId: user.languageId || defaultLanguageId,
       dmpIds,
       jti,
-      expiresIn: generalConfig.jwtTTL,
     };
 
     context.logger.debug(prepareObjectForLogs(payload), 'generateAccessToken payload');
-
     return jwt.sign(payload, generalConfig.jwtSecret as string, { expiresIn: generalConfig.jwtTTL });
   } catch(err) {
     if (context?.logger) {
@@ -108,7 +104,6 @@ const generateRefreshToken = async (context: MyContext, jti: string, userId: num
     const payload: JWTRefreshToken = {
       jti,
       id: userId,
-      expiresIn: generalConfig.jwtRefreshTTL,
     };
 
     const token = jwt.sign(payload, generalConfig.jwtRefreshSecret, { expiresIn: generalConfig.jwtRefreshTTL });


### PR DESCRIPTION
Not sure if this will actually help or not. I can see that the dmpIds content is there when we sign the JWT. Its getting lost though either in the signing process or in the decoding process in the client.

Did some investigation into why the `dmpIds` are not appearing in the decoded JWT. The suggestion was to try removing the `expiresIn` from the payload because this can cause some parsers to do weird things. We are already including the expiresIn when we call `sign` which should be enough.


