### PR TITLE
Permissions changes related to commenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - added `publishedQuestion` resolver to `src/resolvers/versionedQuestion.ts`
 
 ### Updated
+- Updated `answer` and `addAnswerComment` permissions to include a collaborator who has `COMMENT` privileges [#243]
+- Update `removeAnswerComment` and `removeFeedbackComment` to allow deletion by creator, plan creator, or OWN-level collaborator [#243]
 - Updated `docker-compose.yaml` to use the `dmptool-network` which will be shared with other repos
 - Updated `answer`, `fundings`, `members` and `plans` resolver to use new `hasPermissionOnPlan` function
 - Update the `tokenService` to add `dmpIds` array that stores the DMPs the user has access to

--- a/src/resolvers/answer.ts
+++ b/src/resolvers/answer.ts
@@ -15,7 +15,7 @@ import { Answer } from "../models/Answer";
 import { VersionedQuestion } from "../models/VersionedQuestion";
 import { VersionedSection } from "../models/VersionedSection";
 import { AnswerComment } from "../models/AnswerComment";
-import { ProjectCollaborator } from "../models/Collaborator";
+import { ProjectCollaborator, ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { User } from "../models/User";
 import { PlanFeedbackComment } from "../models/PlanFeedbackComment";
 import { addVersion } from "../models/PlanVersion";
@@ -59,7 +59,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`Plan with ID ${planId} not found`);
           }
           const project = await Project.findById(reference, context, plan.projectId);
-          if (await hasPermissionOnProject(context, project)) {
+          if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
             const temp = await Answer.findByPlanIdAndVersionedQuestionId(reference, context, planId, versionedQuestionId);
             return temp;
           }
@@ -84,7 +84,8 @@ export const resolvers: Resolvers = {
 
         const plan = await Plan.findById(reference, context, answer.planId);
         const project = await Project.findById(reference, context, plan.projectId);
-        if (project && await hasPermissionOnProject(context, project)) {
+
+        if (project && await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
           return await Answer.findById(reference, context, answerId);
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -176,7 +177,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`Plan ${answer.planId} not found`);
           }
           const project = await Project.findById(reference, context, plan.projectId);
-          if (await hasPermissionOnProject(context, project)) {
+          if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
             // Send out email to project collaborators to let them know that comments were added
             // Get project collaborators emails, minus the user's own email
             const collaborators = await ProjectCollaborator.findByProjectId(reference, context, plan.projectId);
@@ -244,6 +245,7 @@ export const resolvers: Resolvers = {
     // Remove answer comment
     removeAnswerComment: async (_, { answerCommentId, answerId }, context: MyContext): Promise<AnswerComment> => {
       const reference = 'removeAnswerComment resolver';
+      console.log("***REMOVE ANSWER COMMENT CALLED")
       try {
         if (isAuthorized(context.token)) {
           const answer = await Answer.findById(reference, context, answerId);
@@ -258,14 +260,26 @@ export const resolvers: Resolvers = {
           }
 
           const project = await Project.findById(reference, context, plan.projectId);
+          const temp = await hasPermissionOnProject(context, project);
+          console.log('***hasPermissionOnProject', temp);
           if (await hasPermissionOnProject(context, project)) {
             const answerComment = await AnswerComment.findById(reference, context, answerCommentId);
 
             if (!answerComment) {
               throw NotFoundError(`Answer comment ${answerCommentId} not found`);
             }
-            // Only user who created plan can remove comments
-            if (answerComment.createdById === context.token.id) {
+            // Get project collaborators emails, minus the user's own email
+            const collaborators = await ProjectCollaborator.findByProjectId(reference, context, plan.projectId);
+
+            // Allow deletion by comment creator, plan creator, or OWN-level collaborator
+            const isCommentCreator = answerComment.createdById === context.token.id;
+            const isPlanCreator = plan.createdById === context.token.id;
+            const isOwnCollaborator = collaborators.some(
+              c => c.userId === context.token.id && c.accessLevel === "OWN"
+            );
+
+            // Only user who added the comment, the plan creator, or OWN-level collaborator can delete it
+            if (isCommentCreator || isPlanCreator || isOwnCollaborator) {
               return await answerComment.delete(context);
             }
 


### PR DESCRIPTION

## Description

- Updated `answer` and `addAnswerComment` permissions to include a collaborator who has `COMMENT` privileges
- Update `removeAnswerComment` and `removeFeedbackComment` to allow deletion by creator, plan creator, or OWN-level collaborator

Fixes # ([243](https://github.com/CDLUC3/dmsp_backend_prototype/issues/243))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested with corresponding frontend change: https://github.com/CDLUC3/dmsp_frontend_prototype/pull/770


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules