### PR TITLE
Added code to addSection mutation so that tags would be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- `addSection` mutation resolver was not saving `tags`. Added code to add tags for new section [#445]
 - Fixed issue where updating an answer, funding or members was not triggering the creation of a new PlanVersion
 - Fixed bug with maintaining the latest PlanVersion (common standard JSON) when a plan is updated
 - Fixed issue where the title of the DMP in the common standard JSON is using the template title instead of plan title

--- a/src/resolvers/section.ts
+++ b/src/resolvers/section.ts
@@ -62,6 +62,7 @@ export const resolvers: Resolvers = {
           introduction,
           requirements,
           guidance,
+          tags,
           displayOrder
         }
       },
@@ -96,6 +97,21 @@ export const resolvers: Resolvers = {
               section.addError('general', 'Unable to create the section');
             }
             return section;
+          }
+
+          // Add any new Tag associations
+          const addTagErrors = [];
+          for (const item of tags) {
+            const tag = await Tag.findById(reference, context, item.id);
+            if (tag) {
+              const wasAdded = tag.addToSection(context, newSection.id)
+              if (!wasAdded) {
+                addTagErrors.push(tag.name);
+              }
+            }
+          }
+          if (addTagErrors.length > 0) {
+            newSection.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
           }
 
           // if a copyFromVersionedSectionId is provided, clone all the questions


### PR DESCRIPTION
## Description

Currently, if a user adds a new section from scratch, the tags are not saved on `/section/create` page. 

- Updated `addSection` mutation resolver so that `tags` is included in the input variables, and added code to add the tags to the brand new section.

Fixes # ([445](https://github.com/CDLUC3/dmsp_backend_prototype/issues/445))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested 


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules