### PR TITLE
Adds correct counts for answered questions by section and for whole plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added
+- Added model/resolver for `PlanProgress` and nested `progress` in `Plan` resolver [#720]
 - Added checks in `ProjectMember` and `PlanMember` to prevent the deletion of a member if they are the last one [#358]
 - Added a fallback to set a `default` role if none was provided while adding a new `ProjectMember` [#358]
 - Added `findDMPIdsForEmail` helper method to `TokenService` so that the JWT will now contain a list of DMP ids and the user's access level
@@ -22,6 +23,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- Updated `PlanSectionProgress`model so it correctly shows how many answers have been filled. [#719]
 - Fixed an issue where signup failed because context had been reset to different object
 - Fixed an issue causing the DMP version to not include sections/questions in the narrative if they had not been answered
 - Fixed an issue with the null/undefined check on model queries that use 'searchTerm'

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -154,7 +154,7 @@ export class PlanProgress {
     this.totalQuestions = options.totalQuestions;
     this.answeredQuestions = options.answeredQuestions;
     this.percentComplete = this.totalQuestions > 0
-      ? Math.round((this.answeredQuestions / this.totalQuestions) * 100)
+      ? Number(((this.answeredQuestions / this.totalQuestions) * 100).toFixed(1))
       : 0;
   }
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -112,21 +112,71 @@ export class PlanSectionProgress {
     this.answeredQuestions = options.answeredQuestions;
   }
 
-  // Return the progress information for a section on the plan
+  // Return the progress information for sections of the plan
   static async findByPlanId(reference: string, context: MyContext, planId: number): Promise<PlanSectionProgress[]> {
-    const sql = 'SELECT vs.id versionedSectionId, vs.displayOrder, vs.name title, ' +
-                  'COUNT(DISTINCT vq.id) totalQuestions, ' +
-                  'COUNT(DISTINCT CASE WHEN a.json IS NOT NULL THEN vs.id END) answeredQuestions ' +
-                'FROM plans p ' +
-                  'INNER JOIN versionedTemplates vt ON p.versionedTemplateId = vt.id ' +
-                  'INNER JOIN versionedSections vs ON vt.id = vs.versionedTemplateId ' +
-                  'LEFT JOIN versionedQuestions vq ON vs.id = vq.versionedSectionId ' +
-                  'LEFT JOIN answers a ON p.id = a.planId AND vs.id = a.versionedSectionId ' +
-                'WHERE p.id = ? ' +
-                'GROUP BY vs.id, vs.displayOrder, vs.name ' +
-                'ORDER BY vs.displayOrder;';
+    const sql = `SELECT
+        vs.id AS versionedSectionId,
+        vs.displayOrder,
+        vs.name AS title,
+        COUNT(DISTINCT vq.id) AS totalQuestions,
+        COUNT(DISTINCT CASE
+            WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
+            THEN vq.id
+            END) AS answeredQuestions
+        FROM plans p
+            JOIN versionedTemplates vt ON p.versionedTemplateId = vt.id
+            JOIN versionedSections  vs ON vt.id = vs.versionedTemplateId
+            LEFT JOIN versionedQuestions vq ON vs.id = vq.versionedSectionId
+            LEFT JOIN answers a
+            ON a.planId = p.id
+            AND a.versionedQuestionId = vq.id
+        WHERE p.id = ?
+        GROUP BY vs.id, vs.displayOrder, vs.name
+        ORDER BY vs.displayOrder;
+`
+    // if requirements make detecting answered questions more complex (e.g. based on question type)
+    // and based on what constitutes really answered for each, then we may need to call special functions
+    // against each question to get the real count. It'll also use more resources to check them all.
+    // But we may be able to do something like the following to check for non-empty in JSON
+    // "JSON_EXTRACT(a.json, '$.answer') IS NOT NULL AND JSON_UNQUOTE(JSON_EXTRACT(a.json, '$.answer')) <> ''"
+
     const results = await Plan.query(context, sql, [planId?.toString()], reference);
     return Array.isArray(results) ? results.map((entry) => new PlanSectionProgress(entry)) : [];
+  }
+}
+
+export class PlanProgress {
+  public totalQuestions: number;
+  public answeredQuestions: number;
+  public percentComplete: number;
+
+  constructor(options) {
+    this.totalQuestions = options.totalQuestions;
+    this.answeredQuestions = options.answeredQuestions;
+    this.percentComplete = this.totalQuestions > 0
+      ? Math.round((this.answeredQuestions / this.totalQuestions) * 100)
+      : 0;
+  }
+
+  // Return the overall progress information for a plan
+  static async findByPlanId(reference: string, context: MyContext, planId: number): Promise<PlanProgress> {
+    const sql = `SELECT COUNT(DISTINCT vq.id) AS totalQuestions,
+        COUNT(DISTINCT CASE
+            WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
+            THEN vq.id
+        END) AS answeredQuestions
+        FROM plans p
+            JOIN versionedTemplates vt ON vt.id = p.versionedTemplateId
+            JOIN versionedSections  vs ON vs.versionedTemplateId = vt.id
+            JOIN versionedQuestions vq ON vq.versionedSectionId = vs.id
+            LEFT JOIN answers a
+                ON a.planId = p.id
+                AND a.versionedQuestionId = vq.id
+        WHERE p.id = ?;
+`
+
+    const results = await Plan.query(context, sql, [planId?.toString()], reference);
+    return Array.isArray(results) && results.length > 0 ? new PlanProgress(results[0]) : null;
   }
 }
 

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from "graphql";
 import { MyContext } from "../context";
-import { Plan, PlanSearchResult, PlanSectionProgress, PlanStatus, PlanVisibility } from "../models/Plan";
+import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, PlanVisibility } from "../models/Plan";
 import { prepareObjectForLogs } from "../logger";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
@@ -300,6 +300,12 @@ export const resolvers: Resolvers = {
         return await PlanSectionProgress.findByPlanId('plan versionedSections resolver', context, parent.id);
       }
       return [];
+    },
+    progress: async (parent: Plan, _, context: MyContext): Promise<PlanProgress> => {
+      if (parent?.id) {
+        return await PlanProgress.findByPlanId('plan progress resolver', context, parent.id);
+      }
+      return null;
     },
     registered: (parent: Plan) => {
       return normaliseDateTime(parent.registered);

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -72,6 +72,15 @@ export const typeDefs = gql`
     answeredQuestions: Int!
   }
 
+  type PlanProgress {
+    "The total number of questions in the plan"
+    totalQuestions: Int!
+    "The total number of questions the user has answered"
+    answeredQuestions: Int!
+    "The percentage of questions the user has answered"
+    percentComplete: Float!
+  }
+
   enum PlanDownloadFormat {
     CSV
     DOCX
@@ -138,6 +147,8 @@ export const typeDefs = gql`
     featured: Boolean
     "The section search results"
     versionedSections: [PlanSectionProgress!]
+    "The progress the user has made within the plan"
+    progress: PlanProgress
 
     "The members for the plan"
     members: [PlanMember!]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1569,6 +1569,8 @@ export type Plan = {
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** Anticipated research outputs */
   outputs?: Maybe<Array<PlanOutput>>;
+  /** The progress the user has made within the plan */
+  progress?: Maybe<PlanProgress>;
   /** The project the plan is associated with */
   project?: Maybe<Project>;
   /** The timestamp for when the Plan was registered */
@@ -1781,6 +1783,16 @@ export type PlanOutputErrors = {
   __typename?: 'PlanOutputErrors';
   /** General error messages such as the object already exists */
   general?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanProgress = {
+  __typename?: 'PlanProgress';
+  /** The total number of questions the user has answered */
+  answeredQuestions: Scalars['Int']['output'];
+  /** The percentage of questions the user has answered */
+  percentComplete: Scalars['Float']['output'];
+  /** The total number of questions in the plan */
+  totalQuestions: Scalars['Int']['output'];
 };
 
 export type PlanSearchResult = {
@@ -4141,6 +4153,7 @@ export type ResolversTypes = {
   ExternalMember: ResolverTypeWrapper<ExternalMember>;
   ExternalProject: ResolverTypeWrapper<ExternalProject>;
   ExternalSearchInput: ExternalSearchInput;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   FunderPopularityResult: ResolverTypeWrapper<FunderPopularityResult>;
   InitializePlanVersionOutput: ResolverTypeWrapper<InitializePlanVersionOutput>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
@@ -4174,6 +4187,7 @@ export type ResolversTypes = {
   PlanMemberErrors: ResolverTypeWrapper<PlanMemberErrors>;
   PlanOutput: ResolverTypeWrapper<PlanOutput>;
   PlanOutputErrors: ResolverTypeWrapper<PlanOutputErrors>;
+  PlanProgress: ResolverTypeWrapper<PlanProgress>;
   PlanSearchResult: ResolverTypeWrapper<PlanSearchResult>;
   PlanSectionProgress: ResolverTypeWrapper<PlanSectionProgress>;
   PlanStatus: PlanStatus;
@@ -4304,6 +4318,7 @@ export type ResolversParentTypes = {
   ExternalMember: ExternalMember;
   ExternalProject: ExternalProject;
   ExternalSearchInput: ExternalSearchInput;
+  Float: Scalars['Float']['output'];
   FunderPopularityResult: FunderPopularityResult;
   InitializePlanVersionOutput: InitializePlanVersionOutput;
   Int: Scalars['Int']['output'];
@@ -4334,6 +4349,7 @@ export type ResolversParentTypes = {
   PlanMemberErrors: PlanMemberErrors;
   PlanOutput: PlanOutput;
   PlanOutputErrors: PlanOutputErrors;
+  PlanProgress: PlanProgress;
   PlanSearchResult: PlanSearchResult;
   PlanSectionProgress: PlanSectionProgress;
   PlanVersion: PlanVersion;
@@ -4870,6 +4886,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   outputs?: Resolver<Maybe<Array<ResolversTypes['PlanOutput']>>, ParentType, ContextType>;
+  progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -5000,6 +5017,13 @@ export type PlanOutputResolvers<ContextType = MyContext, ParentType extends Reso
 
 export type PlanOutputErrorsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanOutputErrors'] = ResolversParentTypes['PlanOutputErrors']> = {
   general?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PlanProgressResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanProgress'] = ResolversParentTypes['PlanProgress']> = {
+  answeredQuestions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  percentComplete?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  totalQuestions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -5997,6 +6021,7 @@ export type Resolvers<ContextType = MyContext> = {
   PlanMemberErrors?: PlanMemberErrorsResolvers<ContextType>;
   PlanOutput?: PlanOutputResolvers<ContextType>;
   PlanOutputErrors?: PlanOutputErrorsResolvers<ContextType>;
+  PlanProgress?: PlanProgressResolvers<ContextType>;
   PlanSearchResult?: PlanSearchResultResolvers<ContextType>;
   PlanSectionProgress?: PlanSectionProgressResolvers<ContextType>;
   PlanVersion?: PlanVersionResolvers<ContextType>;


### PR DESCRIPTION
## Description

Fixes wrong counts for answered by section (PlanSectionProgress) and missing counts and percentage answered for whole plan (PlanProgress) which is progress subsection in resolver for plan. [#719], [#720]

Fixes https://github.com/CDLUC3/dmsp_frontend_prototype/issues/719 https://github.com/CDLUC3/dmsp_frontend_prototype/issues/720 

## Type of change
Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added model tests
- Checked results in the UI
- Checked results in Apollo explorer

Examples below to show the counts match:

<img width="827" height="542" alt="Screenshot 2025-08-28 at 2 30 46 PM" src="https://github.com/user-attachments/assets/983326d5-41a0-4f70-9d61-e55959b549a2" />

<img width="869" height="256" alt="Screenshot 2025-08-28 at 2 30 27 PM" src="https://github.com/user-attachments/assets/118cf382-289f-4897-a781-9c841ada9a58" />

---

<img width="838" height="717" alt="Screenshot 2025-08-28 at 2 32 19 PM" src="https://github.com/user-attachments/assets/d8f4eccd-284c-4098-bf45-ea494cba832e" />

<img width="960" height="127" alt="Screenshot 2025-08-28 at 3 31 10 PM" src="https://github.com/user-attachments/assets/bf45b094-4fd6-4e01-9026-32c4f5083840" />

---

<img width="954" height="838" alt="Screenshot 2025-09-02 at 8 29 11 AM" src="https://github.com/user-attachments/assets/17bef6ca-063e-4893-88ad-40b365e7bd86" />


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes