### PR TITLE
[Bug fix] - template visibility is not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- When user publishes a template, they can change the `visibility`, but it only saves in the `versionedTemplate` when it should also be updated in the original `template` itself [#715]
 - Fixed an issue where signup failed because context had been reset to different object
 - Fixed an issue causing the DMP version to not include sections/questions in the narrative if they had not been answered
 - Fixed an issue with the null/undefined check on model queries that use 'searchTerm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
-- When user publishes a template, they can change the `visibility`, but it only saves in the `versionedTemplate` when it should also be updated in the original `template` itself [#715]
+- When user publishes a template, they can change the `visibility`, but it only saves in the `versionedTemplate` when it should also be updated in the original `template` itself [#405]
 - Fixed an issue where signup failed because context had been reset to different object
 - Fixed an issue causing the DMP version to not include sections/questions in the narrative if they had not been answered
 - Fixed an issue with the null/undefined check on model queries that use 'searchTerm'

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -230,14 +230,20 @@ export const resolvers: Resolvers = {
         if (isAdmin(context.token)) {
           const template = await Template.findById(reference, context, templateId);
           // Need to create an instance of template in order to access the "update" method below
-          const templateInstance = new Template({ ...template });
+          const templateInstance = new Template({
+            ...template,
+            visibility
+          });
 
           if (templateInstance) {
             if (await hasPermissionOnTemplate(context, template)) {
-              const versions = await VersionedTemplate.findByTemplateId(reference, context, templateId);
-
               let versionedTemplate: VersionedTemplate | null = null;
               try {
+                // First update original template record with new visibility status
+                await templateInstance.update(context);
+
+                const versions = await VersionedTemplate.findByTemplateId(reference, context, templateId);
+
                 versionedTemplate = await generateTemplateVersion(
                   context,
                   templateInstance,


### PR DESCRIPTION
## Description
When a user publishes that template, the visibility setting is changed in the versionedTemplate record, but the template record is not updated with that same visibility.

This posed a problem on the /template page in the NextJS app, where we are running a myTemplates query to get both published and unpublished templates, and the visibility for all the listed templates are all set to the initial ORGANIZATION value.

I believe we should be update the visibility value in the corresponding template table when a template is published.

- Updated createTemplateVersion to update visibility in the corresponding `templates` table record.

Fixes # ([405](https://github.com/CDLUC3/dmsp_backend_prototype/issues/405))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested with frontend


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules