### PR TITLE
Added data migration to ensure userId is nullable on collaborator tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added
+- Added data migration to ensure collaborator tables allow for NULL in `userId` field
 - Added tables to support template customizations
 - Added stub models for each new template customization table with comments on what needs to be done
 - Added dependabot config

--- a/data-migrations/2025-10-03-1529-update-collaborators-userId.sql
+++ b/data-migrations/2025-10-03-1529-update-collaborators-userId.sql
@@ -1,0 +1,6 @@
+# Alter both collaborators table to allow for NULL userIds
+ALTER TABLE `templateCollaborators`
+  MODIFY COLUMN `userId` INT NULL;
+
+ALTER TABLE `projectCollaborators`
+  MODIFY COLUMN `userId` INT NULL;


### PR DESCRIPTION
Fixes [#847](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/847)

Added a migration script to ensure that the `userId` on both collaborator tables is nullable.